### PR TITLE
Fix the travis badge URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
+# This is a c++ project
 language: cpp
+
+# Use container based infrastructure
 sudo: false
+
+# Only do branch builds on master
+branches:
+  only:
+    - master
+
+# Our build matrix of all the options
 matrix:
   include:
     - os: linux

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-NUClear [![Build Status](https://travis-ci.org/Fastcode/NUClear.svg?branch=develop)](https://travis-ci.org/Fastcode/NUClear)
+NUClear [![Build Status](https://travis-ci.org/Fastcode/NUClear.svg?branch=master)](https://travis-ci.org/Fastcode/NUClear)
 =======
 
 NUClear is a C++ software framework designed to aid in the development of real time modular systems.


### PR DESCRIPTION
Travis's URL for the badge is set to develop which is out of date