### PR TITLE
Make NUClear logs always emit

### DIFF
--- a/src/Environment.hpp
+++ b/src/Environment.hpp
@@ -44,8 +44,8 @@ class PowerPlant;
  */
 class Environment {
 public:
-    Environment(PowerPlant& powerplant, std::string reactor_name, const LogLevel& log_level)
-        : powerplant(powerplant), reactor_name(std::move(reactor_name)), log_level(log_level) {}
+    Environment(PowerPlant& powerplant, std::string reactor_name)
+        : powerplant(powerplant), reactor_name(std::move(reactor_name)) {}
 
 private:
     friend class PowerPlant;
@@ -55,8 +55,6 @@ private:
     PowerPlant& powerplant;
     /// @brief The name of the reactor
     std::string reactor_name;
-    /// @brief The log level for this reactor
-    LogLevel log_level;
 };
 
 }  // namespace NUClear

--- a/src/LogLevel.hpp
+++ b/src/LogLevel.hpp
@@ -41,6 +41,15 @@ namespace NUClear {
 enum LogLevel {
     /**
      * @brief
+     *  Don't use this log level when emitting logs, it is for setting reactor log level from non reactor sources.
+     *
+     * Specifically when a NUClear::log is called from code that is not running in a reaction (even transitively) then
+     * the reactor_level will be set to UNKNOWN.
+     */
+    UNKNOWN,
+
+    /**
+     * @brief
      *  The Trace level contains messages that are used to trace the exact flow of execution.
      *
      * @details

--- a/src/PowerPlant.hpp
+++ b/src/PowerPlant.hpp
@@ -122,7 +122,7 @@ public:
      * @tparam T        The type of the reactor to build and install
      * @tparam level    The initial logging level for this reactor to use
      */
-    template <typename T, enum LogLevel level = DEBUG>
+    template <typename T>
     void install();
 
     /**

--- a/src/Reactor.hpp
+++ b/src/Reactor.hpp
@@ -143,9 +143,7 @@ public:
     friend class PowerPlant;
 
     explicit Reactor(std::unique_ptr<Environment> environment)
-        : powerplant(environment->powerplant)
-        , reactor_name(environment->reactor_name)
-        , log_level(environment->log_level) {}
+        : powerplant(environment->powerplant), reactor_name(environment->reactor_name) {}
     Reactor(const Reactor& /*other*/)              = default;
     Reactor(Reactor&& /*other*/) noexcept          = default;
     Reactor& operator=(const Reactor& /*rhs*/)     = delete;
@@ -413,7 +411,7 @@ public:
      * @param args The arguments we are logging
      */
     template <enum LogLevel level = DEBUG, typename... Arguments>
-    void log(Arguments&&... args) {
+    void log(Arguments&&... args) const {
 
         // If the log is above or equal to our log level
         PowerPlant::log<level>(std::forward<Arguments>(args)...);

--- a/src/message/LogMessage.hpp
+++ b/src/message/LogMessage.hpp
@@ -36,8 +36,25 @@ namespace message {
      */
     struct LogMessage {
 
+        /**
+         * @brief Construct a new Log Message object
+         *
+         * @param level          the logging level of the log
+         * @param reactor_level  the logging level of the reactor that made this log
+         * @param message        the string contents of the message
+         * @param task           the currently executing task that made this message or nullptr if not in a task
+         */
+        LogMessage(const LogLevel& level,
+                   const LogLevel& reactor_level,
+                   const std::string& message,
+                   const std::shared_ptr<ReactionStatistics>& task)
+            : level(level), reactor_level(reactor_level), message(message), task(task) {}
+
         /// @brief The logging level of the log.
         LogLevel level{};
+
+        /// @brief The logging level of the reactor that made this log.
+        LogLevel reactor_level{};
 
         /// @brief The string contents of the message.
         std::string message{};

--- a/src/message/LogMessage.hpp
+++ b/src/message/LogMessage.hpp
@@ -40,21 +40,21 @@ namespace message {
          * @brief Construct a new Log Message object
          *
          * @param level          the logging level of the log
-         * @param reactor_level  the logging level of the reactor that made this log
+         * @param display_level  the logging level of the reactor that made this log
          * @param message        the string contents of the message
          * @param task           the currently executing task that made this message or nullptr if not in a task
          */
         LogMessage(const LogLevel& level,
-                   const LogLevel& reactor_level,
+                   const LogLevel& display_level,
                    const std::string& message,
                    const std::shared_ptr<ReactionStatistics>& task)
-            : level(level), reactor_level(reactor_level), message(message), task(task) {}
+            : level(level), display_level(display_level), message(message), task(task) {}
 
         /// @brief The logging level of the log.
         LogLevel level{};
 
-        /// @brief The logging level of the reactor that made this log.
-        LogLevel reactor_level{};
+        /// @brief The logging level of the reactor that made the log (the level to display at).
+        LogLevel display_level{};
 
         /// @brief The string contents of the message.
         std::string message{};

--- a/src/message/LogMessage.hpp
+++ b/src/message/LogMessage.hpp
@@ -46,9 +46,9 @@ namespace message {
          */
         LogMessage(const LogLevel& level,
                    const LogLevel& display_level,
-                   const std::string& message,
-                   const std::shared_ptr<ReactionStatistics>& task)
-            : level(level), display_level(display_level), message(message), task(task) {}
+                   std::string message,
+                   std::shared_ptr<ReactionStatistics> task)
+            : level(level), display_level(display_level), message(std::move(message)), task(std::move(task)) {}
 
         /// @brief The logging level of the log.
         LogLevel level{};

--- a/tests/log/Log.cpp
+++ b/tests/log/Log.cpp
@@ -59,7 +59,9 @@ public:
 
         // Capture the log messages
         on<Trigger<NUClear::message::LogMessage>>().then([](const NUClear::message::LogMessage& log_message) {
-            messages.push_back(LogTestOutput{log_message.message, log_message.level, log_message.task != nullptr});
+            if (log_message.level >= log_message.reactor_level) {
+                messages.push_back(LogTestOutput{log_message.message, log_message.level, log_message.task != nullptr});
+            }
         });
 
         // Run each test

--- a/tests/log/Log.cpp
+++ b/tests/log/Log.cpp
@@ -59,7 +59,7 @@ public:
 
         // Capture the log messages
         on<Trigger<NUClear::message::LogMessage>>().then([](const NUClear::message::LogMessage& log_message) {
-            if (log_message.level >= log_message.reactor_level) {
+            if (log_message.level >= log_message.display_level) {
                 messages.push_back(LogTestOutput{log_message.message, log_message.level, log_message.task != nullptr});
             }
         });


### PR DESCRIPTION
For many log handlers, the display level is important as only the logs you want to view should be displayed.
This display level has been typically set using the log level in each reactor and nuclear has filtered out logs below the display level from reaching the log handlers.
However, some log handlers are able to store and process logs more intelligently and make them available to access beyond their set display level.