### PR TITLE
Change how extensions and task generation works to always be a task

### DIFF
--- a/src/PowerPlant.cpp
+++ b/src/PowerPlant.cpp
@@ -112,13 +112,13 @@ void PowerPlant::submit(std::unique_ptr<threading::ReactionTask>&& task, const b
     if (task) {
         try {
             const std::shared_ptr<threading::ReactionTask> t(std::move(task));
-            submit(t->id, t->priority, t->group_descriptor, t->thread_pool_descriptor, immediate, [t]() { t->run(); });
+            submit(t->id, t->priority, t->group_descriptor, t->pool_descriptor, immediate, [t]() { t->run(); });
         }
         catch (const std::exception& ex) {
-            task->parent.reactor.log<NUClear::ERROR>("There was an exception while submitting a reaction", ex.what());
+            task->parent->reactor.log<NUClear::ERROR>("There was an exception while submitting a reaction", ex.what());
         }
         catch (...) {
-            task->parent.reactor.log<NUClear::ERROR>("There was an unknown exception while submitting a reaction");
+            task->parent->reactor.log<NUClear::ERROR>("There was an unknown exception while submitting a reaction");
         }
     }
 }
@@ -130,7 +130,7 @@ void PowerPlant::log(const LogLevel& level, std::string message) {
     // Direct emit the log message so that any direct loggers can use it
     emit<dsl::word::emit::Direct>(std::make_unique<message::LogMessage>(
         level,
-        current_task != nullptr ? current_task->parent.reactor.log_level : LogLevel::UNKNOWN,
+        current_task != nullptr ? current_task->parent->reactor.log_level : LogLevel::UNKNOWN,
         std::move(message),
         current_task != nullptr ? current_task->stats : nullptr));
 }

--- a/src/PowerPlant.cpp
+++ b/src/PowerPlant.cpp
@@ -30,6 +30,9 @@
 #include "dsl/word/Shutdown.hpp"
 #include "dsl/word/Startup.hpp"
 #include "dsl/word/emit/Direct.hpp"
+#include "extension/ChronoController.hpp"
+#include "extension/IOController.hpp"
+#include "extension/NetworkController.hpp"
 #include "message/CommandLineArguments.hpp"
 #include "message/LogMessage.hpp"
 #include "threading/ReactionTask.hpp"
@@ -54,6 +57,11 @@ PowerPlant::PowerPlant(Configuration config, int argc, const char* argv[]) : sch
 
     // Store our static variable
     powerplant = this;
+
+    // Install the extension controllers
+    install<extension::ChronoController>();
+    install<extension::IOController>();
+    install<extension::NetworkController>();
 
     // Emit our arguments if any.
     message::CommandLineArguments args;

--- a/src/dsl/Parse.hpp
+++ b/src/dsl/Parse.hpp
@@ -40,36 +40,36 @@ namespace dsl {
             return DSL::template bind<Parse<Sentence...>>(r, std::forward<Arguments>(args)...);
         }
 
-        static auto get(threading::Reaction& r)
+        static auto get(threading::ReactionTask& task)
             -> decltype(std::conditional_t<fusion::has_get<DSL>::value, DSL, fusion::NoOp>::template get<
-                        Parse<Sentence...>>(r)) {
+                        Parse<Sentence...>>(task)) {
             return std::conditional_t<fusion::has_get<DSL>::value, DSL, fusion::NoOp>::template get<Parse<Sentence...>>(
-                r);
+                task);
         }
 
-        static bool precondition(threading::Reaction& r) {
+        static bool precondition(threading::ReactionTask& task) {
             return std::conditional_t<fusion::has_precondition<DSL>::value, DSL, fusion::NoOp>::template precondition<
-                Parse<Sentence...>>(r);
+                Parse<Sentence...>>(task);
         }
 
-        static int priority(threading::Reaction& r) {
+        static int priority(threading::ReactionTask& task) {
             return std::conditional_t<fusion::has_priority<DSL>::value, DSL, fusion::NoOp>::template priority<
-                Parse<Sentence...>>(r);
+                Parse<Sentence...>>(task);
         }
 
-        static util::GroupDescriptor group(threading::Reaction& r) {
+        static util::GroupDescriptor group(threading::ReactionTask& task) {
             return std::conditional_t<fusion::has_group<DSL>::value, DSL, fusion::NoOp>::template group<
-                Parse<Sentence...>>(r);
+                Parse<Sentence...>>(task);
         }
 
-        static util::ThreadPoolDescriptor pool(threading::Reaction& r) {
+        static util::ThreadPoolDescriptor pool(threading::ReactionTask& task) {
             return std::conditional_t<fusion::has_pool<DSL>::value, DSL, fusion::NoOp>::template pool<
-                Parse<Sentence...>>(r);
+                Parse<Sentence...>>(task);
         }
 
-        static void postcondition(threading::ReactionTask& r) {
+        static void postcondition(threading::ReactionTask& task) {
             std::conditional_t<fusion::has_postcondition<DSL>::value, DSL, fusion::NoOp>::template postcondition<
-                Parse<Sentence...>>(r);
+                Parse<Sentence...>>(task);
         }
     };
 

--- a/src/dsl/fusion/GetFusion.hpp
+++ b/src/dsl/fusion/GetFusion.hpp
@@ -40,8 +40,8 @@ namespace dsl {
          */
         template <typename Function, typename DSL>
         struct GetCaller {
-            static auto call(threading::Reaction& reaction) -> decltype(Function::template get<DSL>(reaction)) {
-                return Function::template get<DSL>(reaction);
+            static auto call(threading::ReactionTask& task) -> decltype(Function::template get<DSL>(task)) {
+                return Function::template get<DSL>(task);
             }
         };
 
@@ -86,19 +86,19 @@ namespace dsl {
         struct GetFuser<std::tuple<Word1, WordN...>> {
 
             template <typename DSL, typename U = Word1>
-            static auto get(threading::Reaction& reaction)
+            static auto get(threading::ReactionTask& task)
                 -> decltype(util::FunctionFusion<std::tuple<Word1, WordN...>,
-                                                 decltype(std::forward_as_tuple(reaction)),
+                                                 decltype(std::forward_as_tuple(task)),
                                                  GetCaller,
                                                  std::tuple<DSL>,
-                                                 1>::call(reaction)) {
+                                                 1>::call(task)) {
 
                 // Perform our function fusion
                 return util::FunctionFusion<std::tuple<Word1, WordN...>,
-                                            decltype(std::forward_as_tuple(reaction)),
+                                            decltype(std::forward_as_tuple(task)),
                                             GetCaller,
                                             std::tuple<DSL>,
-                                            1>::call(reaction);
+                                            1>::call(task);
             }
         };
 

--- a/src/dsl/fusion/GroupFusion.hpp
+++ b/src/dsl/fusion/GroupFusion.hpp
@@ -77,10 +77,10 @@ namespace dsl {
         struct GroupFuser<std::tuple<Word>> {
 
             template <typename DSL>
-            static util::GroupDescriptor group(threading::Reaction& reaction) {
+            static util::GroupDescriptor group(threading::ReactionTask& task) {
 
                 // Return our group
-                return Word::template group<DSL>(reaction);
+                return Word::template group<DSL>(task);
             }
         };
 
@@ -89,7 +89,7 @@ namespace dsl {
         struct GroupFuser<std::tuple<Word1, Word2, WordN...>> {
 
             template <typename DSL>
-            static void group(const threading::Reaction& /*reaction*/) {
+            static void group(const threading::ReactionTask& /*task*/) {
                 throw std::invalid_argument("Can not be a member of more than one group");
             }
         };

--- a/src/dsl/fusion/NoOp.hpp
+++ b/src/dsl/fusion/NoOp.hpp
@@ -47,27 +47,27 @@ namespace dsl {
             }
 
             template <typename DSL>
-            static std::tuple<> get(const threading::Reaction& /*reaction*/) {
+            static std::tuple<> get(const threading::ReactionTask& /*task*/) {
                 return {};
             }
 
             template <typename DSL>
-            static bool precondition(const threading::Reaction& /*reaction*/) {
+            static bool precondition(const threading::ReactionTask& /*task*/) {
                 return true;
             }
 
             template <typename DSL>
-            static int priority(const threading::Reaction& /*reaction*/) {
+            static int priority(const threading::ReactionTask& /*task*/) {
                 return word::Priority::NORMAL::value;
             }
 
             template <typename DSL>
-            static util::GroupDescriptor group(const threading::Reaction& /*reaction*/) {
-                return util::GroupDescriptor{};
+            static util::GroupDescriptor group(const threading::ReactionTask& /*task*/) {
+                return {};
             }
 
             template <typename DSL>
-            static util::ThreadPoolDescriptor pool(const threading::Reaction& /*reaction*/) {
+            static util::ThreadPoolDescriptor pool(const threading::ReactionTask& /*task*/) {
                 return util::ThreadPoolDescriptor{};
             }
 
@@ -86,15 +86,15 @@ namespace dsl {
 
             static std::tuple<> bind(const std::shared_ptr<threading::Reaction>&);
 
-            static std::tuple<> get(threading::Reaction&);
+            static std::tuple<> get(threading::ReactionTask&);
 
-            static bool precondition(threading::Reaction&);
+            static bool precondition(threading::ReactionTask&);
 
-            static int priority(threading::Reaction&);
+            static int priority(threading::ReactionTask&);
 
-            static util::GroupDescriptor group(threading::Reaction&);
+            static util::GroupDescriptor group(threading::ReactionTask&);
 
-            static util::ThreadPoolDescriptor pool(threading::Reaction&);
+            static util::ThreadPoolDescriptor pool(threading::ReactionTask&);
 
             static void postcondition(threading::ReactionTask&);
         };

--- a/src/dsl/fusion/PoolFusion.hpp
+++ b/src/dsl/fusion/PoolFusion.hpp
@@ -26,7 +26,7 @@
 #include <algorithm>
 #include <stdexcept>
 
-#include "../../threading/Reaction.hpp"
+#include "../../threading/ReactionTask.hpp"
 #include "../operation/DSLProxy.hpp"
 #include "has_pool.hpp"
 
@@ -77,10 +77,10 @@ namespace dsl {
         struct PoolFuser<std::tuple<Word>> {
 
             template <typename DSL>
-            static util::ThreadPoolDescriptor pool(threading::Reaction& reaction) {
+            static util::ThreadPoolDescriptor pool(threading::ReactionTask& task) {
 
                 // Return our pool
-                return Word::template pool<DSL>(reaction);
+                return Word::template pool<DSL>(task);
             }
         };
 
@@ -89,7 +89,7 @@ namespace dsl {
         struct PoolFuser<std::tuple<Word1, Word2, WordN...>> {
 
             template <typename DSL>
-            static util::ThreadPoolDescriptor pool(const threading::Reaction& /*reaction*/) {
+            static util::ThreadPoolDescriptor pool(const threading::ReactionTask& /*task*/) {
                 throw std::invalid_argument("Can not be a member of more than one pool");
             }
         };

--- a/src/dsl/fusion/PreconditionFusion.hpp
+++ b/src/dsl/fusion/PreconditionFusion.hpp
@@ -23,7 +23,7 @@
 #ifndef NUCLEAR_DSL_FUSION_PRECONDITION_FUSION_HPP
 #define NUCLEAR_DSL_FUSION_PRECONDITION_FUSION_HPP
 
-#include "../../threading/Reaction.hpp"
+#include "../../threading/ReactionTask.hpp"
 #include "../operation/DSLProxy.hpp"
 #include "has_precondition.hpp"
 
@@ -75,10 +75,10 @@ namespace dsl {
         struct PreconditionFuser<std::tuple<Word>> {
 
             template <typename DSL>
-            static bool precondition(threading::Reaction& reaction) {
+            static bool precondition(threading::ReactionTask& task) {
 
                 // Run our remaining precondition
-                return Word::template precondition<DSL>(reaction);
+                return Word::template precondition<DSL>(task);
             }
         };
 
@@ -87,11 +87,11 @@ namespace dsl {
         struct PreconditionFuser<std::tuple<Word1, Word2, WordN...>> {
 
             template <typename DSL>
-            static bool precondition(threading::Reaction& reaction) {
+            static bool precondition(threading::ReactionTask& task) {
 
                 // Perform a recursive and operation ending with the first false
-                return Word1::template precondition<DSL>(reaction)
-                       && PreconditionFuser<std::tuple<Word2, WordN...>>::template precondition<DSL>(reaction);
+                return Word1::template precondition<DSL>(task)
+                       && PreconditionFuser<std::tuple<Word2, WordN...>>::template precondition<DSL>(task);
             }
         };
 

--- a/src/dsl/fusion/PriorityFusion.hpp
+++ b/src/dsl/fusion/PriorityFusion.hpp
@@ -23,7 +23,7 @@
 #ifndef NUCLEAR_DSL_FUSION_PRIORITY_FUSION_HPP
 #define NUCLEAR_DSL_FUSION_PRIORITY_FUSION_HPP
 
-#include "../../threading/Reaction.hpp"
+#include "../../threading/ReactionTask.hpp"
 #include "../operation/DSLProxy.hpp"
 #include "has_priority.hpp"
 
@@ -74,10 +74,10 @@ namespace dsl {
         struct PriorityFuser<std::tuple<Word>> {
 
             template <typename DSL>
-            static int priority(threading::Reaction& reaction) {
+            static int priority(threading::ReactionTask& task) {
 
                 // Return our priority
-                return Word::template priority<DSL>(reaction);
+                return Word::template priority<DSL>(task);
             }
         };
 
@@ -86,11 +86,11 @@ namespace dsl {
         struct PriorityFuser<std::tuple<Word1, Word2, WordN...>> {
 
             template <typename DSL>
-            static int priority(threading::Reaction& reaction) {
+            static int priority(threading::ReactionTask& task) {
 
                 // Choose our maximum priority
-                return std::max(Word1::template priority<DSL>(reaction),
-                                PriorityFuser<std::tuple<Word2, WordN...>>::template priority<DSL>(reaction));
+                return std::max(Word1::template priority<DSL>(task),
+                                PriorityFuser<std::tuple<Word2, WordN...>>::template priority<DSL>(task));
             }
         };
 

--- a/src/dsl/fusion/has_get.hpp
+++ b/src/dsl/fusion/has_get.hpp
@@ -23,7 +23,7 @@
 #ifndef NUCLEAR_DSL_FUSION_HAS_GET_HPP
 #define NUCLEAR_DSL_FUSION_HAS_GET_HPP
 
-#include "../../threading/Reaction.hpp"
+#include "../../threading/ReactionTask.hpp"
 #include "NoOp.hpp"
 
 namespace NUClear {
@@ -42,7 +42,8 @@ namespace dsl {
             using no  = std::false_type;
 
             template <typename U>
-            static auto test(int) -> decltype(U::template get<ParsedNoOp>(std::declval<threading::Reaction&>()), yes());
+            static auto test(int) -> decltype(U::template get<ParsedNoOp>(std::declval<threading::ReactionTask&>()),
+                                              yes());
             template <typename>
             static no test(...);
 

--- a/src/dsl/fusion/has_group.hpp
+++ b/src/dsl/fusion/has_group.hpp
@@ -23,7 +23,7 @@
 #ifndef NUCLEAR_DSL_FUSION_HAS_GROUP_HPP
 #define NUCLEAR_DSL_FUSION_HAS_GROUP_HPP
 
-#include "../../threading/Reaction.hpp"
+#include "../../threading/ReactionTask.hpp"
 #include "NoOp.hpp"
 
 namespace NUClear {
@@ -42,7 +42,7 @@ namespace dsl {
             using no  = std::false_type;
 
             template <typename U>
-            static auto test(int) -> decltype(U::template group<ParsedNoOp>(std::declval<threading::Reaction&>()),
+            static auto test(int) -> decltype(U::template group<ParsedNoOp>(std::declval<threading::ReactionTask&>()),
                                               yes());
             template <typename>
             static no test(...);

--- a/src/dsl/fusion/has_pool.hpp
+++ b/src/dsl/fusion/has_pool.hpp
@@ -23,7 +23,7 @@
 #ifndef NUCLEAR_DSL_FUSION_HAS_POOL_HPP
 #define NUCLEAR_DSL_FUSION_HAS_POOL_HPP
 
-#include "../../threading/Reaction.hpp"
+#include "../../threading/ReactionTask.hpp"
 #include "NoOp.hpp"
 
 namespace NUClear {
@@ -42,7 +42,7 @@ namespace dsl {
             using no  = std::false_type;
 
             template <typename U>
-            static auto test(int) -> decltype(U::template pool<ParsedNoOp>(std::declval<threading::Reaction&>()),
+            static auto test(int) -> decltype(U::template pool<ParsedNoOp>(std::declval<threading::ReactionTask&>()),
                                               yes());
             template <typename>
             static no test(...);

--- a/src/dsl/fusion/has_precondition.hpp
+++ b/src/dsl/fusion/has_precondition.hpp
@@ -23,7 +23,7 @@
 #ifndef NUCLEAR_DSL_FUSION_HAS_PRECONDITION_HPP
 #define NUCLEAR_DSL_FUSION_HAS_PRECONDITION_HPP
 
-#include "../../threading/Reaction.hpp"
+#include "../../threading/ReactionTask.hpp"
 #include "NoOp.hpp"
 
 namespace NUClear {
@@ -43,7 +43,7 @@ namespace dsl {
 
             template <typename U>
             static auto test(int)
-                -> decltype(U::template precondition<ParsedNoOp>(std::declval<threading::Reaction&>()), yes());
+                -> decltype(U::template precondition<ParsedNoOp>(std::declval<threading::ReactionTask&>()), yes());
             template <typename>
             static no test(...);
 

--- a/src/dsl/fusion/has_priority.hpp
+++ b/src/dsl/fusion/has_priority.hpp
@@ -23,7 +23,7 @@
 #ifndef NUCLEAR_DSL_FUSION_HAS_PRIORITY_HPP
 #define NUCLEAR_DSL_FUSION_HAS_PRIORITY_HPP
 
-#include "../../threading/Reaction.hpp"
+#include "../../threading/ReactionTask.hpp"
 #include "NoOp.hpp"
 
 namespace NUClear {
@@ -42,8 +42,8 @@ namespace dsl {
             using no  = std::false_type;
 
             template <typename U>
-            static auto test(int) -> decltype(U::template priority<ParsedNoOp>(std::declval<threading::Reaction&>()),
-                                              yes());
+            static auto test(int)
+                -> decltype(U::template priority<ParsedNoOp>(std::declval<threading::ReactionTask&>()), yes());
             template <typename>
             static no test(...);
 

--- a/src/dsl/operation/CacheGet.hpp
+++ b/src/dsl/operation/CacheGet.hpp
@@ -43,7 +43,7 @@ namespace dsl {
         struct CacheGet {
 
             template <typename DSL, typename T = DataType>
-            static std::shared_ptr<const T> get(const threading::Reaction& /*reaction*/) {
+            static std::shared_ptr<const T> get(const threading::ReactionTask& /*task*/) {
 
                 return store::ThreadStore<std::shared_ptr<T>>::value == nullptr
                            ? store::DataStore<DataType>::get()

--- a/src/dsl/word/Always.hpp
+++ b/src/dsl/word/Always.hpp
@@ -28,6 +28,7 @@
 #include <utility>
 
 #include "../../id.hpp"
+#include "../../threading/ReactionIdentifiers.hpp"
 #include "../../threading/ReactionTask.hpp"
 #include "../../util/ThreadPoolDescriptor.hpp"
 
@@ -57,7 +58,7 @@ namespace dsl {
          *
          * @par Ensure Clean Shutdown
          *  If the reaction associated with this task is performing a blocking operation, developers should make the
-         *  the reaction interruptible with an on<Shutdown> reaction.  This will enforce a clean shutdown in the system.
+         *  the reaction interruptable with an on<Shutdown> reaction.  This will enforce a clean shutdown in the system.
          *
          * @attention
          *  Where possible, developers should <b>avoid using this keyword</b>.  It has been provided, but should only be
@@ -71,87 +72,70 @@ namespace dsl {
         struct Always {
 
             template <typename DSL>
-            static util::ThreadPoolDescriptor pool(const threading::Reaction& reaction) {
-                static std::map<NUClear::id_t, NUClear::id_t> pool_id;
+            static util::ThreadPoolDescriptor pool(const threading::ReactionTask& task) {
+                static std::map<NUClear::id_t, NUClear::id_t> pool_ids;
                 static std::mutex mutex;
 
-                const std::lock_guard<std::mutex> lock(mutex);
-                if (pool_id.count(reaction.id) == 0) {
-                    pool_id[reaction.id] = util::ThreadPoolDescriptor::get_unique_pool_id();
+                const auto& reaction = *task.parent;
+                id_t pool_id         = 0;
+
+                /*mutex scope*/ {
+                    const std::lock_guard<std::mutex> lock(mutex);
+                    if (pool_ids.count(reaction.id) == 0) {
+                        pool_ids[reaction.id] = util::ThreadPoolDescriptor::get_unique_pool_id();
+                    }
+                    pool_id = pool_ids.at(reaction.id);
                 }
-                return util::ThreadPoolDescriptor{pool_id[reaction.id], 1, false};
+
+                return util::ThreadPoolDescriptor{pool_id, 1, false};
             }
 
             template <typename DSL>
-            static void bind(const std::shared_ptr<threading::Reaction>& always_reaction) {
-                /**
-                 * Static map mapping reaction id (from the always reaction) to a pair of reaction pointers -- one for
-                 * the always reaction and one for the idle reaction that we generate in this function
-                 * The main purpose of this map is to ensure that the always reaction pointer doesn't get destroyed
-                 */
-                static std::map<NUClear::id_t,
-                                std::pair<std::shared_ptr<threading::Reaction>, std::shared_ptr<threading::Reaction>>>
-                    reaction_store = {};
-
-                /**
-                 * Generate a new reaction for an idle task.
-                 *
-                 * The purpose of this reaction is to ensure that the always reaction is resubmitted in the event that
-                 * the precondition fails. (e.g. on<Always, With<X>> will fail the precondition if there are no X
-                 * messages previously emitted)
-                 *
-                 * In the event that the precondition on the always reaction fails this idle task will run and resubmit
-                 * both the always reaction and the idle reaction.
-                 *
-                 * The idle reaction must have a lower priority than the always reaction and must also run in the same
-                 * thread pool and group as the always reaction.
-                 */
-                auto idle_reaction = std::make_shared<threading::Reaction>(
-                    always_reaction->reactor,
-                    threading::ReactionIdentifiers{always_reaction->identifiers->name + " - IDLE Task",
-                                                   always_reaction->identifiers->reactor,
-                                                   always_reaction->identifiers->dsl,
-                                                   always_reaction->identifiers->function},
-                    [always_reaction](threading::Reaction& ir) -> util::GeneratedCallback {
-                        auto callback = [&ir, always_reaction](const threading::ReactionTask& /*task*/) {
-                            // Get a task for the always reaction and submit it to the scheduler
-                            always_reaction->reactor.powerplant.submit(always_reaction->get_task());
-
-                            // Get a task for the idle reaction and submit it to the scheduler
-                            ir.reactor.powerplant.submit(ir.get_task());
-                        };
-
-                        // Make sure that idle reaction always has lower priority than the always reaction
-                        return {DSL::priority(*always_reaction) - 1,
-                                DSL::group(*always_reaction),
-                                DSL::pool(*always_reaction),
-                                callback};
-                    });
-
-                // Don't emit stats for the idle reaction
-                idle_reaction->emit_stats = false;
-
-                // Keep this reaction handy so it doesn't go out of scope
-                reaction_store[always_reaction->id] = {always_reaction, idle_reaction};
+            static void bind(const std::shared_ptr<threading::Reaction>& reaction) {
 
                 // Create an unbinder for the always reaction
-                always_reaction->unbinders.push_back([](threading::Reaction& r) {
+                reaction->unbinders.push_back([](threading::Reaction& r) {
                     r.enabled = false;
-                    reaction_store.erase(r.id);
                     // TODO(Alex/Trent) Clean up thread pool too
                 });
 
-                // Get a task for the always reaction and submit it to the scheduler
-                always_reaction->reactor.powerplant.submit(always_reaction->get_task());
-
-                // Get a task for the idle reaction and submit it to the scheduler
-                idle_reaction->reactor.powerplant.submit(idle_reaction->get_task());
+                // Submit the always and idle task to the scheduler
+                PowerPlant::powerplant->submit(reaction->get_task());
+                PowerPlant::powerplant->submit(make_idle_task<DSL>(reaction));
             }
 
             template <typename DSL>
             static void postcondition(threading::ReactionTask& task) {
                 // Get a task for the always reaction and submit it to the scheduler
-                task.parent.reactor.powerplant.submit(task.parent.get_task());
+                PowerPlant::powerplant->submit(task.parent->get_task());
+            }
+
+        private:
+            /**
+             * Generate an idle task for Always which will be used to resubmit the Always task if it fails
+             *
+             * @tparam DSL      the DSL that the Always task is using
+             * @param reaction  the reaction that the Always task is associated with
+             *
+             * @return a unique pointer to the idle task which will resubmit the Always task and itself
+             */
+            template <typename DSL>
+            static std::unique_ptr<threading::ReactionTask> make_idle_task(
+                const std::shared_ptr<threading::Reaction>& reaction) {
+
+                auto idle_task = std::make_unique<threading::ReactionTask>(
+                    reaction,
+                    [](threading::ReactionTask& task) { return DSL::priority(task) - 1; },
+                    DSL::pool,
+                    DSL::group);
+
+                idle_task->callback = [](threading::ReactionTask& task) {
+                    // Submit the always and idle tasks to the scheduler
+                    PowerPlant::powerplant->submit(task.parent->get_task());
+                    PowerPlant::powerplant->submit(make_idle_task<DSL>(task.parent));
+                };
+
+                return idle_task;
             }
         };
 

--- a/src/dsl/word/Buffer.hpp
+++ b/src/dsl/word/Buffer.hpp
@@ -47,9 +47,9 @@ namespace dsl {
         struct Buffer {
 
             template <typename DSL>
-            static bool precondition(const threading::Reaction& reaction) {
+            static bool precondition(const threading::ReactionTask& task) {
                 // We only run if there are less than the target number of active tasks
-                return reaction.active_tasks < (n + 1);
+                return task.parent->active_tasks < (n + 1);
             }
         };
 

--- a/src/dsl/word/Group.hpp
+++ b/src/dsl/word/Group.hpp
@@ -72,7 +72,7 @@ namespace dsl {
             static const util::GroupDescriptor group_descriptor;
 
             template <typename DSL>
-            static util::GroupDescriptor group(const threading::Reaction& /*reaction*/) {
+            static util::GroupDescriptor group(const threading::ReactionTask& /*task*/) {
                 return group_descriptor;
             }
         };

--- a/src/dsl/word/IO.hpp
+++ b/src/dsl/word/IO.hpp
@@ -142,7 +142,7 @@ namespace dsl {
             }
 
             template <typename DSL>
-            static Event get(const threading::Reaction& /*reaction*/) {
+            static Event get(const threading::ReactionTask& /*task*/) {
 
                 // If our thread store has a value
                 if (ThreadEventStore::value) {
@@ -155,7 +155,7 @@ namespace dsl {
 
             template <typename DSL>
             static void postcondition(threading::ReactionTask& task) {
-                task.parent.reactor.emit<emit::Direct>(std::make_unique<IOFinished>(task.parent.id));
+                task.parent->reactor.emit<emit::Direct>(std::make_unique<IOFinished>(task.parent->id));
             }
         };
 

--- a/src/dsl/word/Idle.hpp
+++ b/src/dsl/word/Idle.hpp
@@ -68,7 +68,10 @@ namespace dsl {
         struct Idle {
             template <typename DSL>
             static void bind(const std::shared_ptr<threading::Reaction>& reaction) {
-                bind_idle(reaction, PoolType::template pool<DSL>(*reaction));
+
+                // Make a fake task to use for finding an appropriate descriptor
+                threading::ReactionTask task(reaction, DSL::priority, DSL::pool, DSL::group);
+                bind_idle(reaction, PoolType::template pool<DSL>(task));
             }
         };
 

--- a/src/dsl/word/Last.hpp
+++ b/src/dsl/word/Last.hpp
@@ -165,18 +165,18 @@ namespace dsl {
 
         public:
             template <typename DSL>
-            static auto get(threading::Reaction& reaction)
+            static auto get(threading::ReactionTask& task)
                 -> decltype(wrap(
-                    Fusion<DSLWords...>::template get<DSL>(reaction),
+                    Fusion<DSLWords...>::template get<DSL>(task),
                     util::GenerateSequence<
                         0,
-                        std::tuple_size<decltype(Fusion<DSLWords...>::template get<DSL>(reaction))>::value>())) {
+                        std::tuple_size<decltype(Fusion<DSLWords...>::template get<DSL>(task))>::value>())) {
 
                 // Wrap all of our data in last list wrappers
-                return wrap(Fusion<DSLWords...>::template get<DSL>(reaction),
+                return wrap(Fusion<DSLWords...>::template get<DSL>(task),
                             util::GenerateSequence<
                                 0,
-                                std::tuple_size<decltype(Fusion<DSLWords...>::template get<DSL>(reaction))>::value>());
+                                std::tuple_size<decltype(Fusion<DSLWords...>::template get<DSL>(task))>::value>());
             }
         };
 

--- a/src/dsl/word/MainThread.hpp
+++ b/src/dsl/word/MainThread.hpp
@@ -40,9 +40,16 @@ namespace dsl {
          */
         struct MainThread {
 
+            /// the description of the thread pool to be used for this PoolType
+            static util::ThreadPoolDescriptor descriptor() {
+                return util::ThreadPoolDescriptor{NUClear::id_t(util::ThreadPoolDescriptor::MAIN_THREAD_POOL_ID),
+                                                  1,
+                                                  true};
+            }
+
             template <typename DSL>
-            static util::ThreadPoolDescriptor pool(const threading::Reaction& /*reaction*/) {
-                return util::ThreadPoolDescriptor{util::ThreadPoolDescriptor::MAIN_THREAD_POOL_ID, 1, true};
+            static util::ThreadPoolDescriptor pool(const threading::ReactionTask& /*task*/) {
+                return descriptor();
             }
         };
 

--- a/src/dsl/word/Network.hpp
+++ b/src/dsl/word/Network.hpp
@@ -89,8 +89,7 @@ namespace dsl {
             }
 
             template <typename DSL>
-            static std::tuple<std::shared_ptr<NetworkSource>, NetworkData<T>> get(
-                const threading::Reaction& /*reaction*/) {
+            static std::tuple<std::shared_ptr<NetworkSource>, NetworkData<T>> get(threading::ReactionTask& /*task*/) {
 
                 auto* data   = store::ThreadStore<std::vector<uint8_t>>::value;
                 auto* source = store::ThreadStore<NetworkSource>::value;

--- a/src/dsl/word/Once.hpp
+++ b/src/dsl/word/Once.hpp
@@ -40,11 +40,10 @@ namespace dsl {
         struct Once : Single {
 
             // Post condition to unbind this reaction.
-
             template <typename DSL>
-            static void postcondition(threading::ReactionTask& reaction) {
+            static void postcondition(threading::ReactionTask& task) {
                 // Unbind:
-                reaction.parent.unbind();
+                task.parent->unbind();
             }
         };
 

--- a/src/dsl/word/Optional.hpp
+++ b/src/dsl/word/Optional.hpp
@@ -74,18 +74,18 @@ namespace dsl {
 
         public:
             template <typename DSL>
-            static auto get(threading::Reaction& reaction)
+            static auto get(threading::ReactionTask& task)
                 -> decltype(wrap(
-                    Fusion<DSLWords...>::template get<DSL>(reaction),
+                    Fusion<DSLWords...>::template get<DSL>(task),
                     util::GenerateSequence<
                         0,
-                        std::tuple_size<decltype(Fusion<DSLWords...>::template get<DSL>(reaction))>::value>())) {
+                        std::tuple_size<decltype(Fusion<DSLWords...>::template get<DSL>(task))>::value>())) {
 
                 // Wrap all of our data in optional wrappers
-                return wrap(Fusion<DSLWords...>::template get<DSL>(reaction),
+                return wrap(Fusion<DSLWords...>::template get<DSL>(task),
                             util::GenerateSequence<
                                 0,
-                                std::tuple_size<decltype(Fusion<DSLWords...>::template get<DSL>(reaction))>::value>());
+                                std::tuple_size<decltype(Fusion<DSLWords...>::template get<DSL>(task))>::value>());
             }
         };
 

--- a/src/dsl/word/Pool.hpp
+++ b/src/dsl/word/Pool.hpp
@@ -77,7 +77,7 @@ namespace dsl {
              * @tparam DSL the DSL used for this reaction
              */
             template <typename DSL>
-            static util::ThreadPoolDescriptor pool(const threading::Reaction& /*reaction*/) {
+            static util::ThreadPoolDescriptor pool(const threading::ReactionTask& /*task*/) {
                 return pool_descriptor;
             }
         };
@@ -86,7 +86,7 @@ namespace dsl {
         template <>
         struct Pool<void> {
             template <typename DSL>
-            static util::ThreadPoolDescriptor pool(const threading::Reaction& /*reaction*/) {
+            static util::ThreadPoolDescriptor pool(const threading::ReactionTask& /*task*/) {
                 return util::ThreadPoolDescriptor{};
             }
         };

--- a/src/dsl/word/Priority.hpp
+++ b/src/dsl/word/Priority.hpp
@@ -74,7 +74,7 @@ namespace dsl {
                 static constexpr int value = 1000;
 
                 template <typename DSL>
-                static int priority(const threading::Reaction& /*reaction*/) {
+                static int priority(const threading::ReactionTask& /*task*/) {
                     return value;
                 }
             };
@@ -84,7 +84,7 @@ namespace dsl {
                 static constexpr int value = 750;
 
                 template <typename DSL>
-                static int priority(const threading::Reaction& /*reaction*/) {
+                static int priority(const threading::ReactionTask& /*task*/) {
                     return value;
                 }
             };
@@ -94,7 +94,7 @@ namespace dsl {
                 static constexpr int value = 500;
 
                 template <typename DSL>
-                static int priority(const threading::Reaction& /*reaction*/) {
+                static int priority(const threading::ReactionTask& /*task*/) {
                     return value;
                 }
             };
@@ -104,7 +104,7 @@ namespace dsl {
                 static constexpr int value = 250;
 
                 template <typename DSL>
-                static int priority(const threading::Reaction& /*reaction*/) {
+                static int priority(const threading::ReactionTask& /*task*/) {
                     return value;
                 }
             };
@@ -114,7 +114,7 @@ namespace dsl {
                 static constexpr int value = 0;
 
                 template <typename DSL>
-                static int priority(const threading::Reaction& /*reaction*/) {
+                static int priority(const threading::ReactionTask& /*task*/) {
                     return value;
                 }
             };

--- a/src/dsl/word/TCP.hpp
+++ b/src/dsl/word/TCP.hpp
@@ -160,10 +160,10 @@ namespace dsl {
             }
 
             template <typename DSL>
-            static Connection get(threading::Reaction& reaction) {
+            static Connection get(threading::ReactionTask& task) {
 
                 // Get our file descriptor from the magic cache
-                auto event = IO::get<DSL>(reaction);
+                auto event = IO::get<DSL>(task);
 
                 // If our get is being run without an fd (something else triggered) then short circuit
                 if (!event) {

--- a/src/dsl/word/UDP.hpp
+++ b/src/dsl/word/UDP.hpp
@@ -337,9 +337,9 @@ namespace dsl {
             }
 
             template <typename DSL>
-            static RecvResult read(threading::Reaction& reaction) {
+            static RecvResult read(threading::ReactionTask& task) {
                 // Get our file descriptor from the magic cache
-                auto event = IO::get<DSL>(reaction);
+                auto event = IO::get<DSL>(task);
 
                 // If our get is being run without an fd (something else triggered) then short circuit
                 if (!event) {
@@ -422,8 +422,8 @@ namespace dsl {
             }
 
             template <typename DSL>
-            static Packet get(threading::Reaction& reaction) {
-                RecvResult result = read<DSL>(reaction);
+            static Packet get(threading::ReactionTask& task) {
+                RecvResult result = read<DSL>(task);
 
                 Packet p{};
                 p.valid       = result.valid;
@@ -467,8 +467,8 @@ namespace dsl {
                 }
 
                 template <typename DSL>
-                static Packet get(threading::Reaction& reaction) {
-                    RecvResult result = read<DSL>(reaction);
+                static Packet get(threading::ReactionTask& task) {
+                    RecvResult result = read<DSL>(task);
 
                     // Broadcast is only IPv4
                     if (result.local.sock.sa_family == AF_INET) {
@@ -514,8 +514,8 @@ namespace dsl {
                 }
 
                 template <typename DSL>
-                static Packet get(threading::Reaction& reaction) {
-                    RecvResult result = read<DSL>(reaction);
+                static Packet get(threading::ReactionTask& task) {
+                    RecvResult result = read<DSL>(task);
 
                     const auto& a = result.local;
                     const bool multicast =
@@ -538,6 +538,7 @@ namespace dsl {
                 }
             };
         };
+
     }  // namespace word
 
     namespace trait {

--- a/src/extension/IOController_Windows.ipp
+++ b/src/extension/IOController_Windows.ipp
@@ -137,7 +137,6 @@ namespace extension {
         }
     }
 
-
     IOController::IOController(std::unique_ptr<NUClear::Environment> environment) : Reactor(std::move(environment)) {
 
         // Create an event to use for the notifier (used for getting out of WSAWaitForMultipleEvents())

--- a/src/threading/Reaction.cpp
+++ b/src/threading/Reaction.cpp
@@ -26,7 +26,6 @@
 #include <utility>
 
 #include "../id.hpp"
-#include "../util/GeneratedCallback.hpp"
 #include "ReactionIdentifiers.hpp"
 #include "ReactionTask.hpp"
 
@@ -49,20 +48,8 @@ namespace threading {
             return nullptr;
         }
 
-        // Run our generator to get a functor we can run
-        auto callback = generator(*this);
-
-        // If our generator returns a valid function
-        if (callback) {
-            return std::make_unique<ReactionTask>(*this,
-                                                  callback.priority,
-                                                  callback.group,
-                                                  callback.pool,
-                                                  std::move(callback.callback));
-        }
-
-        // Otherwise we return a null pointer
-        return nullptr;
+        // Return the task returned by the generator
+        return generator(this->shared_from_this());
     }
 
     void Reaction::unbind() {

--- a/src/threading/Reaction.hpp
+++ b/src/threading/Reaction.hpp
@@ -53,14 +53,14 @@ namespace threading {
      * It also holds a function which is used to generate databound Task objects.
      * i.e. callback with the function arguments already loaded and ready to run.
      */
-    class Reaction {
+    class Reaction : public std::enable_shared_from_this<Reaction> {
         // Reaction handles are given to user code to enable and disable the reaction
         friend class ReactionHandle;
         friend class ReactionTask;
 
     public:
         // The type of the generator that is used to create functions for ReactionTask objects
-        using TaskGenerator = std::function<util::GeneratedCallback(Reaction&)>;
+        using TaskGenerator = std::function<std::unique_ptr<ReactionTask>(const std::shared_ptr<Reaction>&)>;
 
         /**
          * Constructs a new Reaction with the passed callback generator and options.

--- a/src/util/CallbackGenerator.hpp
+++ b/src/util/CallbackGenerator.hpp
@@ -114,7 +114,9 @@ namespace util {
                 }
 
                 // Our finish time
-                task.stats->finished = clock::now();
+                if (task.stats != nullptr) {
+                    task.stats->finished = clock::now();
+                }
 
                 // Run our postconditions
                 DSL::postcondition(task);

--- a/src/util/CallbackGenerator.hpp
+++ b/src/util/CallbackGenerator.hpp
@@ -32,7 +32,6 @@
 #include "../util/apply.hpp"
 #include "../util/unpack.hpp"
 #include "../util/update_current_thread_priority.hpp"
-#include "GeneratedCallback.hpp"
 
 namespace NUClear {
 namespace util {
@@ -69,22 +68,17 @@ namespace util {
                 std::get<DIndex>(data))...);
         }
 
-        GeneratedCallback operator()(threading::Reaction& r) {
+        std::unique_ptr<threading::ReactionTask> operator()(const std::shared_ptr<threading::Reaction>& r) {
 
-            // Add one to our active tasks
-            ++r.active_tasks;
+            auto task = std::make_unique<threading::ReactionTask>(r, DSL::priority, DSL::pool, DSL::group);
 
             // Check if we should even run
-            if (!DSL::precondition(r)) {
-                // Take one from our active tasks
-                --r.active_tasks;
-
-                // We cancel our execution by returning an empty function
-                return {};
+            if (!DSL::precondition(*task)) {
+                return nullptr;
             }
 
             // Bind our data to a variable (this will run in the dispatching thread)
-            auto data = DSL::get(r);
+            auto data = DSL::get(*task);
 
             // Merge our transient data in
             merge_transients(data,
@@ -93,49 +87,45 @@ namespace util {
 
             // Check if our data is good (all the data exists) otherwise terminate the call
             if (!check_data(data)) {
-                // Take one from our active tasks
-                --r.active_tasks;
-
-                // We cancel our execution by returning an empty function
-                return {};
+                return nullptr;
             }
 
             // We have to make a copy of the callback because the "this" variable can go out of scope
-            auto c = callback;
-            return GeneratedCallback(DSL::priority(r),
-                                     DSL::group(r),
-                                     DSL::pool(r),
-                                     [c, data](threading::ReactionTask& task) noexcept {
-                                         // Update our thread's priority to the correct level
-                                         update_current_thread_priority(task.priority);
+            auto c         = callback;
+            task->callback = [c, data](threading::ReactionTask& task) noexcept {
+                // Update our thread's priority to the correct level
+                update_current_thread_priority(task.priority);
 
-                                         // Record our start time
-                                         task.stats->started = clock::now();
+                // Record our start time
+                if (task.stats != nullptr) {
+                    task.stats->started = clock::now();
+                }
 
-                                         // We have to catch any exceptions
-                                         try {
-                                             // We call with only the relevant arguments to the passed function
-                                             util::apply_relevant(c, std::move(data));
-                                         }
-                                         catch (...) {
-                                             // Catch our exception if it happens
-                                             task.stats->exception = std::current_exception();
-                                         }
+                // We have to catch any exceptions
+                try {
+                    // We call with only the relevant arguments to the passed function
+                    util::apply_relevant(c, std::move(data));
+                }
+                catch (...) {
+                    // Catch our exception if it happens
+                    if (task.stats != nullptr) {
+                        task.stats->exception = std::current_exception();
+                    }
+                }
 
-                                         // Our finish time
-                                         task.stats->finished = clock::now();
+                // Our finish time
+                task.stats->finished = clock::now();
 
-                                         // Run our postconditions
-                                         DSL::postcondition(task);
+                // Run our postconditions
+                DSL::postcondition(task);
 
-                                         // Take one from our active tasks
-                                         --task.parent.active_tasks;
+                // Emit our reaction statistics if it wouldn't cause a loop
+                if (task.stats != nullptr) {
+                    PowerPlant::powerplant->emit_shared<dsl::word::emit::Direct>(task.stats);
+                }
+            };
 
-                                         // Emit our reaction statistics if it wouldn't cause a loop
-                                         if (task.emit_stats) {
-                                             PowerPlant::powerplant->emit_shared<dsl::word::emit::Direct>(task.stats);
-                                         }
-                                     });
+            return task;
         }
 
         Function callback;

--- a/src/util/TransientDataElements.hpp
+++ b/src/util/TransientDataElements.hpp
@@ -51,7 +51,7 @@ namespace util {
     };
 
     template <typename DSL>
-    struct TransientDataElements : ExtractTransient<decltype(DSL::get(std::declval<threading::Reaction&>()))> {};
+    struct TransientDataElements : ExtractTransient<decltype(DSL::get(std::declval<threading::ReactionTask&>()))> {};
 
 }  // namespace util
 }  // namespace NUClear

--- a/tests/tests/dsl/CustomGet.cpp
+++ b/tests/tests/dsl/CustomGet.cpp
@@ -33,7 +33,7 @@ std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-gl
 struct CustomGet : NUClear::dsl::operation::TypeBind<CustomGet> {
 
     template <typename DSL>
-    static std::shared_ptr<std::string> get(const NUClear::threading::Reaction& /*unused*/) {
+    static std::shared_ptr<std::string> get(const NUClear::threading::ReactionTask& /*task*/) {
         return std::make_shared<std::string>("Data from a custom getter");
     }
 };

--- a/tests/tests/dsl/Transient.cpp
+++ b/tests/tests/dsl/Transient.cpp
@@ -60,10 +60,10 @@ std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-gl
 struct TransientGetter : NUClear::dsl::operation::TypeBind<TransientMessage> {
 
     template <typename DSL>
-    static TransientMessage get(NUClear::threading::Reaction& r) {
+    static TransientMessage get(NUClear::threading::ReactionTask& task) {
 
         // Get the real message and return it directly so transient can activate
-        auto raw = NUClear::dsl::operation::CacheGet<TransientMessage>::get<DSL>(r);
+        auto raw = NUClear::dsl::operation::CacheGet<TransientMessage>::get<DSL>(task);
         if (raw == nullptr) {
             return {};
         }


### PR DESCRIPTION
Changes how extensions work so they always run on a task object rather than on different types.
By changing the order of construction, all of the reactions can be given full context.