### PR TITLE
Fix some comment typos

### DIFF
--- a/src/util/CallableInfo.hpp
+++ b/src/util/CallableInfo.hpp
@@ -36,7 +36,7 @@ namespace util {
     // Regular
     template <typename T, typename Ret, typename... Args>
     struct CallableInfo<Ret (T::*)(Args...)> : public function_info<Ret, Args...> {};
-    // C Variardic
+    // C Variadic
     template <typename T, typename Ret, typename... Args>
     struct CallableInfo<Ret (T::*)(Args..., ...)> : public function_info<Ret, Args...> {};
     // Types that have cv-qualifiers
@@ -92,7 +92,7 @@ namespace util {
     // Regular
     template <typename Ret, typename... Args>
     struct CallableInfo<Ret(Args...)> : public function_info<Ret, Args...> {};
-    // C Variardic
+    // C Variadic
     template <typename Ret, typename... Args>
     struct CallableInfo<Ret(Args..., ...)> : public function_info<Ret, Args...> {};
     // Types that have cv-qualifiers
@@ -154,7 +154,7 @@ namespace util {
     struct CallableInfo<Ret (*const)(Args...)> : public function_info<Ret(*), Args...> {};
     template <typename Ret, typename... Args>
     struct CallableInfo<Ret (*const&)(Args...)> : public function_info<Ret(*), Args...> {};
-    // C Variardic
+    // C Variadic
     template <typename Ret, typename... Args>
     struct CallableInfo<Ret (*)(Args..., ...)> : public function_info<Ret(*), Args...> {};
     template <typename Ret, typename... Args>
@@ -168,7 +168,7 @@ namespace util {
     // Regular
     template <typename Ret, typename... Args>
     struct CallableInfo<Ret (&)(Args...)> : public function_info<Ret(&), Args...> {};
-    // C Variardic
+    // C Variadic
     template <typename Ret, typename... Args>
     struct CallableInfo<Ret (&)(Args..., ...)> : public function_info<Ret(&), Args...> {};
 

--- a/src/util/Sequence.hpp
+++ b/src/util/Sequence.hpp
@@ -23,9 +23,9 @@ namespace NUClear {
 namespace util {
 
     /**
-     * @brief This class is used to hold a sequence of integers as a variardic pack
+     * @brief This class is used to hold a sequence of integers as a variadic pack
      *
-     * @tparam S the variardic pack containing the sequence
+     * @tparam S the variadic pack containing the sequence
      */
     template <int... S>
     struct Sequence {
@@ -62,10 +62,10 @@ namespace util {
     }  // namespace
 
     /**
-     * @brief Holds a generated integer sequence of numbers as a variardic pack.
+     * @brief Holds a generated integer sequence of numbers as a variadic pack.
      *
      * @details
-     *  This class is used to generate a variardic template pack which contains all of the integers from Start to End
+     *  This class is used to generate a variadic template pack which contains all of the integers from Start to End
      * (non inclusive).
      *  This can then be used in other templates or tempalate expansions as needed (for instance it is useful for
      *  expanding tuples).

--- a/src/util/unpack.hpp
+++ b/src/util/unpack.hpp
@@ -23,12 +23,12 @@ namespace NUClear {
 namespace util {
 
     /**
-     * @brief Executes a series of function calls from a variardic template pack.
+     * @brief Executes a series of function calls from a variadic template pack.
      *
      * @details
-     *  This function is to be used as a helper to expand a variardic template pack into a series of function calls.
-     *  As the variardic function pack can only be expanded in the situation where they are comma seperated (and the
-     *  comma is a syntactic seperator not the comma operator) the only place this can expand is within a function call,
+     *  This function is to be used as a helper to expand a variadic template pack into a series of function calls.
+     *  As the variadic function pack can only be expanded in the situation where they are comma separated (and the
+     *  comma is a syntactic separator not the comma operator) the only place this can expand is within a function call,
      *  or an initializer list (which can only accept a single type).
      *  This function serves that purpose by allowing a series of function calls to be expanded as its parameters. This
      *  will execute each of them without having to recursivly evaluate the pack. e.g.


### PR DESCRIPTION
I was thinking about writing a reaction test API in NUClear, but then I got distracted. I figured I might as well fix these that I spotted while I was here though :shrug: 