### PR TITLE
Swap to rescheduling on task creation rather than task execution

### DIFF
--- a/src/dsl/word/Sync.hpp
+++ b/src/dsl/word/Sync.hpp
@@ -96,9 +96,6 @@ namespace dsl {
                 // Lock our mutex
                 std::lock_guard<std::mutex> lock(mutex);
 
-                // We are finished running
-                running = false;
-
                 // If we have another task, add it
                 if (!queue.empty()) {
                     std::unique_ptr<threading::ReactionTask> next_task(
@@ -107,6 +104,10 @@ namespace dsl {
 
                     // Resubmit this task to the reaction queue
                     task.parent.reactor.powerplant.submit(std::move(next_task));
+                }
+                else {
+                    // We are finished running
+                    running = false;
                 }
             }
         };


### PR DESCRIPTION
Currently when using the Sync keyword due to the fact that rescheduling is done when the task is run rather than created means that if tasks are emitted quickly enough multiple can be in the main queue. These will be rescheduled when they are picked up and executed by the thread pool threads.
This can make a race condition where the tasks end up executing out of order.

This PR fixes this by rescheduling on task creation rather than when it is executed in the main thread pool

# Problems

The potential problem with this PR at the moment is that if a sync task is running this PR may make it run before it is expected to.

For example if you have an extension and it creates a task, and that task has sync even if the extension has not yet executed this task it may get put in the sync queue then to the main queue without the extensions knowledge. It may then execute early as the extension will get a nullptr back and the task will make its way to the main thread pool.

This will also have bad interactions with multiple Sync types, for example Sync along with MainThread depending on the order of those two words will not work together