### PR TITLE
Fix getinterfaces finding CAN buses and segfaulting

### DIFF
--- a/cmake/Modules/FindCATCH.cmake
+++ b/cmake/Modules/FindCATCH.cmake
@@ -17,6 +17,6 @@ INCLUDE(HeaderLibrary)
  
 HeaderLibrary(NAME CATCH
               HEADER catch.hpp
-              URL "https://raw.githubusercontent.com/philsquared/Catch/master/single_include/catch.hpp"
+              URL "https://raw.githubusercontent.com/catchorg/Catch2/master/single_include/catch.hpp"
 )
  

--- a/cmake/Modules/FindCATCH.cmake
+++ b/cmake/Modules/FindCATCH.cmake
@@ -12,11 +12,10 @@
 # WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- 
+
 INCLUDE(HeaderLibrary)
- 
+
 HeaderLibrary(NAME CATCH
               HEADER catch.hpp
-              URL "https://raw.githubusercontent.com/catchorg/Catch2/master/single_include/catch.hpp"
+              URL "https://raw.githubusercontent.com/catchorg/Catch2/master/single_include/catch2/catch.hpp"
 )
- 

--- a/cmake/Modules/HeaderLibrary.cmake
+++ b/cmake/Modules/HeaderLibrary.cmake
@@ -28,6 +28,7 @@ FUNCTION(HeaderLibrary)
     FIND_PATH("${PACKAGE_NAME}_INCLUDE_DIR"
               NAMES ${PACKAGE_HEADER}
               DOC "The ${PACKAGE_NAME} include directory"
+              PATHS "${OUTPUT_DIR}/${PACKAGE_HEADER}"
               PATH_SUFFIXES ${PACKAGE_PATH_SUFFIX}
     )
 

--- a/src/util/network/get_interfaces.cpp
+++ b/src/util/network/get_interfaces.cpp
@@ -150,7 +150,7 @@ namespace util {
 
             // Query our interfaces
             ifaddrs* addrs;
-            if (getifaddrs(&addrs) < 0) {
+            if (::getifaddrs(&addrs) < 0) {
                 throw std::system_error(
                     network_errno, std::system_category(), "Unable to query the interfaces on the platform");
             }
@@ -158,47 +158,55 @@ namespace util {
             // Loop through our interfaces
             for (ifaddrs* cursor = addrs; cursor != nullptr; cursor = cursor->ifa_next) {
 
-                // We only care about ipv4 addresses (one day this will need to change)
-                Interface iface;
+                // Sometimes we find an interface with no IP (like a CAN bus) this is not what we're after
+                if (cursor->ifa_addr) {
 
-                // Clear!
-                std::memset(&iface, 0, sizeof(iface));
+                    // Clear!
+                    Interface iface;
+                    std::memset(&iface, 0, sizeof(iface));
 
-                iface.name = cursor->ifa_name;
+                    iface.name = cursor->ifa_name;
 
-                // Copy across our various addresses
-                switch (cursor->ifa_addr->sa_family) {
-                    case AF_INET: std::memcpy(&iface.ip, cursor->ifa_addr, sizeof(sockaddr_in)); break;
-
-                    case AF_INET6: std::memcpy(&iface.ip, cursor->ifa_addr, sizeof(sockaddr_in6)); break;
-                }
-
-                if (cursor->ifa_netmask != nullptr) {
+                    // Copy across our various addresses
                     switch (cursor->ifa_addr->sa_family) {
-                        case AF_INET: std::memcpy(&iface.netmask, cursor->ifa_netmask, sizeof(sockaddr_in)); break;
+                        case AF_INET: std::memcpy(&iface.ip, cursor->ifa_addr, sizeof(sockaddr_in)); break;
 
-                        case AF_INET6: std::memcpy(&iface.netmask, cursor->ifa_netmask, sizeof(sockaddr_in6)); break;
+                        case AF_INET6: std::memcpy(&iface.ip, cursor->ifa_addr, sizeof(sockaddr_in6)); break;
                     }
-                }
 
-                if (cursor->ifa_dstaddr != nullptr) {
-                    switch (cursor->ifa_addr->sa_family) {
-                        case AF_INET: std::memcpy(&iface.broadcast, cursor->ifa_dstaddr, sizeof(sockaddr_in)); break;
+                    if (cursor->ifa_netmask != nullptr) {
+                        switch (cursor->ifa_addr->sa_family) {
+                            case AF_INET: std::memcpy(&iface.netmask, cursor->ifa_netmask, sizeof(sockaddr_in)); break;
 
-                        case AF_INET6: std::memcpy(&iface.broadcast, cursor->ifa_dstaddr, sizeof(sockaddr_in6)); break;
+                            case AF_INET6:
+                                std::memcpy(&iface.netmask, cursor->ifa_netmask, sizeof(sockaddr_in6));
+                                break;
+                        }
                     }
+
+                    if (cursor->ifa_dstaddr != nullptr) {
+                        switch (cursor->ifa_addr->sa_family) {
+                            case AF_INET:
+                                std::memcpy(&iface.broadcast, cursor->ifa_dstaddr, sizeof(sockaddr_in));
+                                break;
+
+                            case AF_INET6:
+                                std::memcpy(&iface.broadcast, cursor->ifa_dstaddr, sizeof(sockaddr_in6));
+                                break;
+                        }
+                    }
+
+                    iface.flags.broadcast    = (cursor->ifa_flags & IFF_BROADCAST) != 0;
+                    iface.flags.loopback     = (cursor->ifa_flags & IFF_LOOPBACK) != 0;
+                    iface.flags.pointtopoint = (cursor->ifa_flags & IFF_POINTOPOINT) != 0;
+                    iface.flags.multicast    = (cursor->ifa_flags & IFF_MULTICAST) != 0;
+
+                    ifaces.push_back(iface);
                 }
-
-                iface.flags.broadcast    = (cursor->ifa_flags & IFF_BROADCAST) != 0;
-                iface.flags.loopback     = (cursor->ifa_flags & IFF_LOOPBACK) != 0;
-                iface.flags.pointtopoint = (cursor->ifa_flags & IFF_POINTOPOINT) != 0;
-                iface.flags.multicast    = (cursor->ifa_flags & IFF_MULTICAST) != 0;
-
-                ifaces.push_back(iface);
             }
 
             // Free memory
-            freeifaddrs(addrs);
+            ::freeifaddrs(addrs);
 
             return ifaces;
         }


### PR DESCRIPTION
Other network devices such as CAN buses show up with getinterfaces.
These didn't have IP addresses and would cause a segfault.
Also fixes the URL for Catch changing