### PR TITLE
Take shared pointers by value rather than rvalue as it's safer for multiple targets

### DIFF
--- a/src/PowerPlant.hpp
+++ b/src/PowerPlant.hpp
@@ -226,7 +226,7 @@ public:
               class... Remainder,
               typename T,
               typename... Arguments>
-    void emit_shared(std::shared_ptr<T>&& data, Arguments&&... args);
+    void emit_shared(std::shared_ptr<T> data, Arguments&&... args);
 
     template <template <typename> class First, template <typename> class... Remainder, typename... Arguments>
     void emit_shared(Arguments&&... args);

--- a/src/PowerPlant.ipp
+++ b/src/PowerPlant.ipp
@@ -100,7 +100,7 @@ struct EmitCaller {
 
 
 template <template <typename> class First, template <typename> class... Remainder, typename T, typename... Arguments>
-void PowerPlant::emit_shared(std::shared_ptr<T>&& ptr, Arguments&&... args) {
+void PowerPlant::emit_shared(std::shared_ptr<T> ptr, Arguments&&... args) {
 
     using Functions      = std::tuple<First<T>, Remainder<T>...>;
     using ArgumentPack   = decltype(std::forward_as_tuple(*this, ptr, std::forward<Arguments>(args)...));


### PR DESCRIPTION
This also seems to fix the timeouts that are happening in #54 