### PR TITLE
Fix up the incorrect type causing a stats loop

### DIFF
--- a/src/dsl/operation/TypeBind.hpp
+++ b/src/dsl/operation/TypeBind.hpp
@@ -29,18 +29,18 @@ namespace NUClear {
 
 // Forward declarations
 namespace message {
-    struct ReactionEvent;
+    struct ReactionStatistics;
     struct LogMessage;
 }  // namespace message
 
 namespace dsl {
     namespace operation {
 
-        // Disable emitting stats for triggers on ReactionEvent and LogMessage
+        // Disable emitting stats for triggers on types that would cause a loop
         template <typename T>
         struct EmitStats : std::true_type {};
         template <>
-        struct EmitStats<message::ReactionEvent> : std::false_type {};
+        struct EmitStats<message::ReactionStatistics> : std::false_type {};
         template <>
         struct EmitStats<message::LogMessage> : std::false_type {};
 


### PR DESCRIPTION
The loop prevention had the new ReactionEvent type that isn't in yet instead of ReactionStatistics which caused a loop