### PR TITLE
Fix an error where time travelling with no chrono tasks would cause a segmentation fault

### DIFF
--- a/src/extension/ChronoController.hpp
+++ b/src/extension/ChronoController.hpp
@@ -116,7 +116,7 @@ namespace extension {
 
                     } break;
                     case message::TimeTravel::Action::NEAREST: {
-                        clock::time_point nearest =
+                        const clock::time_point nearest =
                             tasks.empty() ? travel.target
                                           : std::min(travel.target, std::min_element(tasks.begin(), tasks.end())->time);
                         clock::set_clock(nearest, travel.rtf);

--- a/src/extension/ChronoController.hpp
+++ b/src/extension/ChronoController.hpp
@@ -116,11 +116,10 @@ namespace extension {
 
                     } break;
                     case message::TimeTravel::Action::NEAREST: {
-                        auto next_task =
-                            std::min_element(tasks.begin(), tasks.end(), [](const ChronoTask& a, const ChronoTask& b) {
-                                return a.time < b.time;
-                            });
-                        clock::set_clock(std::min(next_task->time, travel.target), travel.rtf);
+                        clock::time_point nearest =
+                            tasks.empty() ? travel.target
+                                          : std::min(travel.target, std::min_element(tasks.begin(), tasks.end())->time);
+                        clock::set_clock(nearest, travel.rtf);
                     } break;
                 }
 


### PR DESCRIPTION
When time travelling in NEAREST mode with no chrono tasks, the code would try to dereference an empty list. Fix this to ensure it works when no chrono tasks are present