### PR TITLE
Fix DSL words so they execute in the order they appear

### DIFF
--- a/src/util/FunctionFusion.hpp
+++ b/src/util/FunctionFusion.hpp
@@ -167,10 +167,10 @@ namespace util {
                                        NextStep::call(std::forward<Arguments>(args)...))) {
 
             // Call each on a separate line to preserve order of execution
-            auto a = tuplify(call_one<CurrentFunction>(CurrentRange(), std::forward<Arguments>(args)...));
-            auto b = NextStep::call(std::forward<Arguments>(args)...);
+            auto current   = tuplify(call_one<CurrentFunction>(CurrentRange(), std::forward<Arguments>(args)...));
+            auto remainder = NextStep::call(std::forward<Arguments>(args)...);
 
-            return std::tuple_cat(std::move(a), std::move(b));
+            return std::tuple_cat(std::move(current), std::move(remainder));
         }
     };
 

--- a/src/util/FunctionFusion.hpp
+++ b/src/util/FunctionFusion.hpp
@@ -101,11 +101,13 @@ namespace util {
      * @details Provides a call function that will split the given arguments amongst the functions
      *          according to the provided ranges.
      *
-     * @tparam Functions The functions that we are going to call
-     * @tparam Shared    the number of arguments (from 0) to use in all of the calls
-     * @tparam Ranges    a set of pairs of integers that describe the first and last
-     *                   argument provided to each respective function
-     * @tparam Arguments the type of the provided arguments
+     * @tparam CurrentFunction  the current function we are calling in this class
+     * @tparam Functions        the remaining functions we are going to call
+     * @tparam Shared           the number of arguments (from 0) to use in all of the calls
+     * @tparam CurrentRange     the range of arguments to use in the current call
+     * @tparam Ranges           a set of pairs of integers that describe the first and last
+     *                          argument provided to each respective function
+     * @tparam Arguments        the type of the provided arguments
      */
     template <typename CurrentFunction,
               typename... Functions,
@@ -225,10 +227,10 @@ namespace util {
      *          This allows fusion of functions without knowing the name of the function
      *          that is being fused.
      *
-     * @tparam Functions            the functions we are going to call
+     * @tparam CurrentFunction      the current function we are inspecting
+     * @tparam Functions            the remaining functions we are going to call
      * @tparam Arguments            the arguments we are calling the function with
-     * @tparam FunctionWrapper      the template that is used to wrap the Function objects
-     *                              to be called
+     * @tparam FunctionWrapper      the template that is used to wrap the Function objects to be called
      * @tparam WrapperArgs          template types to be used on the FunctionWrapper in addition to the Fuctions type.
      *                              May be empty.
      * @tparam Shared               the number of parameters (from 0) to use in all of the calls

--- a/src/util/FunctionFusion.hpp
+++ b/src/util/FunctionFusion.hpp
@@ -28,11 +28,11 @@ namespace util {
     /**
      * @brief Applies a single set of function fusion with expanded arguments
      * @details Calls the function held in the template type Function.
-     *          for the arguments it uses the paramter packs Shared and Selected
+     *          for the arguments it uses the parameter packs Shared and Selected
      *          to expand the passed tuple args and forward those selected
      *          arguments to the function. This function is normally called by
      *          the other overload of apply_function_fusion_call to get the expanded
-     *          paramter packs.
+     *          parameter packs.
      *
      * @param  args     the arguments that were passed to the superfunction
      *
@@ -54,14 +54,14 @@ namespace util {
     /**
      * @brief Applies a single set of function fusion with argument ranges
      * @details Calls the function held in the template type Function.
-     *          for the arguments it uses the paramter packs Shared and Selected
+     *          for the arguments it uses the parameter packs Shared and Selected
      *          to expand the passed tuple args and forward those selected
      *          arguments to the function.
      *
      * @param  args     the arguments that were passed to the superfunction
      *
      * @tparam Function     the struct that holds the call function wrapper to be called
-     * @tparam Shared       the number of paramters (from 0) to use in the call
+     * @tparam Shared       the number of parameters (from 0) to use in the call
      * @tparam Start        the index of the first argument to pass to the function
      * @tparam End          the index of the element after the last argument to pass to the function
      * @tparam Arguments    the types of the arguments passed into the function
@@ -82,8 +82,23 @@ namespace util {
     struct FunctionFusionCaller;
 
     /**
+     * @brief Termination case for calling a function fusion.
+     *
+     * @details terminates by just returning an empty tuple
+     *
+     * @tparam Shared the number of arguments (from 0) to use in all of the calls
+     * @tparam Arguments the type of the provided arguments
+     */
+    template <int Shared, typename... Arguments>
+    struct FunctionFusionCaller<std::tuple<>, Shared, std::tuple<>, std::tuple<Arguments...>> {
+        static inline std::tuple<> call(Arguments&&... /*args*/) {
+            return std::tuple<>();
+        }
+    };
+
+    /**
      * @brief Used to call the result of the function fusion with the given arguments
-     * @details Provides a call function that will split the given arguments amoungst the functions
+     * @details Provides a call function that will split the given arguments amongst the functions
      *          according to the provided ranges.
      *
      * @tparam Functions The functions that we are going to call
@@ -92,9 +107,16 @@ namespace util {
      *                   argument provided to each respective function
      * @tparam Arguments the type of the provided arguments
      */
-    template <typename... Functions, int Shared, typename... Ranges, typename... Arguments>
-    struct FunctionFusionCaller<std::tuple<Functions...>, Shared, std::tuple<Ranges...>, std::tuple<Arguments...>>
-        : public std::true_type {
+    template <typename CurrentFunction,
+              typename... Functions,
+              int Shared,
+              typename CurrentRange,
+              typename... Ranges,
+              typename... Arguments>
+    struct FunctionFusionCaller<std::tuple<CurrentFunction, Functions...>,
+                                Shared,
+                                std::tuple<CurrentRange, Ranges...>,
+                                std::tuple<Arguments...>> : public std::true_type {
     private:
         /**
          * @brief Calls a single function in the function set.
@@ -116,16 +138,19 @@ namespace util {
         }
 
         /**
-         * @brief This function exists unimplemented to absorb incorrect template instansiations.
+         * @brief This function exists unimplemented to absorb incorrect template instantiations.
          *
          * @param  swallows arguments
          *
-         * @tparam typename swallows the template paramter
+         * @tparam typename swallows the template parameter
          *
          * @return ignore
          */
         template <typename>
         static inline bool call_one(...);
+
+        using NextStep =
+            FunctionFusionCaller<std::tuple<Functions...>, Shared, std::tuple<Ranges...>, std::tuple<Arguments...>>;
 
     public:
         /**
@@ -136,10 +161,15 @@ namespace util {
          * @return A tuple of the returned values, or if the return value was a tuple fuse it
          */
         static inline auto call(Arguments&&... args)
-            -> decltype(std::tuple_cat(tuplify(call_one<Functions>(Ranges(), std::forward<Arguments>(args)...))...)) {
+            -> decltype(std::tuple_cat(tuplify(call_one<CurrentFunction>(CurrentRange(),
+                                                                         std::forward<Arguments>(args)...)),
+                                       NextStep::call(std::forward<Arguments>(args)...))) {
 
-            // Now to call all of the sets with their arguments
-            return std::tuple_cat(tuplify(call_one<Functions>(Ranges(), std::forward<Arguments>(args)...))...);
+            // Call each on a separate line to preserve order of execution
+            auto a = tuplify(call_one<CurrentFunction>(CurrentRange(), std::forward<Arguments>(args)...));
+            auto b = NextStep::call(std::forward<Arguments>(args)...);
+
+            return std::tuple_cat(std::move(a), std::move(b));
         }
     };
 
@@ -147,7 +177,7 @@ namespace util {
      * @brief SFINAE test struct to see if a function is callable with the provided arguments.
      *
      * @tparam Function  the function to be tested
-     * @tparam Shared    the number of paramters (from 0) to use in the call
+     * @tparam Shared    the number of parameters (from 0) to use in the call
      * @tparam Start     the index of the first argument to pass to the function
      * @tparam End       the index of the element after the last argument to pass to the function
      * @tparam Arguments the types of the arguments passed into the function
@@ -200,7 +230,7 @@ namespace util {
      *                              to be called
      * @tparam WrapperArgs          template types to be used on the FunctionWrapper in addition to the Fuctions type.
      *                              May be empty.
-     * @tparam Shared               the number of paramters (from 0) to use in all of the calls
+     * @tparam Shared               the number of parameters (from 0) to use in all of the calls
      * @tparam Start                the current attempted index of the first argument to pass to the function
      * @tparam End                  the current attempted index of the element after the last argument to pass to the
      *                              function

--- a/src/util/FunctionFusion.hpp
+++ b/src/util/FunctionFusion.hpp
@@ -149,6 +149,7 @@ namespace util {
         template <typename>
         static inline bool call_one(...);
 
+        /// The FunctionFusionCaller next step in the recursion
         using NextStep =
             FunctionFusionCaller<std::tuple<Functions...>, Shared, std::tuple<Ranges...>, std::tuple<Arguments...>>;
 

--- a/src/util/TypeMap.hpp
+++ b/src/util/TypeMap.hpp
@@ -31,9 +31,9 @@ namespace util {
      *
      * @details
      *  This map stores a single value in it's store when the set function is called, and when get is later called
-     *  this object will be returned. This map is accessed by template paramters, because of this when the compiler
+     *  this object will be returned. This map is accessed by template parameters, because of this when the compiler
      *  compiles this map. It can resolve each of the map accesses into a direct function call. This allows the map to
-     *  be looked up at compile time and optimized to very efficent code. There are several variations of the Map
+     *  be looked up at compile time and optimized to very efficient code. There are several variations of the Map
      *  provided through the MapType parameter the operation of each of these is described in their individual
      *  documentation.
      *

--- a/tests/dsl/FusionInOrder.cpp
+++ b/tests/dsl/FusionInOrder.cpp
@@ -35,7 +35,7 @@ class TestReactor : public NUClear::Reactor {
 public:
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : Reactor(std::move(environment)) {
 
-        on<Extension<0>, Extension<1>, Extension<2>, Extension<3>, Extension<4>>().then([this] {});
+        on<Extension<0>, Extension<1>, Extension<2>, Extension<3>, Extension<4>>().then([] {});
     }
 };
 

--- a/tests/dsl/FusionInOrder.cpp
+++ b/tests/dsl/FusionInOrder.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2013      Trent Houliston <trent@houliston.me>, Jake Woods <jake.f.woods@gmail.com>
+ *               2014-2017 Trent Houliston <trent@houliston.me>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <catch.hpp>
+#include <nuclear>
+
+namespace {
+
+std::vector<int> events;
+
+template <int i>
+struct Extension {
+    template <typename DSL>
+    static inline void bind(const std::shared_ptr<NUClear::threading::Reaction>&) {
+        events.push_back(i);
+    }
+};
+
+class TestReactor : public NUClear::Reactor {
+public:
+    TestReactor(std::unique_ptr<NUClear::Environment> environment) : Reactor(std::move(environment)) {
+
+        on<Extension<0>, Extension<1>, Extension<2>, Extension<3>, Extension<4>>().then([this] {});
+    }
+};
+
+}  // namespace
+
+
+TEST_CASE("Testing that the bind functions of extensions are executed in order", "[api][extension][bind]") {
+
+    NUClear::PowerPlant::Configuration config;
+    config.thread_count = 1;
+    NUClear::PowerPlant plant(config);
+    plant.install<TestReactor>();
+
+    REQUIRE(events == std::vector<int>{0, 1, 2, 3, 4});
+}


### PR DESCRIPTION
Currently when you have multiple DSL words in an `on` statement the order they execute is undefined according to the standard.
This can be confusing when you're writing an extension and expect them to execute in the order they appear.

This change changes the function fusion system to execute the functions in the order they appear rather than leaving it up to the compiler to choose.

It seems that for GCC at least the order is the inverse of the order of the arguments hence leading to this fix.