### PR TITLE
Add a DSL word that runs when a specific pool or all pools are idle

### DIFF
--- a/.github/workflows/gcc.yaml
+++ b/.github/workflows/gcc.yaml
@@ -34,10 +34,6 @@ jobs:
             version: "8"
           - container: ubuntu:20.04
             version: "7"
-          - container: ubuntu:18.04
-            version: "6"
-          - container: ubuntu:18.04
-            version: "5"
 
     name: Linux GCC-${{ matrix.toolchain.version }}
     runs-on: ubuntu-latest

--- a/src/PowerPlant.cpp
+++ b/src/PowerPlant.cpp
@@ -75,6 +75,16 @@ void PowerPlant::submit(std::unique_ptr<threading::ReactionTask>&& task, const b
     }
 }
 
+void PowerPlant::add_idle_task(const NUClear::id_t& id,
+                               const util::ThreadPoolDescriptor& pool_descriptor,
+                               std::function<void()>&& task) {
+    scheduler.add_idle_task(id, pool_descriptor, std::move(task));
+}
+
+void PowerPlant::remove_idle_task(const NUClear::id_t& id, const util::ThreadPoolDescriptor& pool_descriptor) {
+    scheduler.remove_idle_task(id, pool_descriptor);
+}
+
 void PowerPlant::shutdown() {
 
     // Stop running before we emit the Shutdown event

--- a/src/PowerPlant.hpp
+++ b/src/PowerPlant.hpp
@@ -132,6 +132,32 @@ public:
     T& install(Args&&... args);
 
     /**
+     * @brief Adds an idle task to the task scheduler.
+     *
+     * This function adds an idle task to the task scheduler, which will be executed when the thread pool associated
+     * with the given `pool_id` has no other tasks to execute. The `task` parameter is a callable object that
+     * represents the idle task to be executed.
+     *
+     * @param id The ID of the task.
+     * @param pool_descriptor The descriptor for the thread pool to test for idle
+     * @param task The idle task to be executed.
+     */
+    void add_idle_task(const NUClear::id_t& id,
+                       const util::ThreadPoolDescriptor& pool_descriptor,
+                       std::function<void()>&& task);
+
+    /**
+     * @brief Removes an idle task from the task scheduler.
+     *
+     * This function removes an idle task from the task scheduler. The `id` and `pool_id` parameters are used to
+     * identify the idle task to be removed.
+     *
+     * @param id The ID of the task.
+     * @param pool_descriptor The descriptor for the thread pool to test for idle
+     */
+    void remove_idle_task(const NUClear::id_t& id, const util::ThreadPoolDescriptor& pool_descriptor);
+
+    /**
      * @brief Generic submit function for submitting tasks to the thread pool.
      *
      * @param id        an id for ordering the task

--- a/src/Reactor.hpp
+++ b/src/Reactor.hpp
@@ -54,6 +54,9 @@ namespace dsl {
 
         struct Priority;
 
+        template <typename>
+        struct Idle;
+
         struct IO;
 
         struct UDP;
@@ -190,6 +193,10 @@ protected:
     /// @copydoc dsl::word::Once
     using Once = dsl::word::Once;
 
+    /// @copydoc dsl::word::Idle
+    template <typename T = void>
+    using Idle = dsl::word::Idle<T>;
+
     /// @copydoc dsl::word::IO
     using IO = dsl::word::IO;
 
@@ -226,6 +233,14 @@ protected:
 
     /// @copydoc dsl::word::Shutdown
     using Shutdown = dsl::word::Shutdown;
+
+    /// @copydoc dsl::word::Pool
+    template <typename T>
+    using Pool = dsl::word::Pool<T>;
+
+    /// @copydoc dsl::word::Group
+    template <typename T, int I>
+    using Group = dsl::word::Group<T, I>;
 
     /// @copydoc dsl::word::Every
     template <int ticks = 0, class period = std::chrono::milliseconds>
@@ -426,6 +441,7 @@ public:
 #include "dsl/word/Every.hpp"
 #include "dsl/word/Group.hpp"
 #include "dsl/word/IO.hpp"
+#include "dsl/word/Idle.hpp"
 #include "dsl/word/Last.hpp"
 #include "dsl/word/MainThread.hpp"
 #include "dsl/word/Network.hpp"

--- a/src/Reactor.hpp
+++ b/src/Reactor.hpp
@@ -235,7 +235,7 @@ protected:
     using Shutdown = dsl::word::Shutdown;
 
     /// @copydoc dsl::word::Pool
-    template <typename T>
+    template <typename T = void>
     using Pool = dsl::word::Pool<T>;
 
     /// @copydoc dsl::word::Group

--- a/src/dsl/word/Always.hpp
+++ b/src/dsl/word/Always.hpp
@@ -81,7 +81,7 @@ namespace dsl {
                 if (pool_id.count(reaction.id) == 0) {
                     pool_id[reaction.id] = util::ThreadPoolDescriptor::get_unique_pool_id();
                 }
-                return util::ThreadPoolDescriptor{pool_id[reaction.id], 1};
+                return util::ThreadPoolDescriptor{pool_id[reaction.id], 1, false};
             }
 
             template <typename DSL>

--- a/src/dsl/word/Idle.hpp
+++ b/src/dsl/word/Idle.hpp
@@ -70,23 +70,7 @@ namespace dsl {
         struct Idle {
             template <typename DSL>
             static inline void bind(const std::shared_ptr<threading::Reaction>& reaction) {
-                bind_idle(reaction, Pool<PoolType>::template pool<DSL>(*reaction));
-            }
-        };
-
-        template <>
-        struct Idle<Pool<>> {
-            template <typename DSL>
-            static inline void bind(const std::shared_ptr<threading::Reaction>& reaction) {
-                bind_idle(reaction, Pool<>::template pool<DSL>(*reaction));
-            }
-        };
-
-        template <>
-        struct Idle<MainThread> {
-            template <typename DSL>
-            static inline void bind(const std::shared_ptr<threading::Reaction>& reaction) {
-                bind_idle(reaction, MainThread::pool<DSL>(*reaction));
+                bind_idle(reaction, PoolType::template pool<DSL>(*reaction));
             }
         };
 

--- a/src/dsl/word/Idle.hpp
+++ b/src/dsl/word/Idle.hpp
@@ -1,0 +1,70 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 NUClear Contributors
+ *
+ * This file is part of the NUClear codebase.
+ * See https://github.com/Fastcode/NUClear for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef NUCLEAR_DSL_WORD_IDLE_HPP
+#define NUCLEAR_DSL_WORD_IDLE_HPP
+
+#include <map>
+#include <mutex>
+#include <typeindex>
+
+#include "../../threading/ReactionTask.hpp"
+
+namespace NUClear {
+namespace dsl {
+    namespace word {
+
+        /**
+         * @brief Execute a task when there is nothing currently running on the thread pool.
+         *
+         * @details
+         *  @code on<Idle<PoolType>>() @endcode
+         *  When the thread pool is idle, this task will be executed. This is use
+         *
+         *
+         * @par Implements
+         *  Bind
+         *
+         * @tparam PoolType the descriptor that was used to create the thread pool
+         *         void for the default pool
+         *         MainThread for the main thread pool
+         */
+        template <typename PoolType>
+        struct Idle {
+
+            template <typename DSL>
+            static inline void bind(const std::shared_ptr<threading::Reaction>& reaction) {
+
+                // Our unbinder to remove this reaction
+                reaction->unbinders.push_back([](const threading::Reaction& r) {
+                    // TODO remove this reaction
+                });
+
+                // TODO add this to the idle task list for the pool
+            }
+        };
+
+    }  // namespace word
+}  // namespace dsl
+}  // namespace NUClear
+
+#endif  // NUCLEAR_DSL_WORD_IDLE_HPP

--- a/src/dsl/word/MainThread.hpp
+++ b/src/dsl/word/MainThread.hpp
@@ -42,7 +42,7 @@ namespace dsl {
 
             template <typename DSL>
             static inline util::ThreadPoolDescriptor pool(const threading::Reaction& /*reaction*/) {
-                return util::ThreadPoolDescriptor{util::ThreadPoolDescriptor::MAIN_THREAD_POOL_ID, 1};
+                return util::ThreadPoolDescriptor{util::ThreadPoolDescriptor::MAIN_THREAD_POOL_ID, 1, true};
             }
         };
 

--- a/src/dsl/word/Pool.hpp
+++ b/src/dsl/word/Pool.hpp
@@ -65,7 +65,7 @@ namespace dsl {
          *  };
          *  @endcode
          */
-        template <typename PoolType>
+        template <typename PoolType = void>
         struct Pool {
 
             static_assert(PoolType::thread_count > 0, "Can not have a thread pool with less than 1 thread");
@@ -84,11 +84,21 @@ namespace dsl {
             }
         };
 
+        template <>
+        struct Pool<void> {
+            template <typename DSL>
+            static inline util::ThreadPoolDescriptor pool(const threading::Reaction& /*reaction*/) {
+                return util::ThreadPoolDescriptor{};
+            }
+        };
+
         // Initialise the thread pool descriptor
         template <typename PoolType>
         const util::ThreadPoolDescriptor Pool<PoolType>::pool_descriptor = {
             util::ThreadPoolDescriptor::get_unique_pool_id(),
-            PoolType::thread_count};
+            PoolType::thread_count,
+            true,
+        };
 
     }  // namespace word
 }  // namespace dsl

--- a/src/dsl/word/Pool.hpp
+++ b/src/dsl/word/Pool.hpp
@@ -84,6 +84,7 @@ namespace dsl {
             }
         };
 
+        // When given void as the pool type we use the default thread pool
         template <>
         struct Pool<void> {
             template <typename DSL>

--- a/src/threading/TaskScheduler.cpp
+++ b/src/threading/TaskScheduler.cpp
@@ -69,8 +69,8 @@ namespace threading {
     void TaskScheduler::pool_func(std::shared_ptr<PoolQueue> pool) {
 
         // Set the thread pool for this thread so it can be accessed elsewhere
-        current_queue = &pool;
-        size_t count  = pool->pool_descriptor.counts_for_idle ? 1 : 0;
+        current_queue      = &pool;
+        const size_t count = pool->pool_descriptor.counts_for_idle ? 1 : 0;
 
         // Sum up the number of threads that are idleable
         total_idleable_threads += count;
@@ -178,7 +178,7 @@ namespace threading {
     }
 
     void TaskScheduler::PoolQueue::submit(Task&& task) {
-        std::lock_guard<std::recursive_mutex> lock(mutex);
+        const std::lock_guard<std::recursive_mutex> lock(mutex);
 
         // Insert in sorted order
         queue.insert(std::lower_bound(queue.begin(), queue.end(), task), std::move(task));
@@ -223,7 +223,7 @@ namespace threading {
                                       std::function<void()>&& task) {
 
         if (pool_descriptor.pool_id == NUClear::id_t(-1)) {
-            std::lock_guard<std::mutex> lock(pool_mutex);
+            const std::lock_guard<std::mutex> lock(pool_mutex);
             idle_tasks.emplace(id, std::move(task));
         }
         else {
@@ -239,7 +239,7 @@ namespace threading {
     void TaskScheduler::remove_idle_task(const NUClear::id_t& id, const util::ThreadPoolDescriptor& pool_descriptor) {
 
         if (pool_descriptor.pool_id == NUClear::id_t(-1)) {
-            std::lock_guard<std::mutex> lock(pool_mutex);
+            const std::lock_guard<std::mutex> lock(pool_mutex);
             if (idle_tasks.count(id) > 0) {
                 idle_tasks.erase(id);
             }

--- a/src/threading/TaskScheduler.cpp
+++ b/src/threading/TaskScheduler.cpp
@@ -290,8 +290,20 @@ namespace threading {
                         // Erase the old position in the queue
                         queue.erase(it);
 
+                        if (pool->pool_descriptor.counts_for_idle && task.checked_runnable) {
+                            ++global_runnable_tasks;
+                            ++pool->runnable_tasks;
+                        }
+
                         // Return the task
                         return task;
+                    }
+                    else if (!it->checked_runnable) {
+                        if (pool->pool_descriptor.counts_for_idle) {
+                            --global_runnable_tasks;
+                            --pool->runnable_tasks;
+                        }
+                        it->checked_runnable = true;
                     }
                 }
 

--- a/src/threading/TaskScheduler.cpp
+++ b/src/threading/TaskScheduler.cpp
@@ -298,7 +298,7 @@ namespace threading {
                         // Return the task
                         return task;
                     }
-                    else if (!it->checked_runnable) {
+                    if (!it->checked_runnable) {
                         if (pool->pool_descriptor.counts_for_idle) {
                             --global_runnable_tasks;
                             --pool->runnable_tasks;

--- a/src/threading/TaskScheduler.hpp
+++ b/src/threading/TaskScheduler.hpp
@@ -103,6 +103,8 @@ namespace threading {
             util::ThreadPoolDescriptor thread_pool_descriptor;
             /// @brief The callback to be executed
             std::function<void()> run;
+            /// @brief If task has been checked for runnable
+            bool checked_runnable{false};
 
             /**
              * @brief Compare tasks based on their priority

--- a/src/threading/TaskScheduler.hpp
+++ b/src/threading/TaskScheduler.hpp
@@ -129,9 +129,9 @@ namespace threading {
             /// @brief The queue of tasks for this specific thread pool
             std::vector<Task> queue;
             /// @brief The mutex which protects the queue
-            std::mutex mutex;
+            std::recursive_mutex mutex;
             /// @brief The condition variable which threads wait on if they can't get a task
-            std::condition_variable condition;
+            std::condition_variable_any condition;
             /// @brief The map of idle tasks for this thread pool
             std::map<NUClear::id_t, std::function<void()>> idle_tasks;
 

--- a/src/threading/TaskScheduler.hpp
+++ b/src/threading/TaskScheduler.hpp
@@ -124,7 +124,9 @@ namespace threading {
             const util::ThreadPoolDescriptor pool_descriptor;
             /// @brief The threads which are running in this thread pool
             std::vector<std::unique_ptr<std::thread>> threads;
-            /// @brief The number of threads currently waiting for a task
+            /// @brief The number of threads which are currently running
+            size_t n_threads{0};
+            /// @brief The number of currently active threads
             size_t idle_threads{0};
             /// @brief The queue of tasks for this specific thread pool
             std::vector<Task> queue;

--- a/src/threading/TaskScheduler.hpp
+++ b/src/threading/TaskScheduler.hpp
@@ -195,10 +195,12 @@ namespace threading {
          * represents the idle task to be executed.
          *
          * @param id The ID of the task.
-         * @param pool_id The ID of the thread pool to which the task belongs.
+         * @param pool_descriptor The descriptor for the thread pool to test for idle
          * @param task The idle task to be executed.
          */
-        void add_idle_task(const NUClear::id_t& id, const id_t& pool_id, std::function<void()>&& task);
+        void add_idle_task(const NUClear::id_t& id,
+                           const util::ThreadPoolDescriptor& pool_descriptor,
+                           std::function<void()>&& task);
 
         /**
          * @brief Removes an idle task from the task scheduler.
@@ -206,10 +208,10 @@ namespace threading {
          * This function removes an idle task from the task scheduler. The `id` and `pool_id` parameters are used to
          * identify the idle task to be removed.
          *
-         * @param id The ID of the task.
-         * @param pool_id The ID of the thread pool to which the task belongs.
+         * @param id The ID of the task
+         * @param pool_descriptor The descriptor for the thread pool to test for idle
          */
-        void remove_idle_task(const NUClear::id_t& id, const id_t& pool_id);
+        void remove_idle_task(const NUClear::id_t& id, const util::ThreadPoolDescriptor& pool_descriptor);
 
     private:
         /**
@@ -281,6 +283,13 @@ namespace threading {
         std::map<NUClear::id_t, size_t> groups{};
         /// @brief mutex for the group map
         std::mutex group_mutex;
+
+        /// @brief global idle tasks to be executed when no other tasks are running
+        std::map<NUClear::id_t, std::function<void()>> idle_tasks{};
+        /// @brief the total number of threads that can be counted as idle
+        std::atomic<size_t> total_idleable_threads{0};
+        /// @brief the number of global idle threads
+        std::atomic<size_t> idle_threads{0};
 
         /// @brief A map of pool descriptor ids to pool descriptors
         std::map<NUClear::id_t, std::shared_ptr<PoolQueue>> pool_queues{};

--- a/src/threading/TaskScheduler.hpp
+++ b/src/threading/TaskScheduler.hpp
@@ -103,6 +103,8 @@ namespace threading {
             util::ThreadPoolDescriptor thread_pool_descriptor;
             /// @brief The callback to be executed
             std::function<void()> run;
+            /// @brief If task has been checked for runnable
+            bool checked_runnable{false};
 
             /**
              * @brief Compare tasks based on their priority
@@ -286,10 +288,12 @@ namespace threading {
         /// @brief mutex for the group map
         std::mutex group_mutex;
 
+        /// @brief mutex for the idle tasks
+        std::mutex idle_mutex;
         /// @brief global idle tasks to be executed when no other tasks are running
         std::map<NUClear::id_t, std::function<void()>> idle_tasks{};
         /// @brief the total number of threads that can be counted as idle
-        std::atomic<size_t> total_idleable_threads{0};
+        std::atomic<size_t> total_runnable_tasks{0};
         /// @brief the number of global idle threads
         std::atomic<size_t> idle_threads{0};
 

--- a/src/threading/TaskScheduler.hpp
+++ b/src/threading/TaskScheduler.hpp
@@ -132,7 +132,14 @@ namespace threading {
             std::mutex mutex;
             /// @brief The condition variable which threads wait on if they can't get a task
             std::condition_variable condition;
+            /// @brief The map of idle tasks for this thread pool
+            std::map<NUClear::id_t, std::function<void()>> idle_tasks;
 
+            /**
+             * @brief Submit a new task to this thread pool
+             *
+             * @param task the task to submit
+             */
             void submit(Task&& task);
         };
 
@@ -179,6 +186,30 @@ namespace threading {
                     const util::ThreadPoolDescriptor& pool,
                     const bool& immediate,
                     std::function<void()>&& func);
+
+        /**
+         * @brief Adds an idle task to the task scheduler.
+         *
+         * This function adds an idle task to the task scheduler, which will be executed when the thread pool associated
+         * with the given `pool_id` has no other tasks to execute. The `task` parameter is a callable object that
+         * represents the idle task to be executed.
+         *
+         * @param id The ID of the task.
+         * @param pool_id The ID of the thread pool to which the task belongs.
+         * @param task The idle task to be executed.
+         */
+        void add_idle_task(const NUClear::id_t& id, const id_t& pool_id, std::function<void()>&& task);
+
+        /**
+         * @brief Removes an idle task from the task scheduler.
+         *
+         * This function removes an idle task from the task scheduler. The `id` and `pool_id` parameters are used to
+         * identify the idle task to be removed.
+         *
+         * @param id The ID of the task.
+         * @param pool_id The ID of the thread pool to which the task belongs.
+         */
+        void remove_idle_task(const NUClear::id_t& id, const id_t& pool_id);
 
     private:
         /**

--- a/src/threading/TaskScheduler.hpp
+++ b/src/threading/TaskScheduler.hpp
@@ -103,8 +103,6 @@ namespace threading {
             util::ThreadPoolDescriptor thread_pool_descriptor;
             /// @brief The callback to be executed
             std::function<void()> run;
-            /// @brief If task has been checked for runnable
-            bool checked_runnable{false};
 
             /**
              * @brief Compare tasks based on their priority
@@ -126,10 +124,8 @@ namespace threading {
             const util::ThreadPoolDescriptor pool_descriptor;
             /// @brief The threads which are running in this thread pool
             std::vector<std::unique_ptr<std::thread>> threads;
-            /// @brief The number of threads which are currently running
-            size_t n_threads{0};
-            /// @brief The number of currently active threads
-            size_t idle_threads{0};
+            /// @brief The number of runnable tasks in this thread pool
+            size_t runnable_tasks{0};
             /// @brief The queue of tasks for this specific thread pool
             std::vector<Task> queue;
             /// @brief The mutex which protects the queue
@@ -292,10 +288,8 @@ namespace threading {
         std::mutex idle_mutex;
         /// @brief global idle tasks to be executed when no other tasks are running
         std::map<NUClear::id_t, std::function<void()>> idle_tasks{};
-        /// @brief the total number of threads that can be counted as idle
-        std::atomic<size_t> total_runnable_tasks{0};
-        /// @brief the number of global idle threads
-        std::atomic<size_t> idle_threads{0};
+        /// @brief the total number of threads that have runnable tasks
+        std::atomic<size_t> global_runnable_tasks{0};
 
         /// @brief A map of pool descriptor ids to pool descriptors
         std::map<NUClear::id_t, std::shared_ptr<PoolQueue>> pool_queues{};

--- a/src/threading/TaskScheduler.hpp
+++ b/src/threading/TaskScheduler.hpp
@@ -124,12 +124,16 @@ namespace threading {
             const util::ThreadPoolDescriptor pool_descriptor;
             /// @brief The threads which are running in this thread pool
             std::vector<std::unique_ptr<std::thread>> threads;
+            /// @brief The number of threads currently waiting for a task
+            size_t idle_threads{0};
             /// @brief The queue of tasks for this specific thread pool
             std::vector<Task> queue;
             /// @brief The mutex which protects the queue
             std::mutex mutex;
             /// @brief The condition variable which threads wait on if they can't get a task
             std::condition_variable condition;
+
+            void submit(Task&& task);
         };
 
     public:

--- a/src/util/GeneratedCallback.hpp
+++ b/src/util/GeneratedCallback.hpp
@@ -47,7 +47,7 @@ namespace util {
         /// @brief the descriptor for the group the task should run in
         GroupDescriptor group{0, std::numeric_limits<size_t>::max()};
         /// @brief the descriptor the thread pool and task queue that the should run in
-        ThreadPoolDescriptor pool{util::ThreadPoolDescriptor::DEFAULT_THREAD_POOL_ID, 0};
+        ThreadPoolDescriptor pool{util::ThreadPoolDescriptor::DEFAULT_THREAD_POOL_ID, 0, true};
         /// @brief the function that should be executed in order to run the task
         threading::ReactionTask::TaskFunction callback{};
 

--- a/src/util/ThreadPoolDescriptor.hpp
+++ b/src/util/ThreadPoolDescriptor.hpp
@@ -36,11 +36,21 @@ namespace util {
      * @brief A description of a thread pool
      */
     struct ThreadPoolDescriptor {
+        ThreadPoolDescriptor() = default;
+        ThreadPoolDescriptor(const NUClear::id_t& pool_id, size_t thread_count, bool counts_for_idle)
+            : pool_id(pool_id), thread_count(thread_count), counts_for_idle(counts_for_idle) {}
+
+        static ThreadPoolDescriptor AllPools() {
+            return ThreadPoolDescriptor(NUClear::id_t(-1), size_t(-1), false);
+        }
+
         /// @brief a unique identifier for this pool
         NUClear::id_t pool_id{ThreadPoolDescriptor::DEFAULT_THREAD_POOL_ID};
 
         /// @brief the number of threads this thread pool will use
         size_t thread_count{0};
+        /// @brief if these threads count towards system idle
+        bool counts_for_idle{true};
 
         /// @brief the ID of the main thread pool (not to be confused with the ID of the main thread)
         static const NUClear::id_t MAIN_THREAD_POOL_ID;

--- a/src/util/ThreadPoolDescriptor.hpp
+++ b/src/util/ThreadPoolDescriptor.hpp
@@ -41,7 +41,7 @@ namespace util {
             : pool_id(pool_id), thread_count(thread_count), counts_for_idle(counts_for_idle) {}
 
         static ThreadPoolDescriptor AllPools() {
-            return ThreadPoolDescriptor(NUClear::id_t(-1), size_t(-1), false);
+            return ThreadPoolDescriptor{NUClear::id_t(-1), size_t(-1), false};
         }
 
         /// @brief a unique identifier for this pool

--- a/tests/dsl/Idle.cpp
+++ b/tests/dsl/Idle.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUClear Contributors
+ * Copyright (c) 2024 NUClear Contributors
  *
  * This file is part of the NUClear codebase.
  * See https://github.com/Fastcode/NUClear for further info.
@@ -123,34 +123,12 @@ TEST_CASE("Test that pool idle triggers when nothing is running", "[api][idle]")
     plant.start();
 
     const std::vector<std::string> expected = {
-        "Default Startup 1",
-        "Default Step 2",
-        "Default Step 3",
-        "Default Idle 4",
-        "Default Step 5",
-        "Default Step 6",
-        "Default Step 7",
-        "Main Startup 9",
-        "Main Step 10",
-        "Main Step 11",
-        "Main Idle 12",
-        "Main Step 13",
-        "Main Step 14",
-        "Main Step 15",
-        "Custom<1> Startup 17",
-        "Custom<1> Step 18",
-        "Custom<1> Step 19",
-        "Custom<1> Idle 20",
-        "Custom<1> Step 21",
-        "Custom<1> Step 22",
-        "Custom<1> Step 23",
-        "Custom<2> Startup 25",
-        "Custom<2> Step 26",
-        "Custom<2> Step 27",
-        "Global Idle 28",
-        "Custom<2> Step 29",
-        "Custom<2> Step 30",
-        "Custom<2> Step 31",
+        "Default Startup 1", "Default Step 2",       "Default Step 3",    "Default Idle 4",    "Default Step 5",
+        "Default Step 6",    "Default Step 7",       "Main Startup 9",    "Main Step 10",      "Main Step 11",
+        "Main Idle 12",      "Main Step 13",         "Main Step 14",      "Main Step 15",      "Custom<1> Startup 17",
+        "Custom<1> Step 18", "Custom<1> Step 19",    "Custom<1> Idle 20", "Custom<1> Step 21", "Custom<1> Step 22",
+        "Custom<1> Step 23", "Custom<2> Startup 25", "Custom<2> Step 26", "Custom<2> Step 27", "Global Idle 28",
+        "Custom<2> Step 29", "Custom<2> Step 30",    "Custom<2> Step 31",
     };
 
     // Make an info print the diff in an easy to read way if we fail

--- a/tests/dsl/Idle.cpp
+++ b/tests/dsl/Idle.cpp
@@ -63,6 +63,10 @@ public:
             events.push_back("Idle");
             emit(std::make_unique<Step<5>>());
         });
+        on<Idle<Pool<>>>().then([this] {  //
+            events.push_back("Idle Pool");
+            emit(std::make_unique<Step<6>>());
+        });
         on<Trigger<Step<5>>>().then([this] {
             events.push_back("Step 5");
             std::this_thread::sleep_for(std::chrono::milliseconds(50));

--- a/tests/dsl/Idle.cpp
+++ b/tests/dsl/Idle.cpp
@@ -73,32 +73,33 @@ public:
         on<Trigger<Step<13>>, MainThread>().then([this] { do_step<13>("Main Step"); });
         on<Trigger<Step<14>>, MainThread>().then([this] { do_step<14>("Main Step"); });
         on<Trigger<Step<15>>, MainThread>().then([this] { do_step<15>("Main Step"); });
-        on<Trigger<Step<15>>, MainThread>().then([this] { mrh.unbind(); });
+        on<Trigger<Step<16>>, MainThread>().then([this] { mrh.unbind(); });
 
         // Idle testing for custom pool
-        on<Trigger<Step<16>>, Pool<CustomPool<1>>>().then([this] { do_step<16>("Custom Startup"); });
-        on<Trigger<Step<17>>, Pool<CustomPool<1>>>().then([this] { do_step<17>("Custom Step"); });
-        on<Trigger<Step<18>>, Pool<CustomPool<1>>>().then([this] { do_step<18>("Custom Step"); });
-        crh = on<Idle<Pool<CustomPool<1>>>>().then([this] { do_step<19>("Custom Idle"); });
-        on<Trigger<Step<20>>, Pool<CustomPool<1>>>().then([this] { do_step<20>("Custom Step"); });
-        on<Trigger<Step<21>>, Pool<CustomPool<1>>>().then([this] { do_step<21>("Custom Step"); });
-        on<Trigger<Step<22>>, Pool<CustomPool<1>>>().then([this] { do_step<22>("Custom Step"); });
-        on<Trigger<Step<23>>, Pool<CustomPool<1>>>().then([this] { crh.unbind(); });
+        on<Trigger<Step<17>>, Pool<CustomPool<1>>>().then([this] { do_step<17>("Custom<1> Startup"); });
+        on<Trigger<Step<18>>, Pool<CustomPool<1>>>().then([this] { do_step<18>("Custom<1> Step"); });
+        on<Trigger<Step<19>>, Pool<CustomPool<1>>>().then([this] { do_step<19>("Custom<1> Step"); });
+        crh = on<Idle<Pool<CustomPool<1>>>>().then([this] { do_step<20>("Custom<1> Idle"); });
+        on<Trigger<Step<21>>, Pool<CustomPool<1>>>().then([this] { do_step<21>("Custom<1> Step"); });
+        on<Trigger<Step<22>>, Pool<CustomPool<1>>>().then([this] { do_step<22>("Custom<1> Step"); });
+        on<Trigger<Step<23>>, Pool<CustomPool<1>>>().then([this] { do_step<23>("Custom<1> Step"); });
+        on<Trigger<Step<24>>, Pool<CustomPool<1>>>().then([this] { crh.unbind(); });
 
         // Idle testing for global
-        on<Trigger<Step<24>>, Pool<CustomPool<2>>>().then([this] { do_step<24>("Custom<2> Startup"); });
-        on<Trigger<Step<25>>, Pool<CustomPool<2>>>().then([this] { do_step<25>("Custom<2> Step"); });
+        on<Trigger<Step<25>>, Pool<CustomPool<2>>>().then([this] { do_step<25>("Custom<2> Startup"); });
         on<Trigger<Step<26>>, Pool<CustomPool<2>>>().then([this] { do_step<26>("Custom<2> Step"); });
-        crh = on<Idle<>>().then([this] { do_step<27>("Global Idle"); });
-        on<Trigger<Step<28>>, Pool<CustomPool<2>>>().then([this] { do_step<28>("Custom<2> Step"); });
+        on<Trigger<Step<27>>, Pool<CustomPool<2>>>().then([this] { do_step<27>("Custom<2> Step"); });
+        grh = on<Idle<>>().then([this] { do_step<28>("Global Idle"); });
         on<Trigger<Step<29>>, Pool<CustomPool<2>>>().then([this] { do_step<29>("Custom<2> Step"); });
         on<Trigger<Step<30>>, Pool<CustomPool<2>>>().then([this] { do_step<30>("Custom<2> Step"); });
-        on<Trigger<Step<31>>, Pool<CustomPool<2>>>().then([this] { powerplant.shutdown(); });
+        on<Trigger<Step<31>>, Pool<CustomPool<2>>>().then([this] { do_step<31>("Custom<2> Step"); });
+        on<Trigger<Step<32>>, Pool<CustomPool<2>>>().then([this] { powerplant.shutdown(); });
 
         on<Startup>().then([this] {
             emit(std::make_unique<Step<1>>());
             emit(std::make_unique<Step<9>>());
-            emit(std::make_unique<Step<16>>());
+            emit(std::make_unique<Step<17>>());
+            emit(std::make_unique<Step<25>>());
         });
     }
 
@@ -107,6 +108,7 @@ private:
     NUClear::threading::ReactionHandle drh;
     NUClear::threading::ReactionHandle mrh;
     NUClear::threading::ReactionHandle crh;
+    NUClear::threading::ReactionHandle grh;
 };
 
 }  // namespace
@@ -121,14 +123,34 @@ TEST_CASE("Test that pool idle triggers when nothing is running", "[api][idle]")
     plant.start();
 
     const std::vector<std::string> expected = {
-        "Startup 0",
-        "Step 1",
-        "Step 2",
-        "Step 3",
-        "Global Idle 4",
-        "Step 5",
-        "Step 6",
-        "Step 7",
+        "Default Startup 1",
+        "Default Step 2",
+        "Default Step 3",
+        "Default Idle 4",
+        "Default Step 5",
+        "Default Step 6",
+        "Default Step 7",
+        "Main Startup 9",
+        "Main Step 10",
+        "Main Step 11",
+        "Main Idle 12",
+        "Main Step 13",
+        "Main Step 14",
+        "Main Step 15",
+        "Custom<1> Startup 17",
+        "Custom<1> Step 18",
+        "Custom<1> Step 19",
+        "Custom<1> Idle 20",
+        "Custom<1> Step 21",
+        "Custom<1> Step 22",
+        "Custom<1> Step 23",
+        "Custom<2> Startup 25",
+        "Custom<2> Step 26",
+        "Custom<2> Step 27",
+        "Global Idle 28",
+        "Custom<2> Step 29",
+        "Custom<2> Step 30",
+        "Custom<2> Step 31",
     };
 
     // Make an info print the diff in an easy to read way if we fail

--- a/tests/dsl/Idle.cpp
+++ b/tests/dsl/Idle.cpp
@@ -53,7 +53,7 @@ public:
         on<Idle<>>().then([this] { do_step<4>("Global Idle"); });
         on<Trigger<Step<5>>>().then([this] { do_step<5>("Step"); });
         on<Trigger<Step<6>>>().then([this] { do_step<6>("Step"); });
-        on<Trigger<Step<6>>>().then([this] { do_step<7>("Step"); });
+        on<Trigger<Step<7>>>().then([this] { do_step<7>("Step"); });
 
         on<Trigger<Step<8>>>().then([this] { powerplant.shutdown(); });
     }
@@ -71,16 +71,14 @@ TEST_CASE("Test that pool idle triggers when nothing is running", "[api][idle]")
     plant.start();
 
     const std::vector<std::string> expected = {
-        "Trigger 0",
-        "Trigger 1",
-        "Trigger 2",
-        "Trigger 3",
-        "Trigger 4",
-        "Trigger 5",
-        "Trigger 6",
-        "Trigger 7",
-        "Trigger 8",
-        "Trigger 9",
+        "Startup 0",
+        "Step 1",
+        "Step 2",
+        "Step 3",
+        "Global Idle 4",
+        "Step 5",
+        "Step 6",
+        "Step 7",
     };
 
     // Make an info print the diff in an easy to read way if we fail

--- a/tests/dsl/Idle.cpp
+++ b/tests/dsl/Idle.cpp
@@ -35,10 +35,11 @@ struct SimpleMessage {
     int data;
 };
 
-constexpr int time_step = 100;
+constexpr int time_step = 50;
 
 class TestReactor : public test_util::TestBase<TestReactor, 10000> {
 public:
+    template <int N>
     struct CustomPool {
         static constexpr int thread_count = 2;
     };
@@ -75,20 +76,24 @@ public:
         on<Trigger<Step<15>>, MainThread>().then([this] { mrh.unbind(); });
 
         // Idle testing for custom pool
-        on<Trigger<Step<16>>, Pool<CustomPool>>().then([this] { do_step<16>("Custom Startup"); });
-        on<Trigger<Step<17>>, Pool<CustomPool>>().then([this] { do_step<17>("Custom Step"); });
-        on<Trigger<Step<18>>, Pool<CustomPool>>().then([this] { do_step<18>("Custom Step"); });
-        crh = on<Idle<Pool<CustomPool>>>().then([this] { do_step<19>("Custom Idle"); });
-        on<Trigger<Step<20>>, Pool<CustomPool>>().then([this] { do_step<20>("Custom Step"); });
-        on<Trigger<Step<21>>, Pool<CustomPool>>().then([this] { do_step<21>("Custom Step"); });
-        on<Trigger<Step<22>>, Pool<CustomPool>>().then([this] { do_step<22>("Custom Step"); });
-        on<Trigger<Step<23>>, Pool<CustomPool>>().then([this] { crh.unbind(); });
+        on<Trigger<Step<16>>, Pool<CustomPool<1>>>().then([this] { do_step<16>("Custom Startup"); });
+        on<Trigger<Step<17>>, Pool<CustomPool<1>>>().then([this] { do_step<17>("Custom Step"); });
+        on<Trigger<Step<18>>, Pool<CustomPool<1>>>().then([this] { do_step<18>("Custom Step"); });
+        crh = on<Idle<Pool<CustomPool<1>>>>().then([this] { do_step<19>("Custom Idle"); });
+        on<Trigger<Step<20>>, Pool<CustomPool<1>>>().then([this] { do_step<20>("Custom Step"); });
+        on<Trigger<Step<21>>, Pool<CustomPool<1>>>().then([this] { do_step<21>("Custom Step"); });
+        on<Trigger<Step<22>>, Pool<CustomPool<1>>>().then([this] { do_step<22>("Custom Step"); });
+        on<Trigger<Step<23>>, Pool<CustomPool<1>>>().then([this] { crh.unbind(); });
 
-        // Global idle everything finished
-        on<Idle<>>().then([this] {
-            events.push_back("Global Idle");
-            powerplant.shutdown();
-        });
+        // Idle testing for global
+        on<Trigger<Step<24>>, Pool<CustomPool<2>>>().then([this] { do_step<24>("Custom<2> Startup"); });
+        on<Trigger<Step<25>>, Pool<CustomPool<2>>>().then([this] { do_step<25>("Custom<2> Step"); });
+        on<Trigger<Step<26>>, Pool<CustomPool<2>>>().then([this] { do_step<26>("Custom<2> Step"); });
+        crh = on<Idle<>>().then([this] { do_step<27>("Global Idle"); });
+        on<Trigger<Step<28>>, Pool<CustomPool<2>>>().then([this] { do_step<28>("Custom<2> Step"); });
+        on<Trigger<Step<29>>, Pool<CustomPool<2>>>().then([this] { do_step<29>("Custom<2> Step"); });
+        on<Trigger<Step<30>>, Pool<CustomPool<2>>>().then([this] { do_step<30>("Custom<2> Step"); });
+        on<Trigger<Step<31>>, Pool<CustomPool<2>>>().then([this] { powerplant.shutdown(); });
 
         on<Startup>().then([this] {
             emit(std::make_unique<Step<1>>());

--- a/tests/dsl/IdleSync.cpp
+++ b/tests/dsl/IdleSync.cpp
@@ -1,0 +1,78 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2013 NUClear Contributors
+ *
+ * This file is part of the NUClear codebase.
+ * See https://github.com/Fastcode/NUClear for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <catch.hpp>
+#include <nuclear>
+
+#include "test_util/TestBase.hpp"
+
+namespace {
+
+/// @brief A vector of events that have happened
+std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+class TestReactor : public test_util::TestBase<TestReactor, 1000> {
+public:
+    TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment), false) {
+
+        // Idle testing for default thread
+        on<Trigger<Step<1>>, Sync<TestReactor>>().then([this] {
+            events.push_back("Step 1 Start");
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            events.push_back("Step 1 End");
+        });
+        on<Trigger<Step<2>>, Sync<TestReactor>, MainThread>().then([this] { events.push_back("Step 2"); });
+        on<Idle<MainThread>>().then([this] {
+            events.push_back("Idle Main Thread");
+            powerplant.shutdown();
+        });
+
+        on<Startup>().then([this] {
+            emit(std::make_unique<Step<1>>());
+            emit(std::make_unique<Step<2>>());
+        });
+    }
+};
+
+}  // namespace
+
+TEST_CASE("Test that pool idle triggers when a waiting task prevents running", "[api][idle]") {
+
+    NUClear::Configuration config;
+    config.thread_count = 4;
+    NUClear::PowerPlant plant(config);
+    plant.install<TestReactor>();
+    plant.start();
+
+    const std::vector<std::string> expected = {
+        "Step 1 Start",
+        "Idle Main Thread",
+        "Step 1 End",
+        "Step 2",
+    };
+
+    // Make an info print the diff in an easy to read way if we fail
+    INFO(test_util::diff_string(expected, events));
+
+    // Check the events fired in order and only those events
+    REQUIRE(events == expected);
+}

--- a/tests/dsl/IdleSync.cpp
+++ b/tests/dsl/IdleSync.cpp
@@ -41,7 +41,7 @@ public:
         });
 
         // Idle testing for default thread
-        on<Trigger<Step<2>>, Sync<TestReactor>>().then([this] {
+        on<Trigger<Step<2>>, Sync<TestReactor>>().then([] {
             events.push_back("Default Start");
             std::this_thread::sleep_for(std::chrono::milliseconds(300));
             events.push_back("Default End");

--- a/tests/dsl/IdleSync.cpp
+++ b/tests/dsl/IdleSync.cpp
@@ -54,7 +54,6 @@ public:
             powerplant.shutdown();
         });
 
-
         on<Startup>().then([this] { emit(std::make_unique<Step<1>>()); });
     }
 };

--- a/tests/dsl/IdleSync.cpp
+++ b/tests/dsl/IdleSync.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUClear Contributors
+ * Copyright (c) 2024 NUClear Contributors
  *
  * This file is part of the NUClear codebase.
  * See https://github.com/Fastcode/NUClear for further info.
@@ -35,12 +35,12 @@ public:
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment), false) {
 
         // Idle testing for default thread
-        on<Trigger<Step<1>>, Sync<TestReactor>>().then([this] {
+        on<Trigger<Step<1>>, Sync<TestReactor>>().then([] {
             events.push_back("Step 1 Start");
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
             events.push_back("Step 1 End");
         });
-        on<Trigger<Step<2>>, Sync<TestReactor>, MainThread>().then([this] { events.push_back("Step 2"); });
+        on<Trigger<Step<2>>, Sync<TestReactor>, MainThread>().then([] { events.push_back("Step 2"); });
         on<Idle<MainThread>>().then([this] {
             events.push_back("Idle Main Thread");
             powerplant.shutdown();

--- a/tests/dsl/MainThread.cpp
+++ b/tests/dsl/MainThread.cpp
@@ -35,7 +35,7 @@ struct MessageB {};
 
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
-    TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment), false) {
+    TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment)) {
 
         // Run a task without MainThread to make sure it isn't on the main thread
         on<Trigger<MessageA>>().then("Non-MainThread reaction", [this] {

--- a/tests/dsl/Sync.cpp
+++ b/tests/dsl/Sync.cpp
@@ -38,7 +38,7 @@ struct Message {
 
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
-    TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment), false) {
+    TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment)) {
 
         on<Trigger<Message<0>>, Sync<TestReactor>>().then([this](const Message<0>& m) {
             events.push_back("Sync A " + m.data);

--- a/tests/test_util/TestBase.hpp
+++ b/tests/test_util/TestBase.hpp
@@ -53,12 +53,9 @@ public:
         : Reactor(std::move(environment)) {
 
         // Shutdown if the system is idle
-        on<Trigger<ShutdownOnIdle>, Priority::IDLE>().then([this] { powerplant.shutdown(); });
-        on<Startup>().then([this, shutdown_on_idle] {
-            if (shutdown_on_idle) {
-                emit(std::make_unique<ShutdownOnIdle>());
-            }
-        });
+        if (shutdown_on_idle) {
+            on<Idle<>>().then([this] { powerplant.shutdown(); });
+        }
 
         // Timeout if the test doesn't complete in time
         on<Watchdog<BaseClass, timeout, std::chrono::milliseconds>, MainThread>().then([this] {


### PR DESCRIPTION
Adds a new DSL word Idle that can be used to execute a reaction when the pool does not have a current task.

There are 4 main variants that this implements

```cpp
on<Idle<>>
```

Will execute when all non always threads are idle

```cpp
on<Idle<Pool<>>
```

Will execute when the default thread pool is idle

```cpp
on<Idle<MainThread>>
```

Will execute when the main thread's pool is idle

```cpp
on<Idle<SomePoolDescriptor>>
```

Will execute when that specific pool is idle

- [x] Fix up the deadlock caused by the recursive mutex acquisition