### PR TITLE
Refactor the chrono controller to have higher accuracy

### DIFF
--- a/src/extension/ChronoController.hpp
+++ b/src/extension/ChronoController.hpp
@@ -21,6 +21,7 @@
 
 #include "../PowerPlant.hpp"
 #include "../Reactor.hpp"
+#include "../util/precise_sleep.hpp"
 
 namespace NUClear {
 namespace extension {
@@ -30,8 +31,28 @@ namespace extension {
         using ChronoTask = NUClear::dsl::operation::ChronoTask;
 
     public:
-        explicit ChronoController(std::unique_ptr<NUClear::Environment> environment)
-            : Reactor(std::move(environment)), wait_offset(std::chrono::milliseconds(0)) {
+        explicit ChronoController(std::unique_ptr<NUClear::Environment> environment) : Reactor(std::move(environment)) {
+
+            // Estimate the accuracy of our cv wait and precise sleep
+            for (int i = 0; i < 3; ++i) {
+                // Estimate the accuracy of our cv wait
+                std::mutex test;
+                std::unique_lock<std::mutex> lock(test);
+                const auto cv_s = NUClear::clock::now();
+                wait.wait_for(lock, std::chrono::milliseconds(1));
+                const auto cv_e = NUClear::clock::now();
+                const auto cv_a = NUClear::clock::duration(cv_e - cv_s - std::chrono::milliseconds(1));
+
+                // Estimate the accuracy of our precise sleep
+                const auto ns_s = NUClear::clock::now();
+                util::precise_sleep(std::chrono::milliseconds(1));
+                const auto ns_e = NUClear::clock::now();
+                const auto ns_a = NUClear::clock::duration(ns_e - ns_s - std::chrono::milliseconds(1));
+
+                // Use the largest time we have seen
+                cv_accuracy = cv_a > cv_accuracy ? cv_a : cv_accuracy;
+                ns_accuracy = ns_a > ns_accuracy ? ns_a : ns_accuracy;
+            }
 
             on<Trigger<ChronoTask>>().then("Add Chrono task", [this](const std::shared_ptr<const ChronoTask>& task) {
                 // Lock the mutex while we're doing stuff
@@ -40,6 +61,7 @@ namespace extension {
                 // Add our new task to the heap if we are still running
                 if (running) {
                     tasks.push_back(*task);
+                    std::push_heap(tasks.begin(), tasks.end(), std::greater<>());
                 }
 
                 // Poke the system
@@ -60,6 +82,7 @@ namespace extension {
                     // Remove if it exists
                     if (it != tasks.end()) {
                         tasks.erase(it);
+                        std::make_heap(tasks.begin(), tasks.end(), std::greater<>());
                     }
 
                     // Poke the system to make sure it's not waiting on something that's gone
@@ -74,65 +97,81 @@ namespace extension {
             });
 
             on<Always, Priority::REALTIME>().then("Chrono Controller", [this] {
-                // Acquire the mutex lock so we can wait on it
-                std::unique_lock<std::mutex> lock(mutex);
+                // Run until we are told to stop
+                while (running) {
 
-                if (!running) {
-                    return;
-                }
+                    // Acquire the mutex lock so we can wait on it
+                    std::unique_lock<std::mutex> lock(mutex);
 
-                // If we have tasks to do
-                if (!tasks.empty()) {
+                    // If we have no chrono tasks wait until we are notified
+                    if (tasks.empty()) {
+                        wait.wait(lock);
+                    }
+                    else {
+                        auto start  = NUClear::clock::now();
+                        auto target = tasks.front().time;
 
-                    // Make the list into a heap so we can remove the soonest ones
-                    std::make_heap(tasks.begin(), tasks.end(), std::greater<>());
+                        if (target - start > cv_accuracy) {
+                            // Wait on the cv
+                            wait.wait_until(lock, target - cv_accuracy);
 
-                    // If we are within the wait offset of the time, spinlock until we get there for greater
-                    // accuracy
-                    if (NUClear::clock::now() + wait_offset > tasks.front().time) {
-
-                        // Spinlock!
-                        while (NUClear::clock::now() < tasks.front().time) {
+                            // Update the accuracy of our cv wait
+                            const auto end   = NUClear::clock::now();
+                            const auto error = end - (target - cv_accuracy);  // when ended - when wanted to end
+                            if (error.count() > 0) {                          // only if we were late
+                                cv_accuracy = error > cv_accuracy ? error : ((cv_accuracy * 99 + error) / 100);
+                            }
                         }
+                        else if (target - start > ns_accuracy) {
+                            // Wait on nanosleep
+                            util::precise_sleep(target - start - ns_accuracy);
 
-                        const NUClear::clock::time_point now = NUClear::clock::now();
+                            // Update the accuracy of our precise sleep
+                            const auto end   = NUClear::clock::now();
+                            const auto error = end - (target - ns_accuracy);  // when ended - when wanted to end
+                            if (error.count() > 0) {                          // only if we were late
+                                ns_accuracy = error > ns_accuracy ? error : ((ns_accuracy * 99 + error) / 100);
+                            }
+                        }
+                        else {
+                            // Spinlock until we get to the time
+                            while (NUClear::clock::now() < tasks.front().time) {
+                            }
 
-                        // Move back from the end poping the heap
-                        for (auto end = tasks.end(); end != tasks.begin() && tasks.front().time < now;) {
                             // Run our task and if it returns false remove it
                             const bool renew = tasks.front()();
 
                             // Move this to the back of the list
-                            std::pop_heap(tasks.begin(), end, std::greater<>());
+                            std::pop_heap(tasks.begin(), tasks.end(), std::greater<>());
 
-                            if (!renew) {
-                                end = tasks.erase(--end);
+                            if (renew) {
+                                // Put the item back in the list
+                                std::push_heap(tasks.begin(), tasks.end(), std::greater<>());
                             }
                             else {
-                                --end;
+                                // Remove the item from the list
+                                tasks.pop_back();
                             }
                         }
                     }
-                    // Otherwise we wait for the next event using a wait_for (with a small offset for greater
-                    // accuracy) Either that or until we get interrupted with a new event
-                    else {
-                        wait.wait_until(lock, tasks.front().time - wait_offset);
-                    }
-                }
-                // Otherwise we wait for something to happen
-                else {
-                    wait.wait(lock);
                 }
             });
         }
 
     private:
+        /// @brief The list of tasks we need to process
         std::vector<dsl::operation::ChronoTask> tasks;
+        /// @brief The mutex we use to lock the task list
         std::mutex mutex;
+        /// @brief The condition variable we use to wait on
         std::condition_variable wait;
+        /// @brief If we are running or not
         bool running{true};
 
-        NUClear::clock::duration wait_offset;
+        /// @brief The temporal accuracy when waiting on a condition variable
+        NUClear::clock::duration cv_accuracy{0};
+        /// @brief The temporal accuracy when waiting on nanosleep
+        NUClear::clock::duration ns_accuracy{0};
     };
 
 }  // namespace extension

--- a/src/util/precise_sleep.cpp
+++ b/src/util/precise_sleep.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2013      Trent Houliston <trent@houliston.me>, Jake Woods <jake.f.woods@gmail.com>
+ *               2014-2023 Trent Houliston <trent@houliston.me>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "precise_sleep.hpp"
+
+#if defined(_WIN32)
+
+    #include <chrono>
+    #include <cstdint>
+
+    #include "platform.hpp"
+
+namespace NUClear {
+namespace util {
+
+    void precise_sleep(const std::chrono::nanoseconds& ns) {
+        ::LARGE_INTEGER ft;
+        // TODO if ns is negative make it 0 as otherwise it'll become absolute time
+        // Negative for relative time, positive for absolute time
+        // Measures in 100ns increments so divide by 100
+        ft.QuadPart = -static_cast<int64_t>(ns.count() / 100);
+
+        ::HANDLE timer = ::CreateWaitableTimer(nullptr, TRUE, nullptr);
+        ::SetWaitableTimer(timer, &ft, 0, nullptr, nullptr, 0);
+        ::WaitForSingleObject(timer, INFINITE);
+        ::CloseHandle(timer);
+    }
+
+}  // namespace util
+}  // namespace NUClear
+
+#else
+
+    #include <cerrno>
+    #include <cstdint>
+    #include <ctime>
+
+namespace NUClear {
+namespace util {
+
+    void precise_sleep(const std::chrono::nanoseconds& ns) {
+        timespec ts{};
+        ts.tv_sec  = std::chrono::duration_cast<std::chrono::seconds>(ns).count();
+        ts.tv_nsec = (ns - std::chrono::seconds(ts.tv_sec)).count();
+
+        while (::nanosleep(&ts, &ts) == -1 && errno == EINTR) {
+        }
+    }
+
+}  // namespace util
+}  // namespace NUClear
+
+#endif

--- a/src/util/precise_sleep.hpp
+++ b/src/util/precise_sleep.hpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2013      Trent Houliston <trent@houliston.me>, Jake Woods <jake.f.woods@gmail.com>
+ *               2014-2023 Trent Houliston <trent@houliston.me>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef NUCLEAR_UTIL_SLEEPER_HPP
+#define NUCLEAR_UTIL_SLEEPER_HPP
+
+#include <chrono>
+
+namespace NUClear {
+namespace util {
+
+    void precise_sleep(const std::chrono::nanoseconds& ns);
+
+}  // namespace util
+}  // namespace NUClear
+
+#endif  // NUCLEAR_UTIL_SLEEPER_HPP


### PR DESCRIPTION
Currently, the chrono controller will often oversleep and the resulting timings can be a little off.
This refactors the controller so that it keeps track of how much it oversleeps and ensures that it spinlocks to have accurate timing.
This is a particular problem on the windows CI where the sleep accuracy is often up to 14ms off.

Extracted from #70 