### PR TITLE
Refactor the task scheduler so it can take generic tasks

### DIFF
--- a/src/PowerPlant.cpp
+++ b/src/PowerPlant.cpp
@@ -57,7 +57,7 @@ void PowerPlant::submit(std::unique_ptr<threading::ReactionTask>&& task, const b
     // Only submit non null tasks
     if (task) {
         try {
-            std::shared_ptr<threading::ReactionTask> t(std::move(task));
+            const std::shared_ptr<threading::ReactionTask> t(std::move(task));
             submit(t->id, t->priority, t->group_descriptor, t->thread_pool_descriptor, immediate, [t]() { t->run(); });
         }
         catch (...) {

--- a/src/PowerPlant.cpp
+++ b/src/PowerPlant.cpp
@@ -44,8 +44,25 @@ void PowerPlant::start() {
     scheduler.start();
 }
 
-void PowerPlant::submit(std::unique_ptr<threading::ReactionTask>&& task, const bool& immediate) {
-    scheduler.submit(std::move(task), immediate);
+void PowerPlant::submit(const uint64_t& id,
+                        const int& priority,
+                        const util::GroupDescriptor& group,
+                        const util::ThreadPoolDescriptor& pool,
+                        const bool& immediate,
+                        std::function<void()>&& task) {
+    scheduler.submit(id, priority, group, pool, immediate, std::move(task));
+}
+
+void PowerPlant::submit(std::unique_ptr<threading::ReactionTask>&& task, const bool& immediate) noexcept {
+    // Only submit non null tasks
+    if (task) {
+        try {
+            std::shared_ptr<threading::ReactionTask> t(std::move(task));
+            submit(t->id, t->priority, t->group_descriptor, t->thread_pool_descriptor, immediate, [t]() { t->run(); });
+        }
+        catch (...) {
+        }
+    }
 }
 
 void PowerPlant::shutdown() {

--- a/src/PowerPlant.cpp
+++ b/src/PowerPlant.cpp
@@ -60,7 +60,11 @@ void PowerPlant::submit(std::unique_ptr<threading::ReactionTask>&& task, const b
             const std::shared_ptr<threading::ReactionTask> t(std::move(task));
             submit(t->id, t->priority, t->group_descriptor, t->thread_pool_descriptor, immediate, [t]() { t->run(); });
         }
+        catch (const std::exception& ex) {
+            task->parent.reactor.log<NUClear::ERROR>("There was an exception while submitting a reaction", ex.what());
+        }
         catch (...) {
+            task->parent.reactor.log<NUClear::ERROR>("There was an unknown exception while submitting a reaction");
         }
     }
 }

--- a/src/PowerPlant.hpp
+++ b/src/PowerPlant.hpp
@@ -142,12 +142,29 @@ public:
     void install();
 
     /**
+     * @brief Generic submit function for submitting tasks to the thread pool.
+     *
+     * @param id        an id for ordering the task
+     * @param priority  the priority of the task between 0 and 1000
+     * @param group     the details of the execution group this task will run in
+     * @param pool      the details of the thread pool this task will run from
+     * @param immediate if this task should run immediately in the current thread
+     * @param task      the wrapped function to be executed
+     */
+    void submit(const uint64_t& id,
+                const int& priority,
+                const util::GroupDescriptor& group,
+                const util::ThreadPoolDescriptor& pool,
+                const bool& immediate,
+                std::function<void()>&& task);
+
+    /**
      * @brief Submits a new task to the ThreadPool to be queued and then executed.
      *
      * @param task The Reaction task to be executed in the thread pool
      * @param immediate if this task should run immediately in the current thread
      */
-    void submit(std::unique_ptr<threading::ReactionTask>&& task, const bool& immediate = false);
+    void submit(std::unique_ptr<threading::ReactionTask>&& task, const bool& immediate = false) noexcept;
 
     /**
      * @brief Log a message through NUClear's system.

--- a/src/dsl/word/Always.hpp
+++ b/src/dsl/word/Always.hpp
@@ -112,23 +112,10 @@ namespace dsl {
                     [always_reaction](threading::Reaction& idle_reaction) -> util::GeneratedCallback {
                         auto callback = [&idle_reaction, always_reaction](threading::ReactionTask& /*task*/) {
                             // Get a task for the always reaction and submit it to the scheduler
-                            auto always_task = always_reaction->get_task();
-                            if (always_task) {
-                                always_reaction->reactor.powerplant.submit(std::move(always_task));
-                            }
+                            always_reaction->reactor.powerplant.submit(always_reaction->get_task());
 
                             // Get a task for the idle reaction and submit it to the scheduler
-                            auto idle_task = idle_reaction.get_task();
-                            if (idle_task) {
-                                // Set the thread pool on the task
-                                idle_task->thread_pool_descriptor = DSL::pool(*always_reaction);
-
-                                // Make sure that idle reaction always has lower priority than the always reaction
-                                idle_task->priority = DSL::priority(*always_reaction) - 1;
-
-                                // Submit the task to be run
-                                idle_reaction.reactor.powerplant.submit(std::move(idle_task));
-                            }
+                            idle_reaction.reactor.powerplant.submit(idle_reaction.get_task());
                         };
 
                         // Make sure that idle reaction always has lower priority than the always reaction
@@ -152,25 +139,16 @@ namespace dsl {
                 });
 
                 // Get a task for the always reaction and submit it to the scheduler
-                auto always_task = always_reaction->get_task();
-                if (always_task) {
-                    always_reaction->reactor.powerplant.submit(std::move(always_task));
-                }
+                always_reaction->reactor.powerplant.submit(always_reaction->get_task());
 
                 // Get a task for the idle reaction and submit it to the scheduler
-                auto idle_task = idle_reaction->get_task();
-                if (idle_task) {
-                    idle_reaction->reactor.powerplant.submit(std::move(idle_task));
-                }
+                idle_reaction->reactor.powerplant.submit(idle_reaction->get_task());
             }
 
             template <typename DSL>
             static inline void postcondition(threading::ReactionTask& task) {
                 // Get a task for the always reaction and submit it to the scheduler
-                auto new_task = task.parent.get_task();
-                if (new_task) {
-                    task.parent.reactor.powerplant.submit(std::move(new_task));
-                }
+                task.parent.reactor.powerplant.submit(task.parent.get_task());
             }
         };
 

--- a/src/dsl/word/Every.hpp
+++ b/src/dsl/word/Every.hpp
@@ -93,22 +93,8 @@ namespace dsl {
                 // Send our configuration out
                 reaction->reactor.emit<emit::Direct>(std::make_unique<operation::ChronoTask>(
                     [reaction, jump](NUClear::clock::time_point& time) {
-                        try {
                             // submit the reaction to the thread pool
-                            auto task = reaction->get_task();
-                            if (task) {
-                                reaction->reactor.powerplant.submit(std::move(task));
-                            }
-                        }
-                        // If there is an exception while generating a reaction print it here, this shouldn't happen
-                        catch (const std::exception& ex) {
-                            reaction->reactor.log<NUClear::ERROR>("There was an exception while generating a reaction",
-                                                                  ex.what());
-                        }
-                        catch (...) {
-                            reaction->reactor.log<NUClear::ERROR>(
-                                "There was an unknown exception while generating a reaction");
-                        }
+                        reaction->reactor.powerplant.submit(reaction->get_task());
 
                         time += jump;
 

--- a/src/dsl/word/Watchdog.hpp
+++ b/src/dsl/word/Watchdog.hpp
@@ -266,15 +266,8 @@ namespace dsl {
 
                 // Check if our watchdog has timed out
                 if (NUClear::clock::now() > (service_time + period(ticks))) {
-                    try {
                         // Submit the reaction to the thread pool
-                        auto task = reaction->get_task();
-                        if (task) {
-                            reaction->reactor.powerplant.submit(std::move(task));
-                        }
-                    }
-                    catch (...) {
-                    }
+                    reaction->reactor.powerplant.submit(reaction->get_task());
 
                     // Now automatically service the watchdog
                     time = NUClear::clock::now() + period(ticks);

--- a/src/dsl/word/emit/Direct.hpp
+++ b/src/dsl/word/emit/Direct.hpp
@@ -56,24 +56,9 @@ namespace dsl {
 
                     // Run all our reactions that are interested
                     for (auto& reaction : store::TypeCallbackStore<DataType>::get()) {
-                        try {
-
-                            // Set our thread local store data each time (as during direct it can be overwritten)
-                            store::ThreadStore<std::shared_ptr<DataType>>::value = &data;
-
-                            auto task = reaction->get_task();
-                            if (task) {
-                                powerplant.submit(std::move(task), true);
-                            }
-                        }
-                        catch (const std::exception& ex) {
-                            PowerPlant::log<NUClear::ERROR>("There was an exception while generating a reaction",
-                                                            ex.what());
-                        }
-                        catch (...) {
-                            PowerPlant::log<NUClear::ERROR>(
-                                "There was an unknown exception while generating a reaction");
-                        }
+                        // Set our thread local store data each time (as during direct it can be overwritten)
+                        store::ThreadStore<std::shared_ptr<DataType>>::value = &data;
+                        powerplant.submit(reaction->get_task(), true);
                     }
 
                     // Unset our thread local store data

--- a/src/dsl/word/emit/Initialise.hpp
+++ b/src/dsl/word/emit/Initialise.hpp
@@ -56,7 +56,7 @@ namespace dsl {
                     static std::atomic<uint64_t> id{0};
 
                     // Submit a task to the power plant to emit this object
-                    powerplant.submit(++id,
+                    powerplant.submit(threading::ReactionTask::new_task_id(),
                                       1000,
                                       util::GroupDescriptor{},
                                       util::ThreadPoolDescriptor{},

--- a/src/dsl/word/emit/Initialise.hpp
+++ b/src/dsl/word/emit/Initialise.hpp
@@ -53,9 +53,15 @@ namespace dsl {
 
                 static void emit(PowerPlant& powerplant, std::shared_ptr<DataType> data) {
 
-                    // Delay the emit by 0 seconds, this will delay the emit until the chrono controller starts, which
-                    // will be when the system starts
-                    Delay<DataType>::emit(powerplant, data, std::chrono::seconds(0));
+                    static std::atomic<uint64_t> id{0};
+
+                    // Submit a task to the power plant to emit this object
+                    powerplant.submit(++id,
+                                      1000,
+                                      util::GroupDescriptor{},
+                                      util::ThreadPoolDescriptor{},
+                                      false,
+                                      [&powerplant, data] { powerplant.emit_shared<dsl::word::emit::Local>(data); });
                 }
             };
 

--- a/src/dsl/word/emit/Initialise.hpp
+++ b/src/dsl/word/emit/Initialise.hpp
@@ -53,8 +53,6 @@ namespace dsl {
 
                 static void emit(PowerPlant& powerplant, std::shared_ptr<DataType> data) {
 
-                    static std::atomic<uint64_t> id{0};
-
                     // Submit a task to the power plant to emit this object
                     powerplant.submit(threading::ReactionTask::new_task_id(),
                                       1000,

--- a/src/dsl/word/emit/Local.hpp
+++ b/src/dsl/word/emit/Local.hpp
@@ -51,26 +51,12 @@ namespace dsl {
 
                 static void emit(PowerPlant& powerplant, std::shared_ptr<DataType> data) {
 
-                    // Set our thread local store data
-                    store::ThreadStore<std::shared_ptr<DataType>>::value = &data;
-
                     // Run all our reactions that are interested
                     for (auto& reaction : store::TypeCallbackStore<DataType>::get()) {
-                        try {
-                            auto task = reaction->get_task();
-                            if (task) {
-                                powerplant.submit(std::move(task));
-                            }
-                        }
-                        // If there is an exception while generating a reaction print it here, this shouldn't happen
-                        catch (const std::exception& ex) {
-                            PowerPlant::log<NUClear::ERROR>("There was an exception while generating a reaction",
-                                                            ex.what());
-                        }
-                        catch (...) {
-                            PowerPlant::log<NUClear::ERROR>(
-                                "There was an unknown exception while generating a reaction");
-                        }
+
+                        // Set our thread local store data
+                        store::ThreadStore<std::shared_ptr<DataType>>::value = &data;
+                        powerplant.submit(reaction->get_task());
                     }
 
                     // Unset our thread local store data

--- a/src/extension/IOController_Posix.hpp
+++ b/src/extension/IOController_Posix.hpp
@@ -202,15 +202,8 @@ namespace extension {
                                             // Store the event in our thread local cache
                                             IO::ThreadEventStore::value = &e;
 
-                                            // Submit the task (which should run the get)
-                                            try {
-                                                auto task = it->reaction->get_task();
-                                                if (task) {
-                                                    powerplant.submit(std::move(task));
-                                                }
-                                            }
-                                            catch (...) {
-                                            }
+                                            // Submit the task
+                                            powerplant.submit(it->reaction->get_task());
 
                                             // Reset our value
                                             IO::ThreadEventStore::value = nullptr;

--- a/src/extension/IOController_Windows.hpp
+++ b/src/extension/IOController_Windows.hpp
@@ -181,15 +181,8 @@ namespace extension {
                                 // Store the IO event in our thread local cache
                                 IO::ThreadEventStore::value = &io_event;
 
-                                // Submit the task (which should run the get)
-                                try {
-                                    auto task = r->second.reaction->get_task();
-                                    if (task) {
-                                        powerplant.submit(std::move(task));
-                                    }
-                                }
-                                catch (...) {
-                                }
+                                // Submit the task
+                                powerplant.submit(r->second.reaction->get_task());
 
                                 // Reset our value
                                 IO::ThreadEventStore::value = nullptr;

--- a/src/extension/NetworkController.hpp
+++ b/src/extension/NetworkController.hpp
@@ -67,10 +67,7 @@ namespace extension {
 
                     // Execute on our interested reactions
                     for (auto it = rs.first; it != rs.second; ++it) {
-                        auto task = it->second->get_task();
-                        if (task) {
-                            powerplant.submit(std::move(task));
-                        }
+                        powerplant.submit(it->second->get_task());
                     }
                 }
 

--- a/src/threading/Reaction.hpp
+++ b/src/threading/Reaction.hpp
@@ -70,21 +70,29 @@ namespace threading {
          */
         inline std::unique_ptr<ReactionTask> get_task() {
 
-            // If we are not enabled, don't run
-            if (!enabled) {
-                return nullptr;
+            try {
+                // If we are not enabled, don't run
+                if (!enabled) {
+                    return nullptr;
+                }
+
+                // Run our generator to get a functor we can run
+                auto callback = generator(*this);
+
+                // If our generator returns a valid function
+                if (callback) {
+                    return std::make_unique<ReactionTask>(*this,
+                                                          callback.priority,
+                                                          callback.group,
+                                                          callback.pool,
+                                                          std::move(callback.callback));
+                }
             }
-
-            // Run our generator to get a functor we can run
-            auto callback = generator(*this);
-
-            // If our generator returns a valid function
-            if (callback) {
-                return std::make_unique<ReactionTask>(*this,
-                                                      callback.priority,
-                                                      callback.group,
-                                                      callback.pool,
-                                                      std::move(callback.callback));
+            catch (const std::exception& ex) {
+                reactor.log<NUClear::ERROR>("There was an exception while generating a task", ex.what());
+            }
+            catch (...) {
+                reactor.log<NUClear::ERROR>("There was an unknown exception while generating a task");
             }
 
             // Otherwise we return a null pointer

--- a/src/threading/Reaction.hpp
+++ b/src/threading/Reaction.hpp
@@ -70,29 +70,21 @@ namespace threading {
          */
         inline std::unique_ptr<ReactionTask> get_task() {
 
-            try {
-                // If we are not enabled, don't run
-                if (!enabled) {
-                    return nullptr;
-                }
-
-                // Run our generator to get a functor we can run
-                auto callback = generator(*this);
-
-                // If our generator returns a valid function
-                if (callback) {
-                    return std::make_unique<ReactionTask>(*this,
-                                                          callback.priority,
-                                                          callback.group,
-                                                          callback.pool,
-                                                          std::move(callback.callback));
-                }
+            // If we are not enabled, don't run
+            if (!enabled) {
+                return nullptr;
             }
-            catch (const std::exception& ex) {
-                reactor.log<NUClear::ERROR>("There was an exception while generating a task", ex.what());
-            }
-            catch (...) {
-                reactor.log<NUClear::ERROR>("There was an unknown exception while generating a task");
+
+            // Run our generator to get a functor we can run
+            auto callback = generator(*this);
+
+            // If our generator returns a valid function
+            if (callback) {
+                return std::make_unique<ReactionTask>(*this,
+                                                      callback.priority,
+                                                      callback.group,
+                                                      callback.pool,
+                                                      std::move(callback.callback));
             }
 
             // Otherwise we return a null pointer

--- a/src/threading/ReactionTask.hpp
+++ b/src/threading/ReactionTask.hpp
@@ -145,27 +145,6 @@ namespace threading {
     template <typename ReactionType>
     ATTRIBUTE_TLS Task<ReactionType>* Task<ReactionType>::current_task = nullptr;  // NOLINT
 
-    /**
-     * @brief This overload is used to sort reactions by priority.
-     *
-     * @param a the reaction task a
-     * @param b the reaction task b
-     *
-     * @return true if a has lower priority than b, false otherwise
-     */
-    template <typename ReactionType>
-    inline bool operator<(const std::unique_ptr<Task<ReactionType>>& a, const std::unique_ptr<Task<ReactionType>>& b) {
-
-        // Comparision order is as follows:
-        //  nullptr is greater than anything else so it's removed from a queue first
-        //  higher priority tasks are greater than lower priority tasks
-        //  tasks created first (smaller ids) should run before tasks created later
-        return a == nullptr                 ? true
-               : b == nullptr               ? false
-               : a->priority == b->priority ? a->id < b->id
-                                            : a->priority > b->priority;
-    }
-
     // Alias the templated Task so that public API remains intact
     class Reaction;
     using ReactionTask = Task<Reaction>;

--- a/src/threading/ReactionTask.hpp
+++ b/src/threading/ReactionTask.hpp
@@ -79,7 +79,7 @@ namespace threading {
              const util::ThreadPoolDescriptor& thread_pool_descriptor,
              TaskFunction&& callback)
             : parent(parent)
-            , id(++task_id_source)
+            , id(new_task_id())
             , priority(priority)
             , stats(std::make_shared<message::ReactionStatistics>(parent.identifiers,
                                                                   parent.id,
@@ -111,6 +111,15 @@ namespace threading {
 
             // Run our callback
             callback(*this);
+        }
+
+        /**
+         * @brief Generate a new unique task id
+         *
+         * @return a new unique task id
+         */
+        static inline uint64_t new_task_id() {
+            return ++task_id_source;
         }
 
         /// @brief the parent Reaction object which spawned this


### PR DESCRIPTION
Currently the Task Scheduler can only schedule reaction tasks.
It's useful for features like Initialise if generic functions can be scheduled rather than only reactions.

This PR refactors the task scheduler so it can take any generic function and schedule it as it would a reaction.