### PR TITLE
Fix Serialisation to properly deal with trivially copyable types

### DIFF
--- a/docs/networking.rst
+++ b/docs/networking.rst
@@ -43,9 +43,8 @@ checks explicitly for an explicit type. Be careful about multiple declarations.
 For this partial specialisation three static methods need to be defined.
 
 .. codeblock:: c++
-    static inline std::vector<char> serialise(const T& in)
+    static inline std::vector<uint8_t> serialise(const T& in)
 
-    static inline T deserialise(const std::vector<char>& in)
+    static inline T deserialise(const std::vector<uint8_t>& in)
 
     static inline uint64_t hash()
-

--- a/src/PowerPlant.cpp
+++ b/src/PowerPlant.cpp
@@ -24,7 +24,7 @@
 
 namespace NUClear {
 
-PowerPlant* PowerPlant::powerplant = nullptr;  // NOLINT
+PowerPlant* PowerPlant::powerplant = nullptr;
 
 PowerPlant::~PowerPlant() {
     // Make sure reactors are destroyed before anything else

--- a/src/PowerPlant.cpp
+++ b/src/PowerPlant.cpp
@@ -24,6 +24,7 @@
 
 namespace NUClear {
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PowerPlant* PowerPlant::powerplant = nullptr;
 
 PowerPlant::~PowerPlant() {

--- a/src/dsl/word/Network.hpp
+++ b/src/dsl/word/Network.hpp
@@ -96,7 +96,7 @@ namespace dsl {
             static inline std::tuple<std::shared_ptr<NetworkSource>, NetworkData<T>> get(
                 const threading::Reaction& /*reaction*/) {
 
-                auto* data   = store::ThreadStore<std::vector<char>>::value;
+                auto* data   = store::ThreadStore<std::vector<uint8_t>>::value;
                 auto* source = store::ThreadStore<NetworkSource>::value;
 
                 if (data && source) {

--- a/src/dsl/word/UDP.hpp
+++ b/src/dsl/word/UDP.hpp
@@ -91,7 +91,7 @@ namespace dsl {
                 /// @brief If the packet is valid
                 bool valid{false};
                 /// @brief The data that was received
-                std::vector<char> payload{};
+                std::vector<uint8_t> payload{};
                 /// @brief The local address that the packet was received on
                 util::network::sock_t local{};
                 /// @brief The remote address that the packet was received from
@@ -121,7 +121,7 @@ namespace dsl {
                 Target remote;
 
                 /// @brief The data to be sent in the packet
-                std::vector<char> payload{};
+                std::vector<uint8_t> payload{};
 
                 /**
                  * @brief Casts this packet to a boolean to check if it is valid
@@ -350,7 +350,7 @@ namespace dsl {
                 }
 
                 // Allocate max size for a UDP packet
-                std::vector<char> buffer(65535, 0);
+                std::vector<uint8_t> buffer(65535, 0);
 
                 // Make some variables to hold our message header information
                 std::array<char, 0x100> cmbuff = {0};

--- a/src/dsl/word/UDP.hpp
+++ b/src/dsl/word/UDP.hpp
@@ -356,7 +356,7 @@ namespace dsl {
                 std::array<char, 0x100> cmbuff = {0};
                 util::network::sock_t remote{};
                 iovec payload{};
-                payload.iov_base = buffer.data();
+                payload.iov_base = reinterpret_cast<char*>(buffer.data());
                 payload.iov_len  = static_cast<decltype(payload.iov_len)>(buffer.size());
 
                 // Make our message header to receive with

--- a/src/dsl/word/emit/Network.hpp
+++ b/src/dsl/word/emit/Network.hpp
@@ -39,7 +39,7 @@ namespace dsl {
                 /// The hash identifying the type of object
                 uint64_t hash{0};
                 /// The serialised data
-                std::vector<char> payload{};
+                std::vector<uint8_t> payload{};
                 /// If the message should be sent reliably
                 bool reliable{false};
             };

--- a/src/dsl/word/emit/UDP.hpp
+++ b/src/dsl/word/emit/UDP.hpp
@@ -157,7 +157,7 @@ namespace dsl {
                     }
 
                     // Serialise to our payload
-                    std::vector<char> payload = util::serialise::Serialise<DataType>::serialise(*data);
+                    std::vector<uint8_t> payload = util::serialise::Serialise<DataType>::serialise(*data);
 
                     // Try to send our payload
                     if (::sendto(fd,

--- a/src/dsl/word/emit/UDP.hpp
+++ b/src/dsl/word/emit/UDP.hpp
@@ -161,7 +161,7 @@ namespace dsl {
 
                     // Try to send our payload
                     if (::sendto(fd,
-                                 payload.data(),
+                                 reinterpret_cast<const char*>(payload.data()),
                                  static_cast<socklen_t>(payload.size()),
                                  0,
                                  &remote.sock,

--- a/src/extension/NetworkController.hpp
+++ b/src/extension/NetworkController.hpp
@@ -51,15 +51,15 @@ namespace extension {
             network.set_packet_callback([this](const network::NUClearNetwork::NetworkTarget& remote,
                                                const uint64_t& hash,
                                                const bool& reliable,
-                                               std::vector<char>&& payload) {
+                                               std::vector<uint8_t>&& payload) {
                 // Construct our NetworkSource information
                 dsl::word::NetworkSource src{remote.name, remote.target, reliable};
 
                 // Move the payload in as we are stealing it
-                std::vector<char> p(std::move(payload));
+                std::vector<uint8_t> p(std::move(payload));
 
                 // Store in our thread local cache
-                dsl::store::ThreadStore<std::vector<char>>::value        = &p;
+                dsl::store::ThreadStore<std::vector<uint8_t>>::value        = &p;
                 dsl::store::ThreadStore<dsl::word::NetworkSource>::value = &src;
 
                 /* Mutex Scope */ {
@@ -76,7 +76,7 @@ namespace extension {
                 }
 
                 // Clear our cache
-                dsl::store::ThreadStore<std::vector<char>>::value        = nullptr;
+                dsl::store::ThreadStore<std::vector<uint8_t>>::value        = nullptr;
                 dsl::store::ThreadStore<dsl::word::NetworkSource>::value = nullptr;
             });
 

--- a/src/extension/network/NUClearNetwork.cpp
+++ b/src/extension/network/NUClearNetwork.cpp
@@ -1015,7 +1015,7 @@ namespace extension {
             // Work out what chunk of data we are sending
             // const cast is fine as posix guarantees it won't be modified on a sendmsg
             const char* start = reinterpret_cast<const char*>(payload.data()) + (packet_no * packet_data_mtu);
-            data[1].iov_base  = const_cast<char*>(start);
+            data[1].iov_base  = const_cast<char*>(start);  // NOLINT(cppcoreguidelines-pro-type-const-cast)
             data[1].iov_len = packet_no + 1 < header.packet_count ? packet_data_mtu : payload.size() % packet_data_mtu;
 
             // Set our target and send (once again const cast is fine)

--- a/src/extension/network/NUClearNetwork.cpp
+++ b/src/extension/network/NUClearNetwork.cpp
@@ -46,10 +46,10 @@ namespace extension {
          *
          * @return the data and who it was sent from
          */
-        std::pair<util::network::sock_t, std::vector<char>> read_socket(fd_t fd) {
+        std::pair<util::network::sock_t, std::vector<uint8_t>> read_socket(fd_t fd) {
 
             // Allocate a vector that can hold a datagram
-            std::vector<char> payload(1500);
+            std::vector<uint8_t> payload(1500);
             iovec iov{};
             iov.iov_base = payload.data();
             iov.iov_len  = static_cast<decltype(iov.iov_len)>(payload.size());
@@ -82,7 +82,7 @@ namespace extension {
         }
 
         void NUClearNetwork::set_packet_callback(
-            std::function<void(const NetworkTarget&, const uint64_t&, const bool&, std::vector<char>&&)> f) {
+            std::function<void(const NetworkTarget&, const uint64_t&, const bool&, std::vector<uint8_t>&&)> f) {
             packet_callback = std::move(f);
         }
 
@@ -547,7 +547,7 @@ namespace extension {
             }
         }
 
-        void NUClearNetwork::process_packet(const sock_t& address, std::vector<char>&& payload) {
+        void NUClearNetwork::process_packet(const sock_t& address, std::vector<uint8_t>&& payload) {
 
             // First validate this is a NUClear network packet we can read (a version 2 NUClear packet)
             if (payload.size() >= sizeof(PacketHeader) && payload[0] == '\xE2' && payload[1] == '\x98'
@@ -671,7 +671,7 @@ namespace extension {
                                 if (it != remote->recent_packets.end() && packet.reliable) {
 
                                     // Allocate room for the whole ack packet
-                                    std::vector<char> r(sizeof(ACKPacket) + (packet.packet_count / 8), 0);
+                                    std::vector<uint8_t> r(sizeof(ACKPacket) + (packet.packet_count / 8), 0);
                                     ACKPacket& response   = *reinterpret_cast<ACKPacket*>(r.data());
                                     response              = ACKPacket();
                                     response.packet_id    = packet.packet_id;
@@ -703,8 +703,8 @@ namespace extension {
                             if (packet.packet_count == 1) {
 
                                 // Copy our data into a vector
-                                std::vector<char> out(&packet.data,
-                                                      &packet.data + payload.size() - sizeof(DataPacket) + 1);
+                                std::vector<uint8_t> out(&packet.data,
+                                                         &packet.data + payload.size() - sizeof(DataPacket) + 1);
 
                                 // If this is a reliable packet, send an ack back
                                 if (packet.reliable) {
@@ -751,7 +751,7 @@ namespace extension {
 
                                         // A basic ack has room for 8 packets and we need 1 extra byte for each 8
                                         // additional packets
-                                        std::vector<char> r(sizeof(NACKPacket) + (packet.packet_count / 8), 0);
+                                        std::vector<uint8_t> r(sizeof(NACKPacket) + (packet.packet_count / 8), 0);
                                         NACKPacket& response  = *reinterpret_cast<NACKPacket*>(r.data());
                                         response              = NACKPacket();
                                         response.packet_id    = packet.packet_id;
@@ -790,7 +790,7 @@ namespace extension {
                                 if (packet.reliable) {
                                     // A basic ack has room for 8 packets and we need 1 extra byte for each 8
                                     // additional packets
-                                    std::vector<char> r(sizeof(ACKPacket) + (packet.packet_count / 8), 0);
+                                    std::vector<uint8_t> r(sizeof(ACKPacket) + (packet.packet_count / 8), 0);
                                     ACKPacket& response   = *reinterpret_cast<ACKPacket*>(r.data());
                                     response              = ACKPacket();
                                     response.packet_id    = packet.packet_id;
@@ -825,7 +825,7 @@ namespace extension {
                                     }
 
                                     // Read in our data
-                                    std::vector<char> out;
+                                    std::vector<uint8_t> out;
                                     out.reserve(payload_size);
                                     for (auto& p : assembler.second) {
                                         const DataPacket& part = *reinterpret_cast<DataPacket*>(p.second.data());
@@ -997,7 +997,7 @@ namespace extension {
         void NUClearNetwork::send_packet(const sock_t& target,
                                          NUClear::extension::network::DataPacket header,
                                          uint16_t packet_no,
-                                         const std::vector<char>& payload,
+                                         const std::vector<uint8_t>& payload,
                                          const bool& /*reliable*/) {
 
             // Our packet we are sending
@@ -1028,7 +1028,7 @@ namespace extension {
 
 
         void NUClearNetwork::send(const uint64_t& hash,
-                                  const std::vector<char>& payload,
+                                  const std::vector<uint8_t>& payload,
                                   const std::string& target,
                                   bool reliable) {
 

--- a/src/extension/network/NUClearNetwork.cpp
+++ b/src/extension/network/NUClearNetwork.cpp
@@ -1019,7 +1019,7 @@ namespace extension {
             data[1].iov_len = packet_no + 1 < header.packet_count ? packet_data_mtu : payload.size() % packet_data_mtu;
 
             // Set our target and send (once again const cast is fine)
-            message.msg_name    = const_cast<sockaddr*>(&target.sock);
+            message.msg_name    = const_cast<sockaddr*>(&target.sock);  // NOLINT(cppcoreguidelines-pro-type-const-cast)
             message.msg_namelen = target.size();
 
             // TODO(trent): if reliable, run select first to see if this socket is writeable

--- a/src/extension/network/NUClearNetwork.cpp
+++ b/src/extension/network/NUClearNetwork.cpp
@@ -51,7 +51,7 @@ namespace extension {
             // Allocate a vector that can hold a datagram
             std::vector<uint8_t> payload(1500);
             iovec iov{};
-            iov.iov_base = payload.data();
+            iov.iov_base = reinterpret_cast<char*>(payload.data());
             iov.iov_len  = static_cast<decltype(iov.iov_len)>(payload.size());
 
             // Who we are receiving from

--- a/src/extension/network/NUClearNetwork.cpp
+++ b/src/extension/network/NUClearNetwork.cpp
@@ -534,7 +534,7 @@ namespace extension {
 
                 // Send the packet
                 if (::sendto(data_fd,
-                             announce_packet.data(),
+                             reinterpret_cast<const char*>(announce_packet.data()),
                              static_cast<socklen_t>(announce_packet.size()),
                              0,
                              &it->second->target.sock,
@@ -595,7 +595,7 @@ namespace extension {
 
                                         // Say hi back!
                                         ::sendto(data_fd,
-                                                 announce_packet.data(),
+                                                 reinterpret_cast<const char*>(announce_packet.data()),
                                                  static_cast<socklen_t>(announce_packet.size()),
                                                  0,
                                                  &ptr->target.sock,
@@ -688,7 +688,7 @@ namespace extension {
 
                                     // Send the packet
                                     ::sendto(data_fd,
-                                             r.data(),
+                                             reinterpret_cast<const char*>(r.data()),
                                              static_cast<socklen_t>(r.size()),
                                              0,
                                              &to.sock,
@@ -771,7 +771,7 @@ namespace extension {
 
                                         // Send the packet
                                         ::sendto(data_fd,
-                                                 r.data(),
+                                                 reinterpret_cast<const char*>(r.data()),
                                                  static_cast<socklen_t>(r.size()),
                                                  0,
                                                  &to.sock,
@@ -807,7 +807,7 @@ namespace extension {
 
                                     // Send the packet
                                     ::sendto(data_fd,
-                                             r.data(),
+                                             reinterpret_cast<const char*>(r.data()),
                                              static_cast<socklen_t>(r.size()),
                                              0,
                                              &to.sock,

--- a/src/extension/network/NUClearNetwork.hpp
+++ b/src/extension/network/NUClearNetwork.hpp
@@ -75,7 +75,7 @@ namespace extension {
                 std::mutex assemblers_mutex;
                 /// Storage for fragmented packets while we build them
                 std::map<uint16_t,
-                         std::pair<std::chrono::steady_clock::time_point, std::map<uint16_t, std::vector<char>>>>
+                         std::pair<std::chrono::steady_clock::time_point, std::map<uint16_t, std::vector<uint8_t>>>>
                     assemblers{};
 
                 /// Struct storing the kalman filter for round trip time
@@ -130,7 +130,7 @@ namespace extension {
              * @param target        who we are sending to (blank means everyone)
              * @param reliable      if the delivery of the data should be ensured
              */
-            void send(const uint64_t& hash, const std::vector<char>& payload, const std::string& target, bool reliable);
+            void send(const uint64_t& hash, const std::vector<uint8_t>& payload, const std::string& target, bool reliable);
 
             /**
              * @brief Set the callback to use when a data packet is completed
@@ -138,7 +138,7 @@ namespace extension {
              * @param f the callback function
              */
             void set_packet_callback(
-                std::function<void(const NetworkTarget&, const uint64_t&, const bool&, std::vector<char>&&)> f);
+                std::function<void(const NetworkTarget&, const uint64_t&, const bool&, std::vector<uint8_t>&&)> f);
 
             /**
              * @brief Set the callback to use when a node joins the network
@@ -231,7 +231,7 @@ namespace extension {
                 DataPacket header{};
 
                 /// The data to send
-                std::vector<char> payload{};
+                std::vector<uint8_t> payload{};
             };
 
             /**
@@ -255,7 +255,7 @@ namespace extension {
              * @param address   who the packet came from
              * @param data      the data that was sent in this packet
              */
-            void process_packet(const sock_t& address, std::vector<char>&& payload);
+            void process_packet(const sock_t& address, std::vector<uint8_t>&& payload);
 
             /**
              * @brief Send an announce packet to our announce address
@@ -279,7 +279,7 @@ namespace extension {
             void send_packet(const sock_t& target,
                              DataPacket header,
                              uint16_t packet_no,
-                             const std::vector<char>& payload,
+                             const std::vector<uint8_t>& payload,
                              const bool& reliable);
 
             /**
@@ -307,13 +307,13 @@ namespace extension {
             uint16_t packet_data_mtu{1000};
 
             // Our announce packet
-            std::vector<char> announce_packet{};
+            std::vector<uint8_t> announce_packet{};
 
             /// An atomic source for packet IDs to make sure they are semi unique
             std::atomic<uint16_t> packet_id_source{0};
 
             /// The callback to execute when a data packet is completed
-            std::function<void(const NetworkTarget&, const uint64_t&, const bool&, std::vector<char>&&)>
+            std::function<void(const NetworkTarget&, const uint64_t&, const bool&, std::vector<uint8_t>&&)>
                 packet_callback;
             /// The callback to execute when a node joins the network
             std::function<void(const NetworkTarget&)> join_callback;

--- a/src/id.hpp
+++ b/src/id.hpp
@@ -27,9 +27,7 @@
 
 namespace NUClear {
 
-/**
- * @brief A unique identifier for a thread pool
- */
+/// @brief This type is used when NUClear requires a unique identifier
 using id_t = std::size_t;
 
 }  // namespace NUClear

--- a/src/threading/ReactionTask.hpp
+++ b/src/threading/ReactionTask.hpp
@@ -151,13 +151,13 @@ namespace threading {
     };
 
     // Initialize our id source
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     template <typename ReactionType>
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     std::atomic<NUClear::id_t> Task<ReactionType>::task_id_source(0);
 
     // Initialize our current task
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     template <typename ReactionType>
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     ATTRIBUTE_TLS Task<ReactionType>* Task<ReactionType>::current_task = nullptr;
 
     // Alias the templated Task so that public API remains intact

--- a/src/threading/ReactionTask.hpp
+++ b/src/threading/ReactionTask.hpp
@@ -28,6 +28,7 @@
 #include <memory>
 #include <typeindex>
 #include <vector>
+
 #include "../id.hpp"
 #include "../message/ReactionStatistics.hpp"
 #include "../util/GroupDescriptor.hpp"
@@ -151,11 +152,11 @@ namespace threading {
 
     // Initialize our id source
     template <typename ReactionType>
-    std::atomic<NUClear::id_t> Task<ReactionType>::task_id_source(0);  // NOLINT
+    std::atomic<NUClear::id_t> Task<ReactionType>::task_id_source(0);
 
     // Initialize our current task
     template <typename ReactionType>
-    ATTRIBUTE_TLS Task<ReactionType>* Task<ReactionType>::current_task = nullptr;  // NOLINT
+    ATTRIBUTE_TLS Task<ReactionType>* Task<ReactionType>::current_task = nullptr;
 
     // Alias the templated Task so that public API remains intact
     class Reaction;

--- a/src/threading/ReactionTask.hpp
+++ b/src/threading/ReactionTask.hpp
@@ -151,10 +151,12 @@ namespace threading {
     };
 
     // Initialize our id source
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     template <typename ReactionType>
     std::atomic<NUClear::id_t> Task<ReactionType>::task_id_source(0);
 
     // Initialize our current task
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     template <typename ReactionType>
     ATTRIBUTE_TLS Task<ReactionType>* Task<ReactionType>::current_task = nullptr;
 

--- a/src/util/serialise/Serialise.hpp
+++ b/src/util/serialise/Serialise.hpp
@@ -23,9 +23,11 @@
 #ifndef NUCLEAR_UTIL_SERIALISE_SERIALISE_HPP
 #define NUCLEAR_UTIL_SERIALISE_SERIALISE_HPP
 
+#include <cstdint>
 #include <cstring>
 #include <string>
 #include <type_traits>
+#include <vector>
 
 #include "../demangle.hpp"
 #include "xxhash.hpp"

--- a/src/util/serialise/Serialise.hpp
+++ b/src/util/serialise/Serialise.hpp
@@ -51,13 +51,13 @@ namespace util {
         template <typename T>
         struct Serialise<T, std::enable_if_t<std::is_trivially_copyable<T>::value, T>> {
 
-            static inline std::vector<char> serialise(const T& in) {
-                std::vector<char> out(sizeof(T));
+            static inline std::vector<uint8_t> serialise(const T& in) {
+                std::vector<uint8_t> out(sizeof(T));
                 std::memcpy(out.data(), &in, sizeof(T));
                 return out;
             }
 
-            static inline T deserialise(const std::vector<char>& in) {
+            static inline T deserialise(const std::vector<uint8_t>& in) {
                 if (in.size() != sizeof(T)) {
                     throw std::length_error("Serialised data is not the correct size");
                 }
@@ -81,8 +81,8 @@ namespace util {
 
             using V = std::remove_reference_t<iterator_value_type_t<T>>;
 
-            static inline std::vector<char> serialise(const T& in) {
-                std::vector<char> out;
+            static inline std::vector<uint8_t> serialise(const T& in) {
+                std::vector<uint8_t> out;
                 out.reserve(sizeof(V) * size_t(std::distance(std::begin(in), std::end(in))));
 
                 for (const V& item : in) {
@@ -93,7 +93,7 @@ namespace util {
                 return out;
             }
 
-            static inline T deserialise(const std::vector<char>& in) {
+            static inline T deserialise(const std::vector<uint8_t>& in) {
 
                 if (in.size() % sizeof(V) != 0) {
                     throw std::length_error("Serialised data is not the correct size");
@@ -123,14 +123,14 @@ namespace util {
                                               || std::is_base_of<::google::protobuf::MessageLite, T>::value,
                                           T>> {
 
-            static inline std::vector<char> serialise(const T& in) {
-                std::vector<char> output(in.ByteSize());
+            static inline std::vector<uint8_t> serialise(const T& in) {
+                std::vector<uint8_t> output(in.ByteSize());
                 in.SerializeToArray(output.data(), output.size());
 
                 return output;
             }
 
-            static inline T deserialise(const std::vector<char>& in) {
+            static inline T deserialise(const std::vector<uint8_t>& in) {
                 // Make a buffer
                 T out;
 

--- a/src/util/serialise/Serialise.hpp
+++ b/src/util/serialise/Serialise.hpp
@@ -94,6 +94,10 @@ namespace util {
 
             static inline T deserialise(const std::vector<char>& in) {
 
+                if (in.size() % sizeof(V) != 0) {
+                    throw std::length_error("Serialised data is not the correct size");
+                }
+
                 T out;
 
                 const auto* data = reinterpret_cast<const V*>(in.data());

--- a/src/util/serialise/Serialise.hpp
+++ b/src/util/serialise/Serialise.hpp
@@ -25,8 +25,10 @@
 
 #include <cstdint>
 #include <cstring>
+#include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <typeinfo>
 #include <vector>
 
 #include "../demangle.hpp"

--- a/src/util/serialise/Serialise.hpp
+++ b/src/util/serialise/Serialise.hpp
@@ -23,6 +23,7 @@
 #ifndef NUCLEAR_UTIL_SERIALISE_SERIALISE_HPP
 #define NUCLEAR_UTIL_SERIALISE_SERIALISE_HPP
 
+#include <cstring>
 #include <string>
 #include <type_traits>
 

--- a/tests/dsl/UDP.cpp
+++ b/tests/dsl/UDP.cpp
@@ -165,7 +165,7 @@ struct Finished {
 class TestReactor : public test_util::TestBase<TestReactor> {
 private:
     void handle_data(const std::string& name, const UDP::Packet& packet) {
-        const std::string data(packet.payload.data(), packet.payload.size());
+        const std::string data(packet.payload.begin(), packet.payload.end());
 
         // Convert IP address to string in dotted decimal format
         const std::string local = packet.local.address + ":" + std::to_string(packet.local.port);

--- a/tests/util/serialise/serialise.cpp
+++ b/tests/util/serialise/serialise.cpp
@@ -22,8 +22,11 @@
 
 #include "util/serialise/Serialise.hpp"
 
+#include <array>
 #include <catch.hpp>
+#include <csdtint>
 #include <list>
+#include <vector>
 
 SCENARIO("Serialisation works correctly on single primitives", "[util][serialise][single][primitive]") {
 

--- a/tests/util/serialise/serialise.cpp
+++ b/tests/util/serialise/serialise.cpp
@@ -35,7 +35,7 @@ SCENARIO("Serialisation works correctly on single primitives", "[util][serialise
 
             THEN("The serialised data is as expected") {
                 REQUIRE(serialised.size() == sizeof(uint32_t));
-                REQUIRE(serialised == std::vector<uint8_t>{char(0xCA), char(0xFE), char(0xFE), char(0xCA)});
+                REQUIRE(serialised == std::vector<uint8_t>{0xCA, 0xFE, 0xFE, 0xCA});
             }
         }
 
@@ -50,11 +50,7 @@ SCENARIO("Serialisation works correctly on single primitives", "[util][serialise
     }
 
     GIVEN("serialised data for a primitive value") {
-        std::vector<uint8_t> in;
-        in.push_back(char(0xCA));
-        in.push_back(char(0xFE));
-        in.push_back(char(0xFE));
-        in.push_back(char(0xCA));
+        std::vector<uint8_t> in = {0xCA, 0xFE, 0xFE, 0xCA};
 
         WHEN("it is deserialised") {
             auto deserialised = NUClear::util::serialise::Serialise<uint32_t>::deserialise(in);
@@ -76,10 +72,7 @@ SCENARIO("Serialisation works correctly on single primitives", "[util][serialise
     }
 
     GIVEN("serialised data that is too small") {
-        std::vector<uint8_t> in;
-        in.push_back(char(0xBA));
-        in.push_back(char(0xAD));
-        in.push_back(char(0xBA));
+        std::vector<uint8_t> in = {0xBA, 0xAD, 0xBA};
 
         WHEN("it is deserialised") {
             THEN("The deserialise function throws an exception") {
@@ -89,12 +82,7 @@ SCENARIO("Serialisation works correctly on single primitives", "[util][serialise
     }
 
     GIVEN("serialised data that is too large") {
-        std::vector<uint8_t> in;
-        in.push_back(char(0xBA));
-        in.push_back(char(0xDB));
-        in.push_back(char(0xAD));
-        in.push_back(char(0xBA));
-        in.push_back(char(0xDB));
+        std::vector<uint8_t> in = {0xBA, 0xDB, 0xAD, 0xBA, 0xDB};
 
         WHEN("it is deserialised") {
             THEN("The deserialise function throws an exception") {
@@ -116,11 +104,9 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of prim
             auto serialised = NUClear::util::serialise::Serialise<TestType>::serialise(in);
 
             THEN("The serialised data is as expected") {
-                auto s = std::string(serialised.begin(), serialised.end());
-                REQUIRE(serialised.size() == sizeof(uint32_t) * in.size());
                 std::vector<uint8_t> expected =
                     {0xAB, 0xBA, 0xBA, 0xAB, 0xDE, 0xAD, 0xAD, 0xDE, 0xCA, 0xFE, 0xFE, 0xCA, 0xBE, 0xEF, 0xEF, 0xBE};
-                REQUIRE(s == expected);
+                REQUIRE(serialised == expected);
             }
         }
 
@@ -162,13 +148,7 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of prim
     }
 
     GIVEN("serialised data that does not divide evenly into the size") {
-        std::vector<uint8_t> in;
-        in.push_back(char(0xBA));
-        in.push_back(char(0xAD));
-        in.push_back(char(0xBA));
-        in.push_back(char(0xBA));
-        in.push_back(char(0xAD));
-        in.push_back(char(0xBA));
+        std::vector<uint8_t> in = {0xBA, 0xAD, 0xBA, 0xBA, 0xAD, 0xBA};
 
         WHEN("it is deserialised") {
             THEN("The deserialise function throws an exception") {
@@ -178,7 +158,7 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of prim
     }
 
     GIVEN("empty serialised data") {
-        std::vector<uint8_t> in;
+        std::vector<uint8_t> in{};
 
         WHEN("it is deserialised") {
             auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
@@ -201,7 +181,7 @@ struct TriviallyCopyable {
         return a == rhs.a && b == rhs.b && c[0] == rhs.c[0] && c[1] == rhs.c[1];
     }
 };
-static_assert(std::is_trivially_copyable<TriviallyCopyable>::value "This type should be trivially copyable");
+static_assert(std::is_trivially_copyable<TriviallyCopyable>::value, "This type should be trivially copyable");
 
 }  // namespace
 
@@ -233,11 +213,7 @@ SCENARIO("Serialisation works correctly on single trivially copyable types", "[u
     }
 
     GIVEN("serialised data for a primitive value") {
-        std::vector<uint8_t> in;
-        in.push_back(char(0xCA));
-        in.push_back(char(0xFE));
-        in.push_back(char(0xFE));
-        in.push_back(char(0xCA));
+        std::vector<uint8_t> in = {0xCA, 0xFE, 0xFE, 0xCA};
 
         WHEN("it is deserialised") {
             auto deserialised = NUClear::util::serialise::Serialise<TriviallyCopyable>::deserialise(in);
@@ -262,10 +238,7 @@ SCENARIO("Serialisation works correctly on single trivially copyable types", "[u
     }
 
     GIVEN("serialised data that is too small") {
-        std::vector<uint8_t> in;
-        in.push_back(char(0xCA));
-        in.push_back(char(0xFE));
-        in.push_back(char(0xFE));
+        std::vector<uint8_t> in = {0xCA, 0xFE, 0xFE};
 
         WHEN("it is deserialised") {
             THEN("The deserialise function throws an exception") {
@@ -276,13 +249,7 @@ SCENARIO("Serialisation works correctly on single trivially copyable types", "[u
     }
 
     GIVEN("serialised data that is too large") {
-        std::vector<uint8_t> in;
-        in.push_back(char(0xCA));
-        in.push_back(char(0xFE));
-        in.push_back(char(0xFE));
-        in.push_back(char(0xCA));
-        in.push_back(char(0xFE));
-        in.push_back(char(0xFE));
+        std::vector<uint8_t> in = {0xCA, 0xFE, 0xFE, 0xCA, 0xFE, 0xFE};
 
         WHEN("it is deserialised") {
             THEN("The deserialise function throws an exception") {
@@ -349,16 +316,7 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of triv
     }
 
     GIVEN("serialised data that does not divide evenly into the size") {
-        std::vector<uint8_t> in;
-        in.push_back(char(0xBA));
-        in.push_back(char(0xAD));
-        in.push_back(char(0xBA));
-        in.push_back(char(0xBA));
-        in.push_back(char(0xAD));
-        in.push_back(char(0xBA));
-        in.push_back(char(0xBA));
-        in.push_back(char(0xAD));
-        in.push_back(char(0xBA));
+        std::vector<uint8_t> in = {0xBA, 0xAD, 0xBA, 0xBA, 0xAD, 0xBA, 0xBA, 0xAD, 0xBA};
 
         WHEN("it is deserialised") {
             THEN("The deserialise function throws an exception") {

--- a/tests/util/serialise/serialise.cpp
+++ b/tests/util/serialise/serialise.cpp
@@ -75,11 +75,26 @@ SCENARIO("Serialisation works correctly on single primitives", "[util][serialise
         }
     }
 
-    GIVEN("serialised data of the incorrect size") {
+    GIVEN("serialised data that is too small") {
         std::vector<char> in;
-        in.push_back(char(0xCA));
-        in.push_back(char(0xFE));
-        in.push_back(char(0xFE));
+        in.push_back(char(0xBA));
+        in.push_back(char(0xAD));
+        in.push_back(char(0xBA));
+
+        WHEN("it is deserialised") {
+            THEN("The deserialise function throws an exception") {
+                REQUIRE_THROWS_AS(NUClear::util::serialise::Serialise<uint32_t>::deserialise(in), std::length_error);
+            }
+        }
+    }
+
+    GIVEN("serialised data that is too large") {
+        std::vector<char> in;
+        in.push_back(char(0xBA));
+        in.push_back(char(0xDB));
+        in.push_back(char(0xAD));
+        in.push_back(char(0xBA));
+        in.push_back(char(0xDB));
 
         WHEN("it is deserialised") {
             THEN("The deserialise function throws an exception") {
@@ -144,6 +159,22 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of prim
         }
     }
 
+    GIVEN("serialised data that does not divide evenly into the size") {
+        std::vector<char> in;
+        in.push_back(char(0xBA));
+        in.push_back(char(0xAD));
+        in.push_back(char(0xBA));
+        in.push_back(char(0xBA));
+        in.push_back(char(0xAD));
+        in.push_back(char(0xBA));
+
+        WHEN("it is deserialised") {
+            THEN("The deserialise function throws an exception") {
+                REQUIRE_THROWS_AS(NUClear::util::serialise::Serialise<uint32_t>::deserialise(in), std::length_error);
+            }
+        }
+    }
+
     GIVEN("empty serialised data") {
         std::vector<char> in;
 
@@ -170,7 +201,6 @@ struct TriviallyCopyable {
 }  // namespace
 
 SCENARIO("Serialisation works correctly on single trivially copyable types", "[util][serialise][single][trivial]") {
-
 
     GIVEN("a trivially copyable value") {
         TriviallyCopyable in = {0xFF, -1, {0xDE, 0xAD}};
@@ -227,8 +257,25 @@ SCENARIO("Serialisation works correctly on single trivially copyable types", "[u
         }
     }
 
-    GIVEN("serialised data of the incorrect size") {
+    GIVEN("serialised data that is too small") {
         std::vector<char> in;
+        in.push_back(char(0xCA));
+        in.push_back(char(0xFE));
+        in.push_back(char(0xFE));
+
+        WHEN("it is deserialised") {
+            THEN("The deserialise function throws an exception") {
+                REQUIRE_THROWS_AS(NUClear::util::serialise::Serialise<TriviallyCopyable>::deserialise(in),
+                                  std::length_error);
+            }
+        }
+    }
+
+    GIVEN("serialised data that is too large") {
+        std::vector<char> in;
+        in.push_back(char(0xCA));
+        in.push_back(char(0xFE));
+        in.push_back(char(0xFE));
         in.push_back(char(0xCA));
         in.push_back(char(0xFE));
         in.push_back(char(0xFE));
@@ -293,6 +340,25 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of triv
             THEN("The serialised data is the same as the input") {
                 REQUIRE(serialised.size() == in.size());
                 REQUIRE(serialised == in);
+            }
+        }
+    }
+
+    GIVEN("serialised data that does not divide evenly into the size") {
+        std::vector<char> in;
+        in.push_back(char(0xBA));
+        in.push_back(char(0xAD));
+        in.push_back(char(0xBA));
+        in.push_back(char(0xBA));
+        in.push_back(char(0xAD));
+        in.push_back(char(0xBA));
+        in.push_back(char(0xBA));
+        in.push_back(char(0xAD));
+        in.push_back(char(0xBA));
+
+        WHEN("it is deserialised") {
+            THEN("The deserialise function throws an exception") {
+                REQUIRE_THROWS_AS(NUClear::util::serialise::Serialise<uint32_t>::deserialise(in), std::length_error);
             }
         }
     }

--- a/tests/util/serialise/serialise.cpp
+++ b/tests/util/serialise/serialise.cpp
@@ -65,7 +65,6 @@ SCENARIO("Serialisation works correctly on single primitives", "[util][serialise
             auto serialised   = NUClear::util::serialise::Serialise<uint32_t>::serialise(deserialised);
 
             THEN("The serialised data is the same as the input") {
-                REQUIRE(serialised.size() == in.size());
                 REQUIRE(serialised == in);
             }
         }
@@ -141,7 +140,6 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of prim
             auto serialised   = NUClear::util::serialise::Serialise<TestType>::serialise(deserialised);
 
             THEN("The serialised data is the same as the input") {
-                REQUIRE(serialised.size() == in.size());
                 REQUIRE(serialised == in);
             }
         }
@@ -164,7 +162,7 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of prim
             auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
 
             THEN("The deserialised data is empty") {
-                REQUIRE(deserialised.size() == 0);
+                REQUIRE(deserialised.empty());
             }
         }
     }
@@ -231,7 +229,6 @@ SCENARIO("Serialisation works correctly on single trivially copyable types", "[u
             auto serialised   = NUClear::util::serialise::Serialise<TriviallyCopyable>::serialise(deserialised);
 
             THEN("The serialised data is the same as the input") {
-                REQUIRE(serialised.size() == in.size());
                 REQUIRE(serialised == in);
             }
         }
@@ -309,7 +306,6 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of triv
             auto serialised   = NUClear::util::serialise::Serialise<TestType>::serialise(deserialised);
 
             THEN("The serialised data is the same as the input") {
-                REQUIRE(serialised.size() == in.size());
                 REQUIRE(serialised == in);
             }
         }
@@ -332,7 +328,7 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of triv
             auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
 
             THEN("The deserialised data is empty") {
-                REQUIRE(deserialised.size() == 0);
+                REQUIRE(deserialised.empty());
             }
         }
     }

--- a/tests/util/serialise/serialise.cpp
+++ b/tests/util/serialise/serialise.cpp
@@ -35,7 +35,7 @@ SCENARIO("Serialisation works correctly on single primitives", "[util][serialise
 
             THEN("The serialised data is as expected") {
                 REQUIRE(serialised.size() == sizeof(uint32_t));
-                REQUIRE(serialised == std::vector<char>{char(0xCA), char(0xFE), char(0xFE), char(0xCA)});
+                REQUIRE(serialised == std::vector<uint8_t>{char(0xCA), char(0xFE), char(0xFE), char(0xCA)});
             }
         }
 
@@ -50,7 +50,7 @@ SCENARIO("Serialisation works correctly on single primitives", "[util][serialise
     }
 
     GIVEN("serialised data for a primitive value") {
-        std::vector<char> in;
+        std::vector<uint8_t> in;
         in.push_back(char(0xCA));
         in.push_back(char(0xFE));
         in.push_back(char(0xFE));
@@ -76,7 +76,7 @@ SCENARIO("Serialisation works correctly on single primitives", "[util][serialise
     }
 
     GIVEN("serialised data that is too small") {
-        std::vector<char> in;
+        std::vector<uint8_t> in;
         in.push_back(char(0xBA));
         in.push_back(char(0xAD));
         in.push_back(char(0xBA));
@@ -89,7 +89,7 @@ SCENARIO("Serialisation works correctly on single primitives", "[util][serialise
     }
 
     GIVEN("serialised data that is too large") {
-        std::vector<char> in;
+        std::vector<uint8_t> in;
         in.push_back(char(0xBA));
         in.push_back(char(0xDB));
         in.push_back(char(0xAD));
@@ -118,7 +118,9 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of prim
             THEN("The serialised data is as expected") {
                 auto s = std::string(serialised.begin(), serialised.end());
                 REQUIRE(serialised.size() == sizeof(uint32_t) * in.size());
-                REQUIRE(s == "\xAB\xBA\xBA\xAB\xDE\xAD\xAD\xDE\xCA\xFE\xFE\xCA\xBE\xEF\xEF\xBE");
+                std::vector<uint8_t> expected =
+                    {0xAB, 0xBA, 0xBA, 0xAB, 0xDE, 0xAD, 0xAD, 0xDE, 0xCA, 0xFE, 0xFE, 0xCA, 0xBE, 0xEF, 0xEF, 0xBE};
+                REQUIRE(s == expected);
             }
         }
 
@@ -133,8 +135,8 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of prim
     }
 
     GIVEN("serialised data for multiple primitives") {
-        std::string in_s = "\xBE\xEF\xEF\xBE\xAB\xBA\xBA\xAB\xDE\xAD\xAD\xDE\xCA\xFE\xFE\xCA";
-        std::vector<char> in(in_s.begin(), in_s.end());
+        std::vector<uint8_t> in =
+            {0xBE, 0xEF, 0xEF, 0xBE, 0xAB, 0xBA, 0xBA, 0xAB, 0xDE, 0xAD, 0xAD, 0xDE, 0xCA, 0xFE, 0xFE, 0xCA};
 
         WHEN("it is deserialised") {
             auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
@@ -160,7 +162,7 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of prim
     }
 
     GIVEN("serialised data that does not divide evenly into the size") {
-        std::vector<char> in;
+        std::vector<uint8_t> in;
         in.push_back(char(0xBA));
         in.push_back(char(0xAD));
         in.push_back(char(0xBA));
@@ -176,7 +178,7 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of prim
     }
 
     GIVEN("empty serialised data") {
-        std::vector<char> in;
+        std::vector<uint8_t> in;
 
         WHEN("it is deserialised") {
             auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
@@ -189,6 +191,7 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of prim
 }
 
 namespace {
+
 struct TriviallyCopyable {
     uint8_t a;
     int8_t b;
@@ -198,6 +201,8 @@ struct TriviallyCopyable {
         return a == rhs.a && b == rhs.b && c[0] == rhs.c[0] && c[1] == rhs.c[1];
     }
 };
+static_assert(std::is_trivially_copyable<TriviallyCopyable>::value "This type should be trivially copyable");
+
 }  // namespace
 
 SCENARIO("Serialisation works correctly on single trivially copyable types", "[util][serialise][single][trivial]") {
@@ -210,8 +215,7 @@ SCENARIO("Serialisation works correctly on single trivially copyable types", "[u
 
             THEN("The serialised data is as expected") {
                 REQUIRE(serialised.size() == sizeof(TriviallyCopyable));
-                std::string s(serialised.begin(), serialised.end());
-                REQUIRE(s == "\xFF\xFF\xDE\xAD");
+                REQUIRE(serialised == std::vector<uint8_t>({0xFF, 0xFF, 0xDE, 0xAD}));
             }
         }
 
@@ -229,7 +233,7 @@ SCENARIO("Serialisation works correctly on single trivially copyable types", "[u
     }
 
     GIVEN("serialised data for a primitive value") {
-        std::vector<char> in;
+        std::vector<uint8_t> in;
         in.push_back(char(0xCA));
         in.push_back(char(0xFE));
         in.push_back(char(0xFE));
@@ -258,7 +262,7 @@ SCENARIO("Serialisation works correctly on single trivially copyable types", "[u
     }
 
     GIVEN("serialised data that is too small") {
-        std::vector<char> in;
+        std::vector<uint8_t> in;
         in.push_back(char(0xCA));
         in.push_back(char(0xFE));
         in.push_back(char(0xFE));
@@ -272,7 +276,7 @@ SCENARIO("Serialisation works correctly on single trivially copyable types", "[u
     }
 
     GIVEN("serialised data that is too large") {
-        std::vector<char> in;
+        std::vector<uint8_t> in;
         in.push_back(char(0xCA));
         in.push_back(char(0xFE));
         in.push_back(char(0xFE));
@@ -320,7 +324,7 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of triv
 
     GIVEN("serialised data for multiple trivials") {
         std::string in_s = "Hello World!";
-        std::vector<char> in(in_s.begin(), in_s.end());
+        std::vector<uint8_t> in(in_s.begin(), in_s.end());
 
         WHEN("it is deserialised") {
             auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
@@ -345,7 +349,7 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of triv
     }
 
     GIVEN("serialised data that does not divide evenly into the size") {
-        std::vector<char> in;
+        std::vector<uint8_t> in;
         in.push_back(char(0xBA));
         in.push_back(char(0xAD));
         in.push_back(char(0xBA));
@@ -364,7 +368,7 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of triv
     }
 
     GIVEN("empty serialised data") {
-        std::vector<char> in;
+        std::vector<uint8_t> in;
 
         WHEN("it is deserialised") {
             auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);

--- a/tests/util/serialise/serialise.cpp
+++ b/tests/util/serialise/serialise.cpp
@@ -24,7 +24,7 @@
 
 #include <array>
 #include <catch.hpp>
-#include <csdtint>
+#include <cstdint>
 #include <list>
 #include <vector>
 

--- a/tests/util/serialise/serialise.cpp
+++ b/tests/util/serialise/serialise.cpp
@@ -173,7 +173,7 @@ namespace {
 struct TriviallyCopyable {
     uint8_t a;
     int8_t b;
-    uint8_t c[2];
+    std::array<uint8_t, 2> c;
 
     bool operator==(const TriviallyCopyable& rhs) const {
         return a == rhs.a && b == rhs.b && c[0] == rhs.c[0] && c[1] == rhs.c[1];

--- a/tests/util/serialise/serialise.cpp
+++ b/tests/util/serialise/serialise.cpp
@@ -1,0 +1,311 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2015 NUClear Contributors
+ *
+ * This file is part of the NUClear codebase.
+ * See https://github.com/Fastcode/NUClear for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "util/serialise/Serialise.hpp"
+
+#include <catch.hpp>
+#include <list>
+
+SCENARIO("Serialisation works correctly on single primitives", "[util][serialise][single][primitive]") {
+
+    GIVEN("a primitive value") {
+        uint32_t in = 0xCAFEFECA;  // Mirrored so that endianess doesn't matter for the test
+
+        WHEN("it is serialised") {
+            auto serialised = NUClear::util::serialise::Serialise<uint32_t>::serialise(in);
+
+            THEN("The serialised data is as expected") {
+                REQUIRE(serialised.size() == sizeof(uint32_t));
+                REQUIRE(serialised == std::vector<char>{char(0xCA), char(0xFE), char(0xFE), char(0xCA)});
+            }
+        }
+
+        WHEN("it is round tripped through the serialise and deserialise functions") {
+            auto serialised   = NUClear::util::serialise::Serialise<uint32_t>::serialise(in);
+            auto deserialised = NUClear::util::serialise::Serialise<uint32_t>::deserialise(serialised);
+
+            THEN("The deserialised data is the same as the input") {
+                REQUIRE(deserialised == in);
+            }
+        }
+    }
+
+    GIVEN("serialised data for a primitive value") {
+        std::vector<char> in;
+        in.push_back(char(0xCA));
+        in.push_back(char(0xFE));
+        in.push_back(char(0xFE));
+        in.push_back(char(0xCA));
+
+        WHEN("it is deserialised") {
+            auto deserialised = NUClear::util::serialise::Serialise<uint32_t>::deserialise(in);
+
+            THEN("The deserialised data is as expected") {
+                REQUIRE(deserialised == 0xCAFEFECA);
+            }
+        }
+
+        WHEN("it is round tripped through the deserialise and serialise functions") {
+            auto deserialised = NUClear::util::serialise::Serialise<uint32_t>::deserialise(in);
+            auto serialised   = NUClear::util::serialise::Serialise<uint32_t>::serialise(deserialised);
+
+            THEN("The serialised data is the same as the input") {
+                REQUIRE(serialised.size() == in.size());
+                REQUIRE(serialised == in);
+            }
+        }
+    }
+
+    GIVEN("serialised data of the incorrect size") {
+        std::vector<char> in;
+        in.push_back(char(0xCA));
+        in.push_back(char(0xFE));
+        in.push_back(char(0xFE));
+
+        WHEN("it is deserialised") {
+            THEN("The deserialise function throws an exception") {
+                REQUIRE_THROWS_AS(NUClear::util::serialise::Serialise<uint32_t>::deserialise(in), std::length_error);
+            }
+        }
+    }
+}
+
+TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of primitives",
+                   "[util][serialise][multiple][primitive]",
+                   std::vector<uint32_t>,
+                   std::list<uint32_t>) {
+
+    GIVEN("a vector of primitive values") {
+        TestType in = {0xABBABAAB, 0xDEADADDE, 0xCAFEFECA, 0xBEEFEFBE};
+
+        WHEN("it is serialised") {
+            auto serialised = NUClear::util::serialise::Serialise<TestType>::serialise(in);
+
+            THEN("The serialised data is as expected") {
+                auto s = std::string(serialised.begin(), serialised.end());
+                REQUIRE(serialised.size() == sizeof(uint32_t) * in.size());
+                REQUIRE(s == "\xAB\xBA\xBA\xAB\xDE\xAD\xAD\xDE\xCA\xFE\xFE\xCA\xBE\xEF\xEF\xBE");
+            }
+        }
+
+        WHEN("it is round tripped through the serialise and deserialise functions") {
+            auto serialised   = NUClear::util::serialise::Serialise<TestType>::serialise(in);
+            auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(serialised);
+
+            THEN("The deserialised data is the same as the input") {
+                REQUIRE(deserialised == in);
+            }
+        }
+    }
+
+    GIVEN("serialised data for multiple primitives") {
+        std::string in_s = "\xBE\xEF\xEF\xBE\xAB\xBA\xBA\xAB\xDE\xAD\xAD\xDE\xCA\xFE\xFE\xCA";
+        std::vector<char> in(in_s.begin(), in_s.end());
+
+        WHEN("it is deserialised") {
+            auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
+
+            THEN("The deserialised data is as expected") {
+                REQUIRE(deserialised.size() == 4);
+                REQUIRE(*std::next(deserialised.begin(), 0) == 0xBEEFEFBE);
+                REQUIRE(*std::next(deserialised.begin(), 1) == 0xABBABAAB);
+                REQUIRE(*std::next(deserialised.begin(), 2) == 0xDEADADDE);
+                REQUIRE(*std::next(deserialised.begin(), 3) == 0xCAFEFECA);
+            }
+        }
+
+        WHEN("it is round tripped through the deserialise and serialise functions") {
+            auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
+            auto serialised   = NUClear::util::serialise::Serialise<TestType>::serialise(deserialised);
+
+            THEN("The serialised data is the same as the input") {
+                REQUIRE(serialised.size() == in.size());
+                REQUIRE(serialised == in);
+            }
+        }
+    }
+
+    GIVEN("empty serialised data") {
+        std::vector<char> in;
+
+        WHEN("it is deserialised") {
+            auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
+
+            THEN("The deserialised data is empty") {
+                REQUIRE(deserialised.size() == 0);
+            }
+        }
+    }
+}
+
+namespace {
+struct TriviallyCopyable {
+    uint8_t a;
+    int8_t b;
+    uint8_t c[2];
+
+    bool operator==(const TriviallyCopyable& rhs) const {
+        return a == rhs.a && b == rhs.b && c[0] == rhs.c[0] && c[1] == rhs.c[1];
+    }
+};
+}  // namespace
+
+SCENARIO("Serialisation works correctly on single trivially copyable types", "[util][serialise][single][trivial]") {
+
+
+    GIVEN("a trivially copyable value") {
+        TriviallyCopyable in = {0xFF, -1, {0xDE, 0xAD}};
+
+        WHEN("it is serialised") {
+            auto serialised = NUClear::util::serialise::Serialise<TriviallyCopyable>::serialise(in);
+
+            THEN("The serialised data is as expected") {
+                REQUIRE(serialised.size() == sizeof(TriviallyCopyable));
+                std::string s(serialised.begin(), serialised.end());
+                REQUIRE(s == "\xFF\xFF\xDE\xAD");
+            }
+        }
+
+        WHEN("it is round tripped through the serialise and deserialise functions") {
+            auto serialised   = NUClear::util::serialise::Serialise<TriviallyCopyable>::serialise(in);
+            auto deserialised = NUClear::util::serialise::Serialise<TriviallyCopyable>::deserialise(serialised);
+
+            THEN("The deserialised data is the same as the input") {
+                REQUIRE(deserialised.a == in.a);
+                REQUIRE(deserialised.b == in.b);
+                REQUIRE(deserialised.c[0] == in.c[0]);
+                REQUIRE(deserialised.c[1] == in.c[1]);
+            }
+        }
+    }
+
+    GIVEN("serialised data for a primitive value") {
+        std::vector<char> in;
+        in.push_back(char(0xCA));
+        in.push_back(char(0xFE));
+        in.push_back(char(0xFE));
+        in.push_back(char(0xCA));
+
+        WHEN("it is deserialised") {
+            auto deserialised = NUClear::util::serialise::Serialise<TriviallyCopyable>::deserialise(in);
+
+            THEN("The deserialised data is as expected") {
+                REQUIRE(deserialised.a == 0xCA);
+                REQUIRE(deserialised.b == -0x02);
+                REQUIRE(deserialised.c[0] == 0xFE);
+                REQUIRE(deserialised.c[1] == 0xCA);
+            }
+        }
+
+        WHEN("it is round tripped through the deserialise and serialise functions") {
+            auto deserialised = NUClear::util::serialise::Serialise<TriviallyCopyable>::deserialise(in);
+            auto serialised   = NUClear::util::serialise::Serialise<TriviallyCopyable>::serialise(deserialised);
+
+            THEN("The serialised data is the same as the input") {
+                REQUIRE(serialised.size() == in.size());
+                REQUIRE(serialised == in);
+            }
+        }
+    }
+
+    GIVEN("serialised data of the incorrect size") {
+        std::vector<char> in;
+        in.push_back(char(0xCA));
+        in.push_back(char(0xFE));
+        in.push_back(char(0xFE));
+
+        WHEN("it is deserialised") {
+            THEN("The deserialise function throws an exception") {
+                REQUIRE_THROWS_AS(NUClear::util::serialise::Serialise<TriviallyCopyable>::deserialise(in),
+                                  std::length_error);
+            }
+        }
+    }
+}
+
+
+TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of trivially copyable types",
+                   "[util][serialise][multiple][trivial]",
+                   std::vector<TriviallyCopyable>,
+                   std::list<TriviallyCopyable>) {
+
+    GIVEN("a vector of trivial values") {
+        TestType in = {{'h', 'e', {'l', 'o'}}, {'w', 'o', {'r', 'd'}}};
+
+        WHEN("it is serialised") {
+            auto serialised = NUClear::util::serialise::Serialise<TestType>::serialise(in);
+
+            THEN("The serialised data is as expected") {
+                auto s = std::string(serialised.begin(), serialised.end());
+                REQUIRE(serialised.size() == sizeof(uint32_t) * in.size());
+                REQUIRE(s == "heloword");
+            }
+        }
+
+        WHEN("it is round tripped through the serialise and deserialise functions") {
+            auto serialised   = NUClear::util::serialise::Serialise<TestType>::serialise(in);
+            auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(serialised);
+
+            THEN("The deserialised data is the same as the input") {
+                REQUIRE(deserialised == in);
+            }
+        }
+    }
+
+    GIVEN("serialised data for multiple trivials") {
+        std::string in_s = "Hello World!";
+        std::vector<char> in(in_s.begin(), in_s.end());
+
+        WHEN("it is deserialised") {
+            auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
+
+            THEN("The deserialised data is as expected") {
+                REQUIRE(deserialised.size() == 3);
+                REQUIRE(*std::next(deserialised.begin(), 0) == TriviallyCopyable{'H', 'e', {'l', 'l'}});
+                REQUIRE(*std::next(deserialised.begin(), 1) == TriviallyCopyable{'o', ' ', {'W', 'o'}});
+                REQUIRE(*std::next(deserialised.begin(), 2) == TriviallyCopyable{'r', 'l', {'d', '!'}});
+            }
+        }
+
+        WHEN("it is round tripped through the deserialise and serialise functions") {
+            auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
+            auto serialised   = NUClear::util::serialise::Serialise<TestType>::serialise(deserialised);
+
+            THEN("The serialised data is the same as the input") {
+                REQUIRE(serialised.size() == in.size());
+                REQUIRE(serialised == in);
+            }
+        }
+    }
+
+    GIVEN("empty serialised data") {
+        std::vector<char> in;
+
+        WHEN("it is deserialised") {
+            auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
+
+            THEN("The deserialised data is empty") {
+                REQUIRE(deserialised.size() == 0);
+            }
+        }
+    }
+}

--- a/tests/util/serialise/serialise.cpp
+++ b/tests/util/serialise/serialise.cpp
@@ -28,10 +28,10 @@
 SCENARIO("Serialisation works correctly on single primitives", "[util][serialise][single][primitive]") {
 
     GIVEN("a primitive value") {
-        uint32_t in = 0xCAFEFECA;  // Mirrored so that endianess doesn't matter for the test
+        const uint32_t in = 0xCAFEFECA;  // Mirrored so that endianess doesn't matter for the test
 
         WHEN("it is serialised") {
-            auto serialised = NUClear::util::serialise::Serialise<uint32_t>::serialise(in);
+            const auto serialised = NUClear::util::serialise::Serialise<uint32_t>::serialise(in);
 
             THEN("The serialised data is as expected") {
                 REQUIRE(serialised.size() == sizeof(uint32_t));
@@ -40,8 +40,8 @@ SCENARIO("Serialisation works correctly on single primitives", "[util][serialise
         }
 
         WHEN("it is round tripped through the serialise and deserialise functions") {
-            auto serialised   = NUClear::util::serialise::Serialise<uint32_t>::serialise(in);
-            auto deserialised = NUClear::util::serialise::Serialise<uint32_t>::deserialise(serialised);
+            const auto serialised   = NUClear::util::serialise::Serialise<uint32_t>::serialise(in);
+            const auto deserialised = NUClear::util::serialise::Serialise<uint32_t>::deserialise(serialised);
 
             THEN("The deserialised data is the same as the input") {
                 REQUIRE(deserialised == in);
@@ -50,10 +50,10 @@ SCENARIO("Serialisation works correctly on single primitives", "[util][serialise
     }
 
     GIVEN("serialised data for a primitive value") {
-        std::vector<uint8_t> in = {0xCA, 0xFE, 0xFE, 0xCA};
+        const std::vector<uint8_t> in = {0xCA, 0xFE, 0xFE, 0xCA};
 
         WHEN("it is deserialised") {
-            auto deserialised = NUClear::util::serialise::Serialise<uint32_t>::deserialise(in);
+            const auto deserialised = NUClear::util::serialise::Serialise<uint32_t>::deserialise(in);
 
             THEN("The deserialised data is as expected") {
                 REQUIRE(deserialised == 0xCAFEFECA);
@@ -61,8 +61,8 @@ SCENARIO("Serialisation works correctly on single primitives", "[util][serialise
         }
 
         WHEN("it is round tripped through the deserialise and serialise functions") {
-            auto deserialised = NUClear::util::serialise::Serialise<uint32_t>::deserialise(in);
-            auto serialised   = NUClear::util::serialise::Serialise<uint32_t>::serialise(deserialised);
+            const auto deserialised = NUClear::util::serialise::Serialise<uint32_t>::deserialise(in);
+            const auto serialised   = NUClear::util::serialise::Serialise<uint32_t>::serialise(deserialised);
 
             THEN("The serialised data is the same as the input") {
                 REQUIRE(serialised == in);
@@ -71,7 +71,7 @@ SCENARIO("Serialisation works correctly on single primitives", "[util][serialise
     }
 
     GIVEN("serialised data that is too small") {
-        std::vector<uint8_t> in = {0xBA, 0xAD, 0xBA};
+        const std::vector<uint8_t> in = {0xBA, 0xAD, 0xBA};
 
         WHEN("it is deserialised") {
             THEN("The deserialise function throws an exception") {
@@ -81,7 +81,7 @@ SCENARIO("Serialisation works correctly on single primitives", "[util][serialise
     }
 
     GIVEN("serialised data that is too large") {
-        std::vector<uint8_t> in = {0xBA, 0xDB, 0xAD, 0xBA, 0xDB};
+        const std::vector<uint8_t> in = {0xBA, 0xDB, 0xAD, 0xBA, 0xDB};
 
         WHEN("it is deserialised") {
             THEN("The deserialise function throws an exception") {
@@ -97,21 +97,21 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of prim
                    std::list<uint32_t>) {
 
     GIVEN("a vector of primitive values") {
-        TestType in = {0xABBABAAB, 0xDEADADDE, 0xCAFEFECA, 0xBEEFEFBE};
+        const TestType in = {0xABBABAAB, 0xDEADADDE, 0xCAFEFECA, 0xBEEFEFBE};
 
         WHEN("it is serialised") {
-            auto serialised = NUClear::util::serialise::Serialise<TestType>::serialise(in);
+            const auto serialised = NUClear::util::serialise::Serialise<TestType>::serialise(in);
 
             THEN("The serialised data is as expected") {
-                std::vector<uint8_t> expected =
+                const std::vector<uint8_t> expected =
                     {0xAB, 0xBA, 0xBA, 0xAB, 0xDE, 0xAD, 0xAD, 0xDE, 0xCA, 0xFE, 0xFE, 0xCA, 0xBE, 0xEF, 0xEF, 0xBE};
                 REQUIRE(serialised == expected);
             }
         }
 
         WHEN("it is round tripped through the serialise and deserialise functions") {
-            auto serialised   = NUClear::util::serialise::Serialise<TestType>::serialise(in);
-            auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(serialised);
+            const auto serialised   = NUClear::util::serialise::Serialise<TestType>::serialise(in);
+            const auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(serialised);
 
             THEN("The deserialised data is the same as the input") {
                 REQUIRE(deserialised == in);
@@ -120,11 +120,11 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of prim
     }
 
     GIVEN("serialised data for multiple primitives") {
-        std::vector<uint8_t> in =
+        const std::vector<uint8_t> in =
             {0xBE, 0xEF, 0xEF, 0xBE, 0xAB, 0xBA, 0xBA, 0xAB, 0xDE, 0xAD, 0xAD, 0xDE, 0xCA, 0xFE, 0xFE, 0xCA};
 
         WHEN("it is deserialised") {
-            auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
+            const auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
 
             THEN("The deserialised data is as expected") {
                 REQUIRE(deserialised.size() == 4);
@@ -136,8 +136,8 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of prim
         }
 
         WHEN("it is round tripped through the deserialise and serialise functions") {
-            auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
-            auto serialised   = NUClear::util::serialise::Serialise<TestType>::serialise(deserialised);
+            const auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
+            const auto serialised   = NUClear::util::serialise::Serialise<TestType>::serialise(deserialised);
 
             THEN("The serialised data is the same as the input") {
                 REQUIRE(serialised == in);
@@ -146,7 +146,7 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of prim
     }
 
     GIVEN("serialised data that does not divide evenly into the size") {
-        std::vector<uint8_t> in = {0xBA, 0xAD, 0xBA, 0xBA, 0xAD, 0xBA};
+        const std::vector<uint8_t> in = {0xBA, 0xAD, 0xBA, 0xBA, 0xAD, 0xBA};
 
         WHEN("it is deserialised") {
             THEN("The deserialise function throws an exception") {
@@ -156,10 +156,10 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of prim
     }
 
     GIVEN("empty serialised data") {
-        std::vector<uint8_t> in{};
+        const std::vector<uint8_t> in{};
 
         WHEN("it is deserialised") {
-            auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
+            const auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
 
             THEN("The deserialised data is empty") {
                 REQUIRE(deserialised.empty());
@@ -186,10 +186,10 @@ static_assert(std::is_trivially_copyable<TriviallyCopyable>::value, "This type s
 SCENARIO("Serialisation works correctly on single trivially copyable types", "[util][serialise][single][trivial]") {
 
     GIVEN("a trivially copyable value") {
-        TriviallyCopyable in = {0xFF, -1, {0xDE, 0xAD}};
+        const TriviallyCopyable in = {0xFF, -1, {0xDE, 0xAD}};
 
         WHEN("it is serialised") {
-            auto serialised = NUClear::util::serialise::Serialise<TriviallyCopyable>::serialise(in);
+            const auto serialised = NUClear::util::serialise::Serialise<TriviallyCopyable>::serialise(in);
 
             THEN("The serialised data is as expected") {
                 REQUIRE(serialised.size() == sizeof(TriviallyCopyable));
@@ -198,8 +198,8 @@ SCENARIO("Serialisation works correctly on single trivially copyable types", "[u
         }
 
         WHEN("it is round tripped through the serialise and deserialise functions") {
-            auto serialised   = NUClear::util::serialise::Serialise<TriviallyCopyable>::serialise(in);
-            auto deserialised = NUClear::util::serialise::Serialise<TriviallyCopyable>::deserialise(serialised);
+            const auto serialised   = NUClear::util::serialise::Serialise<TriviallyCopyable>::serialise(in);
+            const auto deserialised = NUClear::util::serialise::Serialise<TriviallyCopyable>::deserialise(serialised);
 
             THEN("The deserialised data is the same as the input") {
                 REQUIRE(deserialised.a == in.a);
@@ -211,10 +211,10 @@ SCENARIO("Serialisation works correctly on single trivially copyable types", "[u
     }
 
     GIVEN("serialised data for a primitive value") {
-        std::vector<uint8_t> in = {0xCA, 0xFE, 0xFE, 0xCA};
+        const std::vector<uint8_t> in = {0xCA, 0xFE, 0xFE, 0xCA};
 
         WHEN("it is deserialised") {
-            auto deserialised = NUClear::util::serialise::Serialise<TriviallyCopyable>::deserialise(in);
+            const auto deserialised = NUClear::util::serialise::Serialise<TriviallyCopyable>::deserialise(in);
 
             THEN("The deserialised data is as expected") {
                 REQUIRE(deserialised.a == 0xCA);
@@ -225,8 +225,8 @@ SCENARIO("Serialisation works correctly on single trivially copyable types", "[u
         }
 
         WHEN("it is round tripped through the deserialise and serialise functions") {
-            auto deserialised = NUClear::util::serialise::Serialise<TriviallyCopyable>::deserialise(in);
-            auto serialised   = NUClear::util::serialise::Serialise<TriviallyCopyable>::serialise(deserialised);
+            const auto deserialised = NUClear::util::serialise::Serialise<TriviallyCopyable>::deserialise(in);
+            const auto serialised   = NUClear::util::serialise::Serialise<TriviallyCopyable>::serialise(deserialised);
 
             THEN("The serialised data is the same as the input") {
                 REQUIRE(serialised == in);
@@ -235,7 +235,7 @@ SCENARIO("Serialisation works correctly on single trivially copyable types", "[u
     }
 
     GIVEN("serialised data that is too small") {
-        std::vector<uint8_t> in = {0xCA, 0xFE, 0xFE};
+        const std::vector<uint8_t> in = {0xCA, 0xFE, 0xFE};
 
         WHEN("it is deserialised") {
             THEN("The deserialise function throws an exception") {
@@ -246,7 +246,7 @@ SCENARIO("Serialisation works correctly on single trivially copyable types", "[u
     }
 
     GIVEN("serialised data that is too large") {
-        std::vector<uint8_t> in = {0xCA, 0xFE, 0xFE, 0xCA, 0xFE, 0xFE};
+        const std::vector<uint8_t> in = {0xCA, 0xFE, 0xFE, 0xCA, 0xFE, 0xFE};
 
         WHEN("it is deserialised") {
             THEN("The deserialise function throws an exception") {
@@ -264,10 +264,10 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of triv
                    std::list<TriviallyCopyable>) {
 
     GIVEN("a vector of trivial values") {
-        TestType in = {{'h', 'e', {'l', 'o'}}, {'w', 'o', {'r', 'd'}}};
+        const TestType in = {{'h', 'e', {'l', 'o'}}, {'w', 'o', {'r', 'd'}}};
 
         WHEN("it is serialised") {
-            auto serialised = NUClear::util::serialise::Serialise<TestType>::serialise(in);
+            const auto serialised = NUClear::util::serialise::Serialise<TestType>::serialise(in);
 
             THEN("The serialised data is as expected") {
                 auto s = std::string(serialised.begin(), serialised.end());
@@ -277,8 +277,8 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of triv
         }
 
         WHEN("it is round tripped through the serialise and deserialise functions") {
-            auto serialised   = NUClear::util::serialise::Serialise<TestType>::serialise(in);
-            auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(serialised);
+            const auto serialised   = NUClear::util::serialise::Serialise<TestType>::serialise(in);
+            const auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(serialised);
 
             THEN("The deserialised data is the same as the input") {
                 REQUIRE(deserialised == in);
@@ -287,11 +287,11 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of triv
     }
 
     GIVEN("serialised data for multiple trivials") {
-        std::string in_s = "Hello World!";
-        std::vector<uint8_t> in(in_s.begin(), in_s.end());
+        const std::string in_s = "Hello World!";
+        const std::vector<uint8_t> in(in_s.begin(), in_s.end());
 
         WHEN("it is deserialised") {
-            auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
+            const auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
 
             THEN("The deserialised data is as expected") {
                 REQUIRE(deserialised.size() == 3);
@@ -302,8 +302,8 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of triv
         }
 
         WHEN("it is round tripped through the deserialise and serialise functions") {
-            auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
-            auto serialised   = NUClear::util::serialise::Serialise<TestType>::serialise(deserialised);
+            const auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
+            const auto serialised   = NUClear::util::serialise::Serialise<TestType>::serialise(deserialised);
 
             THEN("The serialised data is the same as the input") {
                 REQUIRE(serialised == in);
@@ -312,7 +312,7 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of triv
     }
 
     GIVEN("serialised data that does not divide evenly into the size") {
-        std::vector<uint8_t> in = {0xBA, 0xAD, 0xBA, 0xBA, 0xAD, 0xBA, 0xBA, 0xAD, 0xBA};
+        const std::vector<uint8_t> in = {0xBA, 0xAD, 0xBA, 0xBA, 0xAD, 0xBA, 0xBA, 0xAD, 0xBA};
 
         WHEN("it is deserialised") {
             THEN("The deserialise function throws an exception") {
@@ -322,10 +322,10 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of triv
     }
 
     GIVEN("empty serialised data") {
-        std::vector<uint8_t> in;
+        const std::vector<uint8_t> in;
 
         WHEN("it is deserialised") {
-            auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
+            const auto deserialised = NUClear::util::serialise::Serialise<TestType>::deserialise(in);
 
             THEN("The deserialised data is empty") {
                 REQUIRE(deserialised.empty());


### PR DESCRIPTION
Makes the serialisation code handle trivially copyable types.
Also fixes the iterable version as it had a buffer overflow error