### PR TITLE
Connect vscode to SonarCloud

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,9 @@
   "C_Cpp.preferredPathSeparator": "Forward Slash",
   "editor.rulers": [120],
   "cmake.configureOnOpen": true,
-  "C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools"
+  "C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+  "sonarlint.connectedMode.project": {
+    "connectionId": "fastcode",
+    "projectKey": "Fastcode_NUClear"
+  }
 }


### PR DESCRIPTION
Sets up the connection between SonarCloud and VSCode so that it can display warnings in the IDE