### PR TITLE
Prevent powerplant nullptr from inhibiting shutdown

### DIFF
--- a/src/PowerPlant.cpp
+++ b/src/PowerPlant.cpp
@@ -102,9 +102,6 @@ void PowerPlant::shutdown() {
 
     // Shutdown the main threads scheduler
     main_thread_scheduler.shutdown();
-
-    // Bye bye powerplant
-    powerplant = nullptr;
 }
 
 bool PowerPlant::running() const {

--- a/src/PowerPlant.cpp
+++ b/src/PowerPlant.cpp
@@ -90,7 +90,7 @@ void PowerPlant::submit_main(std::unique_ptr<threading::ReactionTask>&& task) {
 
 void PowerPlant::shutdown() {
 
-    // Stop running before we emit events the Shutdown event
+    // Stop running before we emit the Shutdown event
     // Some things such as on<Always> depend on this flag and it's possible to miss it
     is_running = false;
 

--- a/src/PowerPlant.ipp
+++ b/src/PowerPlant.ipp
@@ -163,6 +163,9 @@ namespace {
 template <enum LogLevel level, typename... Arguments>
 void PowerPlant::log(Arguments&&... args) {
 
+    // If there is no powerplant then do nothing
+    if (powerplant == nullptr) { return; }
+
     // Get the current task
     auto* current_task = threading::ReactionTask::get_current_task();
 

--- a/src/PowerPlant.ipp
+++ b/src/PowerPlant.ipp
@@ -170,8 +170,7 @@ void PowerPlant::log(Arguments&&... args) {
     auto* current_task = threading::ReactionTask::get_current_task();
 
     // Only log if we are not from a reaction, or if our reactor's log level is high enough
-    if (!current_task || level >= current_task->parent.reactor.log_level) {
-
+    if (current_task == nullptr || level >= current_task->parent.reactor.log_level) {
         // Build our log message by concatenating everything to a stream
         std::stringstream output_stream;
         log_impl(output_stream, std::forward<Arguments>(args)...);
@@ -179,7 +178,7 @@ void PowerPlant::log(Arguments&&... args) {
 
         // Direct emit the log message so that any direct loggers can use it
         powerplant->emit<dsl::word::emit::Direct>(std::make_unique<message::LogMessage>(
-            message::LogMessage{level, output, current_task ? current_task->stats.get() : nullptr}));
+            message::LogMessage{level, output, current_task != nullptr ? current_task->stats.get() : nullptr}));
     }
 }
 

--- a/tests/log/Log.cpp
+++ b/tests/log/Log.cpp
@@ -130,14 +130,17 @@ TEST_CASE("Testing the Log<>() function", "[api][log]") {
     free_floating_log<NUClear::ERROR>("Pre Powerplant Construction", NUClear::ERROR);
     free_floating_log<NUClear::FATAL>("Pre Powerplant Construction", NUClear::FATAL);
 
-    // Build with one thread
-    NUClear::PowerPlant::Configuration config;
-    config.thread_count = 1;
-    NUClear::PowerPlant plant(config);
+    // Local scope to force powerplant destruction
+    {
+        // Build with one thread
+        NUClear::PowerPlant::Configuration config;
+        config.thread_count = 1;
+        NUClear::PowerPlant plant(config);
 
-    // Install the test reactor
-    plant.install<TestReactor>();
-    plant.start();
+        // Install the test reactor
+        plant.install<TestReactor>();
+        plant.start();
+    }
 
     // Try to call log before constructing a powerplant
     free_floating_log<NUClear::TRACE>("Post Powerplant Destruction", NUClear::TRACE);

--- a/tests/log/Log.cpp
+++ b/tests/log/Log.cpp
@@ -199,13 +199,15 @@ TEST_CASE("Testing the Log<>() function", "[api][log]") {
     }
 
     // Test post-shutdown logs
-    std::string expected = "Post Powerplant Shutdown " + std::to_string(NUClear::FATAL);
-    REQUIRE(messages[i].message == expected);
-    REQUIRE(messages[i].level == NUClear::FATAL);
-    REQUIRE(messages[i++].from_reaction);
-    REQUIRE(messages[i].message == expected);
-    REQUIRE(messages[i].level == NUClear::FATAL);
-    REQUIRE(messages[i++].from_reaction);
+    {
+        std::string expected = "Post Powerplant Shutdown " + std::to_string(NUClear::FATAL);
+        REQUIRE(messages[i].message == expected);
+        REQUIRE(messages[i].level == NUClear::FATAL);
+        REQUIRE(messages[i++].from_reaction);
+        REQUIRE(messages[i].message == expected);
+        REQUIRE(messages[i].level == NUClear::FATAL);
+        REQUIRE(messages[i++].from_reaction);
+    }
 
     // Test logs from free floating functions
     for (const auto& log_level : levels) {

--- a/tests/log/Log.cpp
+++ b/tests/log/Log.cpp
@@ -142,7 +142,7 @@ TEST_CASE("Testing the Log<>() function", "[api][log]") {
         plant.start();
     }
 
-    // Try to call log before constructing a powerplant
+    // Try to call log after destructing the powerplant
     free_floating_log<NUClear::TRACE>("Post Powerplant Destruction", NUClear::TRACE);
     free_floating_log<NUClear::DEBUG>("Post Powerplant Destruction", NUClear::DEBUG);
     free_floating_log<NUClear::INFO>("Post Powerplant Destruction", NUClear::INFO);


### PR DESCRIPTION
If a `log` happens after a call to `powerplant.shutdown()` then the call to `shutdown()` will fail and the powerplant will segfault. This PR aims to fix this