### PR TITLE
Improve the use of atomics

### DIFF
--- a/src/PowerPlant.cpp
+++ b/src/PowerPlant.cpp
@@ -86,7 +86,7 @@ PowerPlant::~PowerPlant() {
 void PowerPlant::start() {
 
     // We are now running
-    is_running.store(true);
+    is_running.store(true, std::memory_order_release);
 
     // Direct emit startup event and command line arguments
     emit<dsl::word::emit::Direct>(std::make_unique<dsl::word::Startup>());
@@ -150,7 +150,7 @@ void PowerPlant::shutdown() {
 
     // Stop running before we emit the Shutdown event
     // Some things such as on<Always> depend on this flag and it's possible to miss it
-    is_running.store(false);
+    is_running.store(false, std::memory_order_release);
 
     // Emit our shutdown event
     emit(std::make_unique<dsl::word::Shutdown>());
@@ -160,7 +160,7 @@ void PowerPlant::shutdown() {
 }
 
 bool PowerPlant::running() const {
-    return is_running.load();
+    return is_running.load(std::memory_order_acquire);
 }
 
 }  // namespace NUClear

--- a/src/dsl/word/Buffer.hpp
+++ b/src/dsl/word/Buffer.hpp
@@ -49,7 +49,7 @@ namespace dsl {
             template <typename DSL>
             static bool precondition(const threading::ReactionTask& task) {
                 // We only run if there are less than the target number of active tasks
-                return task.parent->active_tasks < (n + 1);
+                return task.parent->active_tasks.load(std::memory_order_acquire) < (n + 1);
             }
         };
 

--- a/src/extension/ChronoController.cpp
+++ b/src/extension/ChronoController.cpp
@@ -56,7 +56,7 @@ namespace extension {
             const std::lock_guard<std::mutex> lock(mutex);
 
             // Add our new task to the heap if we are still running
-            if (running.load()) {
+            if (running.load(std::std::memory_order_acquire)) {
                 tasks.push_back(*task);
                 std::push_heap(tasks.begin(), tasks.end(), std::greater<>());
             }
@@ -89,7 +89,7 @@ namespace extension {
         // When we shutdown we notify so we quit now
         on<Shutdown>().then("Shutdown Chrono Controller", [this] {
             const std::lock_guard<std::mutex> lock(mutex);
-            running = false;
+            running.store(false, std::memory_order_release);
             wait.notify_all();
         });
 
@@ -121,14 +121,14 @@ namespace extension {
 
         on<Always, Priority::REALTIME>().then("Chrono Controller", [this] {
             // Run until we are told to stop
-            while (running.load()) {
+            while (running.load(std::memory_order_acquire)) {
 
                 // Acquire the mutex lock so we can wait on it
                 std::unique_lock<std::mutex> lock(mutex);
 
                 // If we have no chrono tasks wait until we are notified
                 if (tasks.empty()) {
-                    wait.wait(lock, [this] { return !running.load() || !tasks.empty(); });
+                    wait.wait(lock, [this] { return !running.load(std::memory_order_acquire) || !tasks.empty(); });
                 }
                 else {
                     auto start  = NUClear::clock::now();
@@ -157,7 +157,8 @@ namespace extension {
                         if (clock::rtf() == 0.0) {
                             // If we are paused then just wait until we are unpaused
                             wait.wait(lock, [&] {
-                                return !running.load() || clock::rtf() != 0.0 || NUClear::clock::now() != start;
+                                return !running.load(std::memory_order_acquire) || clock::rtf() != 0.0
+                                       || NUClear::clock::now() != start;
                             });
                         }
                         else if (time_until_task > cv_accuracy) {  // A long time in the future

--- a/src/extension/ChronoController.cpp
+++ b/src/extension/ChronoController.cpp
@@ -22,6 +22,8 @@
 
 #include "ChronoController.hpp"
 
+#include <atomic>
+
 #include "../util/precise_sleep.hpp"
 
 namespace NUClear {
@@ -56,7 +58,7 @@ namespace extension {
             const std::lock_guard<std::mutex> lock(mutex);
 
             // Add our new task to the heap if we are still running
-            if (running.load(std::std::memory_order_acquire)) {
+            if (running.load(std::memory_order_acquire)) {
                 tasks.push_back(*task);
                 std::push_heap(tasks.begin(), tasks.end(), std::greater<>());
             }

--- a/src/extension/network/NUClearNetwork.cpp
+++ b/src/extension/network/NUClearNetwork.cpp
@@ -727,7 +727,9 @@ namespace extension {
                                              to.size());
 
                                     // Set this packet to have been recently received
-                                    remote->recent_packets[++remote->recent_packets_index] = packet.packet_id;
+                                    remote->recent_packets[remote->recent_packets_index
+                                                               .fetch_add(1, std::memory_order_relaxed)] =
+                                        packet.packet_id;
                                 }
 
                                 packet_callback(*remote, packet.hash, packet.reliable, std::move(out));
@@ -841,7 +843,9 @@ namespace extension {
                                     // If the packet was reliable add that it was recently received
                                     if (packet.reliable) {
                                         // Set this packet to have been recently received
-                                        remote->recent_packets[++remote->recent_packets_index] = packet.packet_id;
+                                        remote->recent_packets[remote->recent_packets_index
+                                                                   .fetch_add(1, std::memory_order_relaxed)] =
+                                            packet.packet_id;
                                     }
 
                                     // We have completed this packet, discard the data

--- a/src/extension/network/NUClearNetwork.hpp
+++ b/src/extension/network/NUClearNetwork.hpp
@@ -313,8 +313,8 @@ namespace extension {
             // Our announce packet
             std::vector<uint8_t> announce_packet;
 
-            /// An atomic source for packet IDs to make sure they are semi unique
-            std::atomic<uint16_t> packet_id_source{0};
+            /// An source for packet IDs to make sure they are semi unique
+            uint16_t packet_id_source{0};
 
             /// The callback to execute when a data packet is completed
             std::function<void(const NetworkTarget&, const uint64_t&, const bool&, std::vector<uint8_t>&&)>

--- a/src/threading/Reaction.hpp
+++ b/src/threading/Reaction.hpp
@@ -104,7 +104,7 @@ namespace threading {
         std::shared_ptr<const ReactionIdentifiers> identifiers;
 
         /// the unique identifier for this Reaction object
-        const NUClear::id_t id{++reaction_id_source};
+        const NUClear::id_t id{reaction_id_source.fetch_add(1, std::memory_order_relaxed)};
 
         /// if this is false, we cannot emit ReactionStatistics from any reaction triggered by this one
         bool emit_stats{true};

--- a/src/threading/ReactionTask.cpp
+++ b/src/threading/ReactionTask.cpp
@@ -40,7 +40,7 @@ namespace threading {
     ReactionTask::~ReactionTask() {
         // Decrement the number of active tasks
         if (parent != nullptr) {
-            --parent->active_tasks;
+            parent->active_tasks.fetch_sub(1, std::memory_order_release);
         }
     }
 
@@ -63,7 +63,7 @@ namespace threading {
 
     NUClear::id_t ReactionTask::new_task_id() {
         static std::atomic<NUClear::id_t> task_id_source(0);
-        return ++task_id_source;
+        return task_id_source.fetch_add(1, std::memory_order_seq_cst);
     }
 
     // Initialize our current task

--- a/src/threading/ReactionTask.hpp
+++ b/src/threading/ReactionTask.hpp
@@ -23,7 +23,6 @@
 #ifndef NUCLEAR_THREADING_REACTION_TASK_HPP
 #define NUCLEAR_THREADING_REACTION_TASK_HPP
 
-#include <atomic>
 #include <functional>
 #include <memory>
 #include <set>

--- a/src/util/GroupDescriptor.hpp
+++ b/src/util/GroupDescriptor.hpp
@@ -49,7 +49,7 @@ namespace util {
         static NUClear::id_t get_unique_group_id() noexcept {
             // Make group 0 the default group
             static std::atomic<NUClear::id_t> source{1};
-            return source++;
+            return source.fetch_add(1, std::memory_order_relaxed);
         }
     };
 

--- a/src/util/ThreadPoolDescriptor.hpp
+++ b/src/util/ThreadPoolDescriptor.hpp
@@ -62,7 +62,7 @@ namespace util {
          */
         static NUClear::id_t get_unique_pool_id() noexcept {
             static std::atomic<NUClear::id_t> source{2};
-            return source++;
+            return source.fetch_add(1, std::memory_order_relaxed);
         }
     };
 

--- a/src/util/TypeMap.hpp
+++ b/src/util/TypeMap.hpp
@@ -23,6 +23,7 @@
 #ifndef NUCLEAR_UTIL_TYPEMAP_HPP
 #define NUCLEAR_UTIL_TYPEMAP_HPP
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <vector>
@@ -68,13 +69,7 @@ namespace util {
          * @param d A pointer to the data to be stored (the map takes ownership)
          */
         static void set(std::shared_ptr<Value> d) {
-
-            // Do this once G++ supports it
-            // std::atomic_store_explicit(&data, d, std::memory_order_relaxed);
-
-            // Lock a mutex and set our data
-            const std::lock_guard<std::mutex> lock(mutex);
-            data = std::move(d);
+            std::atomic_store_explicit(&data, std::move(d), std::memory_order_release);
         }
 
         /**
@@ -83,17 +78,7 @@ namespace util {
          * @return A shared_ptr to the data that was previously stored
          */
         static std::shared_ptr<Value> get() {
-
-            // TODO(Trent) do this when gcc supports it
-            // std::atomic_load_explicit(&data, std::memory_order_relaxed);
-
-            std::shared_ptr<Value> d;
-            {
-                const std::lock_guard<std::mutex> lock(mutex);
-                d = data;
-            }
-
-            return d;
+            return std::atomic_load_explicit(&data, std::memory_order_acquire);
         }
     };
 
@@ -101,8 +86,6 @@ namespace util {
     template <typename MapID, typename Key, typename Value>
     std::shared_ptr<Value>
         TypeMap<MapID, Key, Value>::data;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-    template <typename MapID, typename Key, typename Value>
-    std::mutex TypeMap<MapID, Key, Value>::mutex;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 }  // namespace util
 }  // namespace NUClear


### PR DESCRIPTION
Use of atomics in the system has been improved.
Each of the atomic uses now has a memory order to help describe how the atomic is being used.

Also the get/set of the TypeMap was changed to atomics since most of the g++ versions that we target now support that