### PR TITLE
Make the demangle function consistent across platforms and add a test

### DIFF
--- a/src/util/demangle.cpp
+++ b/src/util/demangle.cpp
@@ -18,16 +18,21 @@
 
 #include "demangle.hpp"
 
+#include <regex>
+
 // Windows symbol demangler
 #ifdef _WIN32
-    // Turn off clang-format to avoid moving platform.h after Dbghelp.h
-    // (Dbghelp.h depends on types from Windows.h)
-    // clang-format off
-#    include "platform.hpp"
-#    include <Dbghelp.h>
 
-#    include <mutex>
-// clang-format on
+    // Dbghelp.h depends on types from Windows.h so it needs to be included first
+    // the define keeps clang-tidy from moving it
+    #ifdef _WIN32
+        #include "platform.hpp"
+    #endif
+
+    #include <Dbghelp.h>
+
+    #include <array>
+    #include <mutex>
 
     #pragma comment(lib, "Dbghelp.lib")
 
@@ -54,6 +59,11 @@ namespace util {
     }
 
     std::string demangle(const char* symbol) {
+        // If the symbol is the empty string then just return it
+        if (symbol != nullptr && symbol[0] == '\0') {
+            return symbol;
+        }
+
         std::lock_guard<std::mutex> lock(symbol_mutex);
 
         // Initialise the symbols if we have to
@@ -61,10 +71,15 @@ namespace util {
             init_symbols();
         }
 
-        char name[256];
+        std::array<char, 256> name{};
+        auto len = UnDecorateSymbolName(symbol, name.data(), DWORD(name.size()), 0);
 
-        if (int len = UnDecorateSymbolName(symbol, name, sizeof(name), 0)) {
-            return std::string(name, len);
+        if (len > 0) {
+            std::string demangled(name.data(), len);
+            demangled = std::regex_replace(demangled, std::regex(R"(struct\s+)"), "");
+            demangled = std::regex_replace(demangled, std::regex(R"(class\s+)"), "");
+            demangled = std::regex_replace(demangled, std::regex(R"(\s+)"), "");
+            return demangled;
         }
         else {
             return symbol;
@@ -94,11 +109,16 @@ namespace util {
      */
     std::string demangle(const char* symbol) {
 
-        int status = -4;  // some arbitrary value to eliminate the compiler warning
+        int status = -1;
         const std::unique_ptr<char, void (*)(void*)> res{abi::__cxa_demangle(symbol, nullptr, nullptr, &status),
                                                          std::free};
+        if (status == 0) {
+            std::string demangled = res.get();
+            demangled             = std::regex_replace(demangled, std::regex(R"(\s+)"), "");
+            return demangled;
+        }
 
-        return status == 0 ? res.get() : symbol;
+        return symbol;
     }
 
 }  // namespace util

--- a/src/util/demangle.cpp
+++ b/src/util/demangle.cpp
@@ -23,11 +23,10 @@
 // Windows symbol demangler
 #ifdef _WIN32
 
-    // Dbghelp.h depends on types from Windows.h so it needs to be included first
-    // the define keeps clang-tidy from moving it
-    #ifdef _WIN32
-        #include "platform.hpp"
-    #endif
+    #include "platform.hpp"
+
+// Dbghelp.h depends on types from Windows.h so it needs to be included first
+// Separate to always include platform.hpp (which includes windows.h) first
 
     #include <Dbghelp.h>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ if(CATCH_FOUND)
       add_compile_options(-Wall -Wextra -pedantic -Werror)
     endif(MSVC)
 
-    file(GLOB test_src test.cpp "api/*.cpp" "dsl/*.cpp" "dsl/emit/*.cpp" "log/*.cpp")
+    file(GLOB test_src test.cpp "api/*.cpp" "dsl/*.cpp" "dsl/emit/*.cpp" "log/*.cpp" "util/*.cpp")
 
     # Some tests must be executed as individual binaries
     file(GLOB individual_tests "${CMAKE_CURRENT_SOURCE_DIR}/individual/*.cpp")

--- a/tests/util/demangle.cpp
+++ b/tests/util/demangle.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2013      Trent Houliston <trent@houliston.me>, Jake Woods <jake.f.woods@gmail.com>
+ *               2014-2023 Trent Houliston <trent@houliston.me>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <catch.hpp>
+#include <string>
+#include <typeinfo>
+
+#include "nuclear"
+
+struct TestSymbol {};
+
+template <typename T>
+struct TestTemplate {};
+
+SCENARIO("Test the demangle function correctly demangles symbols", "[util][demangle]") {
+
+    GIVEN("A valid mangled symbol") {
+        const char* symbol         = typeid(int).name();
+        const std::string expected = "int";
+
+        WHEN("Demangle is called") {
+            const std::string result = NUClear::util::demangle(symbol);
+
+            THEN("It should return the demangled symbol") {
+                REQUIRE(result == expected);
+            }
+        }
+    }
+
+    GIVEN("An empty symbol") {
+        const char* symbol = "";
+        const std::string expected{};
+
+        WHEN("Demangle is called") {
+            const std::string result = NUClear::util::demangle(symbol);
+
+            THEN("It should return an empty string") {
+                REQUIRE(result == expected);
+            }
+        }
+    }
+
+    GIVEN("An invalid symbol") {
+        const char* symbol         = "InvalidSymbol";
+        const std::string expected = "InvalidSymbol";
+
+        WHEN("Demangle is called") {
+            const std::string result = NUClear::util::demangle(symbol);
+
+            THEN("It should return the original symbol") {
+                REQUIRE(result == expected);
+            }
+        }
+    }
+
+    GIVEN("A symbol from a struct") {
+        const char* symbol         = typeid(TestSymbol).name();
+        const std::string expected = "TestSymbol";
+
+        WHEN("Demangle is called") {
+            const std::string result = NUClear::util::demangle(symbol);
+
+            THEN("It should return the demangled symbol") {
+                REQUIRE(result == expected);
+            }
+        }
+    }
+
+    GIVEN("A symbol in a namespace") {
+        const char* symbol         = typeid(NUClear::message::CommandLineArguments).name();
+        const std::string expected = "NUClear::message::CommandLineArguments";
+
+        WHEN("Demangle is called") {
+            const std::string result = NUClear::util::demangle(symbol);
+
+            THEN("It should return the demangled symbol") {
+                REQUIRE(result == expected);
+            }
+        }
+    }
+
+    GIVEN("A templated symbol") {
+        const char* symbol         = typeid(TestTemplate<int>).name();
+        const std::string expected = "TestTemplate<int>";
+
+        WHEN("Demangle is called") {
+            const std::string result = NUClear::util::demangle(symbol);
+
+            THEN("It should return the demangled symbol") {
+                REQUIRE(result == expected);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Demangle returned different results on different platforms.
This makes it a bit more consistent (anonymous namespaces are still different).
Also adds a test to ensure that it works properly on different platforms.