### PR TITLE
Make ReactionStatistics shared

### DIFF
--- a/src/PowerPlant.ipp
+++ b/src/PowerPlant.ipp
@@ -178,7 +178,7 @@ void PowerPlant::log(Arguments&&... args) {
 
         // Direct emit the log message so that any direct loggers can use it
         powerplant->emit<dsl::word::emit::Direct>(std::make_unique<message::LogMessage>(
-            message::LogMessage{level, output, current_task != nullptr ? current_task->stats.get() : nullptr}));
+            message::LogMessage{level, output, current_task != nullptr ? current_task->stats : nullptr}));
     }
 }
 

--- a/src/PowerPlant.ipp
+++ b/src/PowerPlant.ipp
@@ -169,7 +169,7 @@ void PowerPlant::log(Arguments&&... args) {
     std::string output = output_stream.str();
 
     auto* current_task = threading::ReactionTask::get_current_task();
-    auto* task         = current_task ? current_task->stats.get() : nullptr;
+    auto task         = current_task ? current_task->stats : nullptr;
 
     // Direct emit the log message so that any direct loggers can use it
     powerplant->emit<dsl::word::emit::Direct>(

--- a/src/message/LogMessage.hpp
+++ b/src/message/LogMessage.hpp
@@ -19,6 +19,8 @@
 #ifndef NUCLEAR_MESSAGE_LOGMESSAGE_HPP
 #define NUCLEAR_MESSAGE_LOGMESSAGE_HPP
 
+#include <memory>
+
 #include "../LogLevel.hpp"
 #include "ReactionStatistics.hpp"
 
@@ -38,10 +40,7 @@ namespace message {
         std::string message;
 
         /// @brief The currently executing task that made this message
-        /// @warning This pointer is only valid for the duration of the reaction that triggers on this message.
-        ///          After this, it will point to junk memory. This also applies to keywords that reschedule this reaction
-        ///          For example, using the Sync keyword can make it so this pointer is invalid
-        const ReactionStatistics* task;
+        const std::shared_ptr<ReactionStatistics> task;
     };
 
 }  // namespace message

--- a/src/threading/ReactionTask.hpp
+++ b/src/threading/ReactionTask.hpp
@@ -73,7 +73,7 @@ namespace threading {
             : parent(parent)
             , id(++task_id_source)
             , priority(priority)
-            , stats(new message::ReactionStatistics{parent.identifier,
+            , stats(std::make_shared<message::ReactionStatistics>(parent.identifier,
                                                     parent.id,
                                                     id,
                                                     current_task != nullptr ? current_task->parent.id : 0,
@@ -81,7 +81,7 @@ namespace threading {
                                                     clock::now(),
                                                     clock::time_point(std::chrono::seconds(0)),
                                                     clock::time_point(std::chrono::seconds(0)),
-                                                    nullptr})
+                                                    nullptr))
             , emit_stats(parent.emit_stats && (current_task != nullptr ? current_task->emit_stats : true))
             , callback(callback) {}
 

--- a/src/threading/ReactionTask.hpp
+++ b/src/threading/ReactionTask.hpp
@@ -116,7 +116,7 @@ namespace threading {
         /// @brief the priority to run this task at
         int priority;
         /// @brief the statistics object that persists after this for information and debugging
-        std::unique_ptr<message::ReactionStatistics> stats;
+        std::shared_ptr<message::ReactionStatistics> stats;
         /// @brief if these stats are safe to emit. It should start true, and as soon as we are a reaction based on
         /// reaction statistics becomes false for all created tasks. This is to stop infinite loops of death.
         bool emit_stats;

--- a/src/util/CallbackGenerator.hpp
+++ b/src/util/CallbackGenerator.hpp
@@ -126,7 +126,7 @@ namespace util {
 
                         // Emit our reaction statistics if it wouldn't cause a loop
                         if (task->emit_stats) {
-                            PowerPlant::powerplant->emit<dsl::word::emit::Direct>(task->stats);
+                            PowerPlant::powerplant->emit_shared<dsl::word::emit::Direct>(task->stats);
                         }
                     }
 


### PR DESCRIPTION
Was going through some of my old PRs. I reckon that having a warning here is kinda dumb, and that its better to not need the warning. The comment says "persists after this" which does imply that the object could possibly have lifetime beyond the ReactionTask.