### PR TITLE
Swap to using size_t as an id type

### DIFF
--- a/src/PowerPlant.cpp
+++ b/src/PowerPlant.cpp
@@ -49,7 +49,7 @@ void PowerPlant::start() {
     scheduler.start();
 }
 
-void PowerPlant::submit(const uint64_t& id,
+void PowerPlant::submit(const NUClear::id_t& id,
                         const int& priority,
                         const util::GroupDescriptor& group,
                         const util::ThreadPoolDescriptor& pool,

--- a/src/PowerPlant.hpp
+++ b/src/PowerPlant.hpp
@@ -39,6 +39,7 @@
 // Utilities
 #include "Configuration.hpp"
 #include "LogLevel.hpp"
+#include "id.hpp"
 #include "message/LogMessage.hpp"
 #include "threading/ReactionTask.hpp"
 #include "threading/TaskScheduler.hpp"
@@ -135,7 +136,7 @@ public:
      * @param immediate if this task should run immediately in the current thread
      * @param task      the wrapped function to be executed
      */
-    void submit(const uint64_t& id,
+    void submit(const NUClear::id_t& id,
                 const int& priority,
                 const util::GroupDescriptor& group,
                 const util::ThreadPoolDescriptor& pool,

--- a/src/dsl/operation/ChronoTask.hpp
+++ b/src/dsl/operation/ChronoTask.hpp
@@ -24,6 +24,7 @@
 #define NUCLEAR_DSL_OPERATION_CHRONOTASK_HPP
 
 #include "../../clock.hpp"
+#include "../../id.hpp"
 
 namespace NUClear {
 namespace dsl {
@@ -46,11 +47,11 @@ namespace dsl {
              * @param task  the task to run, takes the time to execute as a reference so it can be updated for
              *              future runs
              * @param time  the time to execute this task
-             * @param id    the unique identifer for this task
+             * @param id    the unique identifier for this task
              */
             ChronoTask(std::function<bool(NUClear::clock::time_point&)>&& task,
-                       NUClear::clock::time_point time,
-                       uint64_t id)
+                       const NUClear::clock::time_point& time,
+                       const NUClear::id_t& id)
                 : task(std::move(task)), time(time), id(id) {}
 
             /**
@@ -100,7 +101,7 @@ namespace dsl {
             /// The time this task should be executed
             NUClear::clock::time_point time;
             /// The unique identifier for this task so it can be unbound
-            uint64_t id{0};
+            NUClear::id_t id{0};
         };
 
     }  // namespace operation

--- a/src/dsl/word/Always.hpp
+++ b/src/dsl/word/Always.hpp
@@ -27,6 +27,7 @@
 #include <mutex>
 #include <utility>
 
+#include "../../id.hpp"
 #include "../../threading/ReactionTask.hpp"
 #include "../../util/ThreadPoolDescriptor.hpp"
 
@@ -73,7 +74,7 @@ namespace dsl {
 
             template <typename DSL>
             static inline util::ThreadPoolDescriptor pool(const threading::Reaction& reaction) {
-                static std::map<uint64_t, uint64_t> pool_id;
+                static std::map<NUClear::id_t, NUClear::id_t> pool_id;
                 static std::mutex mutex;
 
                 const std::lock_guard<std::mutex> lock(mutex);
@@ -90,7 +91,7 @@ namespace dsl {
                  * the always reaction and one for the idle reaction that we generate in this function
                  * The main purpose of this map is to ensure that the always reaction pointer doesn't get destroyed
                  */
-                static std::map<uint64_t,
+                static std::map<NUClear::id_t,
                                 std::pair<std::shared_ptr<threading::Reaction>, std::shared_ptr<threading::Reaction>>>
                     reaction_store = {};
 

--- a/src/dsl/word/IO.hpp
+++ b/src/dsl/word/IO.hpp
@@ -23,6 +23,7 @@
 #ifndef NUCLEAR_DSL_WORD_IO_HPP
 #define NUCLEAR_DSL_WORD_IO_HPP
 
+#include "../../id.hpp"
 #include "../../threading/Reaction.hpp"
 #include "../../util/platform.hpp"
 #include "../operation/Unbind.hpp"
@@ -59,9 +60,9 @@ namespace dsl {
          * @brief This is emitted when an IO operation has finished.
          */
         struct IOFinished {
-            explicit IOFinished(const uint64_t& id) : id(id) {}
+            explicit IOFinished(const NUClear::id_t& id) : id(id) {}
             /// @brief The id of the reaction that has finished
-            uint64_t id;
+            NUClear::id_t id;
         };
 
         /**

--- a/src/id.hpp
+++ b/src/id.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2014 NUClear Contributors
+ * Copyright (c) 2023 NUClear Contributors
  *
  * This file is part of the NUClear codebase.
  * See https://github.com/Fastcode/NUClear for further info.
@@ -20,34 +20,18 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef NUCLEAR_DSL_OPERATION_UNBIND_HPP
-#define NUCLEAR_DSL_OPERATION_UNBIND_HPP
+#ifndef NUCLEAR_UTIL_ID_HPP
+#define NUCLEAR_UTIL_ID_HPP
 
-#include "../../id.hpp"
+#include <cstdint>
 
 namespace NUClear {
-namespace dsl {
-    namespace operation {
 
-        /**
-         * @brief Signals that the reaction with this id servicing this type should be unbound and its resources
-         *  cleaned up
-         *
-         * @details When a reaction is finished and won't be run again, this type should be emitted along with the
-         * original DSL word that created it. This signals to its handler to clean it up and not run it again.
-         *
-         * @tparam Word the DSL word that created this binding (or another helper type)
-         */
-        template <typename Word>
-        struct Unbind {
-            explicit Unbind(const NUClear::id_t& id) : id(id){};
+/**
+ * @brief A unique identifier for a thread pool
+ */
+using id_t = std::size_t;
 
-            /// The id of the task to unbind
-            const NUClear::id_t id{0};
-        };
-
-    }  // namespace operation
-}  // namespace dsl
 }  // namespace NUClear
 
-#endif  // NUCLEAR_DSL_OPERATION_UNBIND_HPP
+#endif  // NUCLEAR_UTIL_ID_HPP

--- a/src/message/ReactionStatistics.hpp
+++ b/src/message/ReactionStatistics.hpp
@@ -26,6 +26,7 @@
 #include <exception>
 #include <string>
 #include <vector>
+#include "../id.hpp"
 
 #include "../clock.hpp"
 #include "../threading/ReactionIdentifiers.hpp"
@@ -39,10 +40,10 @@ namespace message {
     struct ReactionStatistics {
 
         ReactionStatistics(threading::ReactionIdentifiers identifiers,
-                           uint64_t reaction_id,
-                           uint64_t task_id,
-                           uint64_t cause_reaction_id,
-                           uint64_t cause_task_id,
+                           const NUClear::id_t& reaction_id,
+                           const NUClear::id_t& task_id,
+                           const NUClear::id_t& cause_reaction_id,
+                           const NUClear::id_t& cause_task_id,
                            const clock::time_point& emitted,
                            const clock::time_point& start,
                            const clock::time_point& finish,
@@ -60,13 +61,13 @@ namespace message {
         /// @brief A string containing the username/on arguments/and callback name of the reaction.
         threading::ReactionIdentifiers identifiers;
         /// @brief The id of this reaction.
-        uint64_t reaction_id{0};
+        NUClear::id_t reaction_id{0};
         /// @brief The task id of this reaction.
-        uint64_t task_id{0};
+        NUClear::id_t task_id{0};
         /// @brief The reaction id of the reaction that caused this one or 0 if there was not one
-        uint64_t cause_reaction_id{0};
+        NUClear::id_t cause_reaction_id{0};
         /// @brief The reaction id of the task that caused this task or 0 if there was not one
-        uint64_t cause_task_id{0};
+        NUClear::id_t cause_task_id{0};
         /// @brief The time that this reaction was emitted to the thread pool
         clock::time_point emitted{};
         /// @brief The time that execution started on this reaction

--- a/src/threading/Reaction.cpp
+++ b/src/threading/Reaction.cpp
@@ -26,7 +26,7 @@ namespace NUClear {
 namespace threading {
 
     // Initialize our reaction source
-    std::atomic<uint64_t> Reaction::reaction_id_source(0);  // NOLINT
+    std::atomic<NUClear::id_t> Reaction::reaction_id_source(0);  // NOLINT
 
     Reaction::Reaction(Reactor& reactor, ReactionIdentifiers&& identifiers, TaskGenerator&& generator)
         : reactor(reactor), identifiers(std::move(identifiers)), generator(std::move(generator)) {}

--- a/src/threading/Reaction.hpp
+++ b/src/threading/Reaction.hpp
@@ -27,6 +27,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include "../id.hpp"
 #include <utility>
 
 #include "../util/GeneratedCallback.hpp"
@@ -107,7 +108,7 @@ namespace threading {
         ReactionIdentifiers identifiers;
 
         /// @brief the unique identifier for this Reaction object
-        const uint64_t id{++reaction_id_source};
+        const NUClear::id_t id{++reaction_id_source};
 
         /// @brief if this is false, we cannot emit ReactionStatistics from any reaction triggered by this one
         bool emit_stats{true};
@@ -128,7 +129,8 @@ namespace threading {
 
     private:
         /// @brief a source for reaction_ids, atomically creates longs
-        static std::atomic<uint64_t> reaction_id_source;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+        static std::atomic<NUClear::id_t>
+            reaction_id_source;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
         /// @brief the callback generator function (creates databound callbacks)
         TaskGenerator generator;
     };

--- a/src/threading/ReactionTask.hpp
+++ b/src/threading/ReactionTask.hpp
@@ -28,7 +28,7 @@
 #include <memory>
 #include <typeindex>
 #include <vector>
-
+#include "../id.hpp"
 #include "../message/ReactionStatistics.hpp"
 #include "../util/GroupDescriptor.hpp"
 #include "../util/ThreadPoolDescriptor.hpp"
@@ -50,7 +50,7 @@ namespace threading {
     class Task {
     private:
         /// @brief a source for task ids, atomically creates longs
-        static std::atomic<std::uint64_t> task_id_source;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+        static std::atomic<NUClear::id_t> task_id_source;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
         /// @brief the current task that is being executed by this thread (or nullptr if none is)
         static ATTRIBUTE_TLS Task* current_task;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -121,14 +121,14 @@ namespace threading {
          *
          * @return a new unique task id
          */
-        static inline uint64_t new_task_id() {
+        static inline NUClear::id_t new_task_id() {
             return ++task_id_source;
         }
 
         /// @brief the parent Reaction object which spawned this
         ReactionType& parent;
         /// @brief the task id of this task (the sequence number of this particular task)
-        uint64_t id{new_task_id()};
+        NUClear::id_t id{new_task_id()};
         /// @brief the priority to run this task at
         int priority;
         /// @brief the statistics object that persists after this for information and debugging
@@ -151,7 +151,7 @@ namespace threading {
 
     // Initialize our id source
     template <typename ReactionType>
-    std::atomic<uint64_t> Task<ReactionType>::task_id_source(0);  // NOLINT
+    std::atomic<NUClear::id_t> Task<ReactionType>::task_id_source(0);  // NOLINT
 
     // Initialize our current task
     template <typename ReactionType>

--- a/src/threading/TaskScheduler.cpp
+++ b/src/threading/TaskScheduler.cpp
@@ -168,7 +168,7 @@ namespace threading {
         }
     }
 
-    void TaskScheduler::submit(const uint64_t& id,
+    void TaskScheduler::submit(const NUClear::id_t& id,
                                const int& priority,
                                const util::GroupDescriptor& group_descriptor,
                                const util::ThreadPoolDescriptor& pool_descriptor,

--- a/src/threading/TaskScheduler.hpp
+++ b/src/threading/TaskScheduler.hpp
@@ -32,6 +32,7 @@
 #include <thread>
 #include <vector>
 
+#include "../id.hpp"
 #include "../util/GroupDescriptor.hpp"
 #include "../util/ThreadPoolDescriptor.hpp"
 #include "../util/platform.hpp"
@@ -93,7 +94,7 @@ namespace threading {
          */
         struct Task {
             /// @brief The id of this task used for ordering
-            uint64_t id;
+            NUClear::id_t id;
             /// @brief The priority of this task
             int priority;
             /// @brief The group descriptor for this task
@@ -168,7 +169,7 @@ namespace threading {
          *                  as normal
          * @param func      the function to execute
          */
-        void submit(const uint64_t& id,
+        void submit(const NUClear::id_t& id,
                     const int& priority,
                     const util::GroupDescriptor& group,
                     const util::ThreadPoolDescriptor& pool,
@@ -242,12 +243,12 @@ namespace threading {
         std::atomic<bool> started{false};
 
         /// @brief A map of group ids to the number of active tasks currently running in that group
-        std::map<uint64_t, size_t> groups{};
+        std::map<NUClear::id_t, size_t> groups{};
         /// @brief mutex for the group map
         std::mutex group_mutex;
 
         /// @brief A map of pool descriptor ids to pool descriptors
-        std::map<uint64_t, std::shared_ptr<PoolQueue>> pool_queues{};
+        std::map<NUClear::id_t, std::shared_ptr<PoolQueue>> pool_queues{};
         /// @brief a mutex for when we are modifying the pool_queues map
         std::mutex pool_mutex;
         /// @brief a pointer to the pool_queue for the current thread so it does not have to access via the map

--- a/src/util/GroupDescriptor.hpp
+++ b/src/util/GroupDescriptor.hpp
@@ -28,6 +28,8 @@
 #include <cstdint>
 #include <limits>
 
+#include "../id.hpp"
+
 namespace NUClear {
 namespace util {
 
@@ -36,7 +38,7 @@ namespace util {
      */
     struct GroupDescriptor {
         /// @brief a unique identifier for this pool
-        uint64_t group_id{0};
+        NUClear::id_t group_id{0};
 
         /// @brief the maximum number of threads that can run concurrently in this group
         size_t thread_count{std::numeric_limits<size_t>::max()};
@@ -44,9 +46,9 @@ namespace util {
         /**
          * @brief Return the next unique ID for a new group
          */
-        static uint64_t get_unique_group_id() noexcept {
+        static NUClear::id_t get_unique_group_id() noexcept {
             // Make group 0 the default group
-            static std::atomic<uint64_t> source{1};
+            static std::atomic<NUClear::id_t> source{1};
             return source++;
         }
     };

--- a/src/util/ThreadPoolDescriptor.cpp
+++ b/src/util/ThreadPoolDescriptor.cpp
@@ -25,8 +25,8 @@
 namespace NUClear {
 namespace util {
 
-    const uint64_t ThreadPoolDescriptor::MAIN_THREAD_POOL_ID    = 0;
-    const uint64_t ThreadPoolDescriptor::DEFAULT_THREAD_POOL_ID = 1;
+    const NUClear::id_t ThreadPoolDescriptor::MAIN_THREAD_POOL_ID    = 0;
+    const NUClear::id_t ThreadPoolDescriptor::DEFAULT_THREAD_POOL_ID = 1;
 
 }  // namespace util
 }  // namespace NUClear

--- a/src/util/ThreadPoolDescriptor.hpp
+++ b/src/util/ThreadPoolDescriptor.hpp
@@ -27,6 +27,8 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "../id.hpp"
+
 namespace NUClear {
 namespace util {
 
@@ -35,21 +37,21 @@ namespace util {
      */
     struct ThreadPoolDescriptor {
         /// @brief a unique identifier for this pool
-        uint64_t pool_id{ThreadPoolDescriptor::DEFAULT_THREAD_POOL_ID};
+        NUClear::id_t pool_id{ThreadPoolDescriptor::DEFAULT_THREAD_POOL_ID};
 
         /// @brief the number of threads this thread pool will use
         size_t thread_count{0};
 
         /// @brief the ID of the main thread pool (not to be confused with the ID of the main thread)
-        static const uint64_t MAIN_THREAD_POOL_ID;
+        static const NUClear::id_t MAIN_THREAD_POOL_ID;
         /// @brief the ID of the default thread pool
-        static const uint64_t DEFAULT_THREAD_POOL_ID;
+        static const NUClear::id_t DEFAULT_THREAD_POOL_ID;
 
         /**
          * @brief Return the next unique ID for a new thread pool
          */
-        static uint64_t get_unique_pool_id() noexcept {
-            static std::atomic<uint64_t> source{2};
+        static NUClear::id_t get_unique_pool_id() noexcept {
+            static std::atomic<NUClear::id_t> source{2};
             return source++;
         }
     };


### PR DESCRIPTION
uint64_t is larger than is necessary on a system for IDs most of the time.
On 32-bit systems, it also causes problems due to uint64_t having alignment requirements.
Swaps to using size_t for the ID which should serve the purposes of being fast and appropriately sized for the system.