### PR TITLE
Change the logic for logging so floating `NUClear::log` calls respect the reactors log level

### DIFF
--- a/src/PowerPlant.ipp
+++ b/src/PowerPlant.ipp
@@ -163,17 +163,22 @@ namespace {
 template <enum LogLevel level, typename... Arguments>
 void PowerPlant::log(Arguments&&... args) {
 
-    // Build our log message by concatenating everything to a stream
-    std::stringstream output_stream;
-    log_impl(output_stream, std::forward<Arguments>(args)...);
-    std::string output = output_stream.str();
-
+    // Get the current task
     auto* current_task = threading::ReactionTask::get_current_task();
     auto* task         = current_task ? current_task->stats.get() : nullptr;
 
-    // Direct emit the log message so that any direct loggers can use it
-    powerplant->emit<dsl::word::emit::Direct>(
-        std::make_unique<message::LogMessage>(message::LogMessage{level, output, task}));
+    if (!task || level >= task->parent.reactor.log_level) {
+
+        // Build our log message by concatenating everything to a stream
+        std::stringstream output_stream;
+        log_impl(output_stream, std::forward<Arguments>(args)...);
+        std::string output = output_stream.str();
+
+
+        // Direct emit the log message so that any direct loggers can use it
+        powerplant->emit<dsl::word::emit::Direct>(
+            std::make_unique<message::LogMessage>(message::LogMessage{level, output, task}));
+    }
 }
 
 }  // namespace NUClear

--- a/src/Reactor.hpp
+++ b/src/Reactor.hpp
@@ -396,7 +396,7 @@ public:
     void log(Arguments&&... args) {
 
         // If the log is above or equal to our log level
-        if (level >= log_level) { powerplant.log<level>(std::forward<Arguments>(args)...); }
+        powerplant.log<level>(std::forward<Arguments>(args)...);
     }
 };
 


### PR DESCRIPTION
Currently, if you use NUClear::log in a non-reactor it will always print the log regardless of the level.
However, if you were calling a dependent function from a reaction, you would expect that the log statements respect the call status of where they came from.