### PR TITLE
Store the identifiers in a struct to help know what they mean

### DIFF
--- a/src/Reactor.hpp
+++ b/src/Reactor.hpp
@@ -22,6 +22,7 @@
 #include <atomic>
 #include <chrono>
 #include <functional>
+#include <regex>
 #include <sstream>
 #include <string>
 #include <typeindex>
@@ -32,6 +33,7 @@
 #include "dsl/Parse.hpp"
 #include "threading/Reaction.hpp"
 #include "threading/ReactionHandle.hpp"
+#include "threading/ReactionIdentifiers.hpp"
 #include "util/CallbackGenerator.hpp"
 #include "util/Sequence.hpp"
 #include "util/tuplify.hpp"
@@ -298,16 +300,21 @@ public:
         template <typename Function, int... Index>
         auto then(const std::string& label, Function&& callback, const util::Sequence<Index...>& /*s*/) {
 
+            // Regex replace NUClear::dsl::Parse with NUClear::Reactor::on so that it reads more like what is expected
+            std::string dsl = std::regex_replace(util::demangle(typeid(DSL).name()),
+                                                 std::regex("NUClear::dsl::Parse<"),
+                                                 "NUClear::Reactor::on<");
+
             // Generate the identifier
-            std::vector<std::string> identifier = {label,
-                                                   reactor.reactor_name,
-                                                   util::demangle(typeid(DSL).name()),
-                                                   util::demangle(typeid(Function).name())};
+            threading::ReactionIdentifiers identifiers{label,
+                                                       reactor.reactor_name,
+                                                       dsl,
+                                                       util::demangle(typeid(Function).name())};
 
             // Generate the reaction
             auto reaction = std::make_shared<threading::Reaction>(
                 reactor,
-                std::move(identifier),
+                std::move(identifiers),
                 util::CallbackGenerator<DSL, Function>(std::forward<Function>(callback)));
 
             // Get our tuple from binding our reaction

--- a/src/dsl/word/Always.hpp
+++ b/src/dsl/word/Always.hpp
@@ -105,10 +105,10 @@ namespace dsl {
                  */
                 auto idle_reaction = std::make_shared<threading::Reaction>(
                     always_reaction->reactor,
-                    std::vector<std::string>{always_reaction->identifier[0] + " - IDLE Task",
-                                             always_reaction->identifier[1],
-                                             always_reaction->identifier[2],
-                                             always_reaction->identifier[3]},
+                    threading::ReactionIdentifiers{always_reaction->identifiers.name + " - IDLE Task",
+                                                   always_reaction->identifiers.reactor,
+                                                   always_reaction->identifiers.dsl,
+                                                   always_reaction->identifiers.function},
                     [always_reaction](threading::Reaction& idle_reaction) -> util::GeneratedCallback {
                         auto callback = [&idle_reaction, always_reaction](threading::ReactionTask& /*task*/) {
                             // Get a task for the always reaction and submit it to the scheduler

--- a/src/message/ReactionStatistics.hpp
+++ b/src/message/ReactionStatistics.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "../clock.hpp"
+#include "../threading/ReactionIdentifiers.hpp"
 
 namespace NUClear {
 namespace message {
@@ -33,8 +34,7 @@ namespace message {
      */
     struct ReactionStatistics {
 
-        ReactionStatistics() = default;
-        ReactionStatistics(std::vector<std::string> identifier,
+        ReactionStatistics(threading::ReactionIdentifiers identifiers,
                            uint64_t reaction_id,
                            uint64_t task_id,
                            uint64_t cause_reaction_id,
@@ -43,7 +43,7 @@ namespace message {
                            const clock::time_point& start,
                            const clock::time_point& finish,
                            std::exception_ptr exception)
-            : identifier(std::move(identifier))
+            : identifiers(std::move(identifiers))
             , reaction_id(reaction_id)
             , task_id(task_id)
             , cause_reaction_id(cause_reaction_id)
@@ -54,7 +54,7 @@ namespace message {
             , exception(std::move(exception)) {}
 
         /// @brief A string containing the username/on arguments/and callback name of the reaction.
-        std::vector<std::string> identifier{};
+        threading::ReactionIdentifiers identifiers;
         /// @brief The id of this reaction.
         uint64_t reaction_id{0};
         /// @brief The task id of this reaction.

--- a/src/threading/Reaction.hpp
+++ b/src/threading/Reaction.hpp
@@ -26,6 +26,7 @@
 #include <utility>
 
 #include "../util/GeneratedCallback.hpp"
+#include "ReactionIdentifiers.hpp"
 #include "ReactionTask.hpp"
 
 namespace NUClear {
@@ -57,10 +58,10 @@ namespace threading {
          * @brief Constructs a new Reaction with the passed callback generator and options
          *
          * @param reactor        the reactor this belongs to
-         * @param identifier     string identifier information about the reaction to help identify it
+         * @param identifiers    string identification information for the reaction
          * @param callback       the callback generator function (creates databound callbacks)
          */
-        Reaction(Reactor& reactor, std::vector<std::string>&& identifier, TaskGenerator&& generator);
+        Reaction(Reactor& reactor, ReactionIdentifiers&& identifiers, TaskGenerator&& generator);
 
         /**
          * @brief creates a new databound callback task that can be executed.
@@ -98,8 +99,8 @@ namespace threading {
         /// @brief the reactor this belongs to
         Reactor& reactor;
 
-        /// @brief This holds the demangled name of the On function that is being called
-        std::vector<std::string> identifier{};
+        /// @brief This holds the identifying strings for this reaction
+        ReactionIdentifiers identifiers;
 
         /// @brief the unique identifier for this Reaction object
         const uint64_t id;

--- a/src/threading/ReactionIdentifiers.hpp
+++ b/src/threading/ReactionIdentifiers.hpp
@@ -26,7 +26,6 @@ namespace threading {
 
     /**
      * @brief This struct holds string fields that can be used to identify a reaction.
-     *
      */
     struct ReactionIdentifiers {
 

--- a/src/threading/ReactionIdentifiers.hpp
+++ b/src/threading/ReactionIdentifiers.hpp
@@ -15,26 +15,43 @@
  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#include "Reaction.hpp"
+
+#ifndef NUCLEAR_THREADING_REACTIONIDENTIFIERS_HPP
+#define NUCLEAR_THREADING_REACTIONIDENTIFIERS_HPP
+
+#include <string>
 
 namespace NUClear {
 namespace threading {
 
-    // Initialize our reaction source
-    std::atomic<uint64_t> Reaction::reaction_id_source(0);  // NOLINT
+    /**
+     * @brief This struct holds string fields that can be used to identify a reaction.
+     *
+     */
+    struct ReactionIdentifiers {
 
-    Reaction::Reaction(Reactor& reactor, ReactionIdentifiers&& identifiers, TaskGenerator&& generator)
-        : reactor(reactor), identifiers(identifiers), id(++reaction_id_source), generator(generator) {}
+        /**
+         * @brief Construct a new Identifiers object
+         *
+         * @param name the name of the reaction provided by the user
+         * @param reactor the name of the reactor that this reaction belongs to
+         * @param dsl the DSL that this reaction was created from
+         * @param function the callback function that this reaction is bound to
+         */
+        ReactionIdentifiers(std::string name, std::string reactor, std::string dsl, std::string function)
+            : name(std::move(name)), reactor(std::move(reactor)), dsl(std::move(dsl)), function(std::move(function)) {}
 
-    void Reaction::unbind() {
-        // Unbind
-        for (auto& u : unbinders) {
-            u(*this);
-        }
-    }
+        /// @brief The name of the reaction provided by the user
+        std::string name;
+        /// @brief The name of the reactor that this reaction belongs to
+        std::string reactor;
+        /// @brief The DSL that this reaction was created from
+        std::string dsl;
+        /// @brief The callback function that this reaction is bound to
+        std::string function;
+    };
 
-    bool Reaction::is_enabled() const {
-        return enabled;
-    }
 }  // namespace threading
 }  // namespace NUClear
+
+#endif  // NUCLEAR_THREADING_REACTIONIDENTIFIERS_HPP

--- a/src/threading/ReactionTask.hpp
+++ b/src/threading/ReactionTask.hpp
@@ -81,7 +81,7 @@ namespace threading {
             : parent(parent)
             , id(++task_id_source)
             , priority(priority)
-            , stats(std::make_shared<message::ReactionStatistics>(parent.identifier,
+            , stats(std::make_shared<message::ReactionStatistics>(parent.identifiers,
                                                                   parent.id,
                                                                   id,
                                                                   current_task != nullptr ? current_task->parent.id : 0,

--- a/tests/api/ReactionStatistics.cpp
+++ b/tests/api/ReactionStatistics.cpp
@@ -47,26 +47,26 @@ public:
 
         on<Trigger<ReactionStatistics>>().then("Reaction Stats Handler", [this](const ReactionStatistics& stats) {
             // If we are seeing ourself, fail
-            REQUIRE(stats.identifier[0] != "Reaction Stats Handler");
+            REQUIRE(stats.identifiers.name != "Reaction Stats Handler");
 
             // If we are seeing the other reaction statistics handler, fail
-            REQUIRE(stats.identifier[0] != "Reaction Stats Handler 2");
+            REQUIRE(stats.identifiers.name != "Reaction Stats Handler 2");
 
             // If we are seeing the other reaction statistics handler, fail
-            REQUIRE(stats.identifier[0] != "NoStats");
+            REQUIRE(stats.identifiers.name != "NoStats");
 
             // Flag if we have seen the message handler
-            if (stats.identifier[0] == "Message Handler") {
+            if (stats.identifiers.name == "Message Handler") {
                 seen_message0 = true;
             }
             // Flag if we have seen the startup handler
-            else if (stats.identifier[0] == "Startup Handler") {
+            else if (stats.identifiers.name == "Startup Handler") {
                 seen_message_startup = true;
             }
 
             // Ensure exceptions are passed through correctly in the exception handler
             if (stats.exception) {
-                REQUIRE(stats.identifier[0] == "Exception Handler");
+                REQUIRE(stats.identifiers.name == "Exception Handler");
                 try {
                     std::rethrow_exception(stats.exception);
                 }


### PR DESCRIPTION
Currently, the identifiers are just stored in an `std::vector` of `std::string`s. It makes it very difficult to know what each of the different identifiers available for a reaction are.
This changes it to be a struct so you can access the fields you care about.