### PR TITLE
Simplify the filtering for TypeBind

### DIFF
--- a/src/dsl/operation/TypeBind.hpp
+++ b/src/dsl/operation/TypeBind.hpp
@@ -27,7 +27,7 @@
 
 namespace NUClear {
 
-// Forward declare the ReactionEvent type
+// Forward declarations
 namespace message {
     struct ReactionEvent;
     struct LogMessage;


### PR DESCRIPTION
Filtering for type bind was partially specialising the struct and rewriting the function. However it only really wanted to change one thing.
This instead uses a data struct to set for specific values