### PR TITLE
Prevent spurious events from poll

### DIFF
--- a/src/extension/IOController_Posix.hpp
+++ b/src/extension/IOController_Posix.hpp
@@ -240,7 +240,7 @@ namespace extension {
             }
 
             // Locking here will ensure we won't return until poll is not running
-            std::lock_guard<std::mutex> lock(poll_mutex);
+            const std::lock_guard<std::mutex> lock(poll_mutex);
         }
 
     public:
@@ -351,7 +351,7 @@ namespace extension {
 
                     // Wait for an event to happen on one of our file descriptors
                     /* mutex scope */ {
-                        std::lock_guard<std::mutex> lock(poll_mutex);
+                        const std::lock_guard<std::mutex> lock(poll_mutex);
                         if (::poll(watches.data(), nfds_t(watches.size()), -1) < 0) {
                             throw std::system_error(
                                 network_errno,

--- a/src/extension/IOController_Posix.hpp
+++ b/src/extension/IOController_Posix.hpp
@@ -98,12 +98,13 @@ namespace extension {
             for (const auto& r : tasks) {
                 // If we are the same fd, then add our interest set and mask out events that are already being processed
                 if (r.fd == watches.back().fd) {
-                    watches.back().events =
-                        event_t((watches.back().events | r.listening_events) & ~r.processing_events);
+                    watches.back().events = event_t((watches.back().events | r.listening_events)
+                                                    & ~(r.processing_events | r.waiting_events));
                 }
                 // Otherwise add a new one and mask out events that are already being processed
                 else {
-                    watches.push_back(pollfd{r.fd, event_t(r.listening_events & ~r.processing_events), 0});
+                    watches.push_back(
+                        pollfd{r.fd, event_t(r.listening_events & ~(r.processing_events | r.waiting_events)), 0});
                 }
             }
 


### PR DESCRIPTION
It would appear that `poll()` will repeatedly return `POLLIN` provided that any call to `read()` on the `fd` will not block. This allows for the following scenario
1. New data arrives on TCP connection
2. `poll()` returns with `POLLIN` and there are `N` bytes available for reading 
3. `on<IO>` is triggered with `N > 0` number of bytes to process
4. `on<IO>` processes `N + M` bytes
5. While `on<IO>` is processing `N + M` bytes, `poll()` returns with `POLLIN` and there are `M` bytes available reading
6. `process_events` is called and sees 0 bytes available for reading (because `on<IO>` just processed the `M` newly arrived bytes)
7. `process_events` thinks EOF has been reached and flags the `fd` to be closed