### PR TITLE
Change how ReactionStatistics works to be more useful for monitoring events

### DIFF
--- a/src/dsl/operation/TypeBind.hpp
+++ b/src/dsl/operation/TypeBind.hpp
@@ -29,6 +29,7 @@ namespace NUClear {
 
 // Forward declarations
 namespace message {
+    struct ReactionEvent;
     struct ReactionStatistics;
     struct LogMessage;
 }  // namespace message
@@ -39,6 +40,8 @@ namespace dsl {
         // Disable emitting stats for triggers on types that would cause a loop
         template <typename T>
         struct EmitStats : std::true_type {};
+        template <>
+        struct EmitStats<message::ReactionEvent> : std::false_type {};
         template <>
         struct EmitStats<message::ReactionStatistics> : std::false_type {};
         template <>

--- a/src/id.hpp
+++ b/src/id.hpp
@@ -30,6 +30,12 @@ namespace NUClear {
 /// This type is used when NUClear requires a unique identifier
 using id_t = std::size_t;
 
+/// A reaction and task id pair identify a specific task/reaction combination
+struct IDPair {
+    id_t reaction_id{0};
+    id_t task_id{0};
+};
+
 }  // namespace NUClear
 
 #endif  // NUCLEAR_UTIL_ID_HPP

--- a/src/threading/ReactionTask.hpp
+++ b/src/threading/ReactionTask.hpp
@@ -84,19 +84,15 @@ namespace threading {
             , pool_descriptor(thread_pool_fn(*this))
             , group_descriptor(group_fn(*this))
             // Only create a stats object if we wouldn't cause an infinite loop of stats
-            , stats(parent != nullptr && parent->emit_stats
-                            && (current_task == nullptr || current_task->stats != nullptr)
-                        ? std::make_shared<message::ReactionStatistics>(
-                              parent->identifiers,
-                              parent->id,
-                              id,
-                              current_task != nullptr ? current_task->parent->id : 0,
-                              current_task != nullptr ? current_task->id : 0,
-                              clock::now(),
-                              clock::time_point(std::chrono::seconds(0)),
-                              clock::time_point(std::chrono::seconds(0)),
-                              nullptr)
-                        : nullptr) {
+            , stats(
+                  parent != nullptr && parent->emit_stats && (current_task == nullptr || current_task->stats != nullptr)
+                      ? std::make_shared<message::ReactionStatistics>(
+                            parent->identifiers,
+                            IDPair{parent->id, id},
+                            current_task != nullptr ? IDPair{current_task->parent->id, current_task->id} : IDPair{0, 0},
+                            pool_descriptor,
+                            group_descriptor)
+                      : nullptr) {
             // Increment the number of active tasks
             if (parent != nullptr) {
                 parent->active_tasks.fetch_add(1, std::memory_order_release);

--- a/src/util/usage_clock.cpp
+++ b/src/util/usage_clock.cpp
@@ -1,0 +1,44 @@
+#include "usage_clock.hpp"
+
+#include <chrono>
+
+// Windows
+#if defined(_WIN32)
+    #include "platform.hpp"
+
+namespace NUClear {
+namespace util {
+
+    cpu_clock::time_point cpu_clock::now() noexcept {
+        FILETIME creation_time;
+        FILETIME exit_time;
+        FILETIME kernel_time;
+        FILETIME user_time;
+        if (GetThreadTimes(GetCurrentThread(), &creation_time, &exit_time, &kernel_time, &user_time) != -1) {
+            // Time in in 100 nanosecond intervals
+            uint64_t time = ((uint64_t(user_time.dwHighDateTime) << 32) | user_time.dwLowDateTime)
+                            + ((uint64_t(kernel_time.dwHighDateTime) << 32) | kernel_time.dwLowDateTime);
+            return time_point(std::chrono::duration<uint64_t, std::ratio<1LL, 10000000LL>>(time));
+        }
+        return time_point();
+    }
+
+}  // namespace util
+}  // namespace NUClear
+
+#else
+    #include <ctime>
+
+namespace NUClear {
+namespace util {
+
+    cpu_clock::time_point cpu_clock::now() noexcept {
+        ::timespec ts{};
+        ::clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts);
+        return time_point(std::chrono::seconds(ts.tv_sec) + std::chrono::nanoseconds(ts.tv_nsec));
+    }
+
+}  // namespace util
+}  // namespace NUClear
+
+#endif  // _WIN32

--- a/src/util/usage_clock.hpp
+++ b/src/util/usage_clock.hpp
@@ -1,0 +1,30 @@
+#ifndef NUCLEAR_UTIL_USAGE_CLOCK_HPP
+#define NUCLEAR_UTIL_USAGE_CLOCK_HPP
+
+#include <chrono>
+
+namespace NUClear {
+namespace util {
+
+    /**
+     * A clock that measures CPU time.
+     */
+    struct cpu_clock {
+        using duration              = std::chrono::nanoseconds;            ///< The duration type of the clock.
+        using rep                   = duration::rep;                       ///< The representation type of the duration.
+        using period                = duration::period;                    ///< The tick period of the clock.
+        using time_point            = std::chrono::time_point<cpu_clock>;  ///< The time point type of the clock.
+        static const bool is_steady = true;                                ///< Indicates if the clock is steady.
+
+        /**
+         * Get the current time point of the cpu clock for the current thread
+         *
+         * @return The current time point.
+         */
+        static time_point now() noexcept;
+    };
+
+}  // namespace util
+}  // namespace NUClear
+
+#endif  // NUCLEAR_UTIL_USAGE_CLOCK_HPP

--- a/tests/tests/api/ReactionStatisticsTiming.cpp
+++ b/tests/tests/api/ReactionStatisticsTiming.cpp
@@ -1,0 +1,181 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 NUClear Contributors
+ *
+ * This file is part of the NUClear codebase.
+ * See https://github.com/Fastcode/NUClear for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <nuclear>
+
+#include "test_util/TestBase.hpp"
+#include "test_util/TimeUnit.hpp"
+
+// Anonymous namespace to keep everything file local
+namespace {
+
+using TimeUnit = test_util::TimeUnit;
+
+/// Events that occur during the test and the time they occur
+/// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+std::vector<std::pair<std::string, NUClear::clock::time_point>> code_events;
+/// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+std::vector<std::pair<std::string, NUClear::clock::time_point>> stat_events;
+
+struct Usage {
+    std::map<std::string, std::chrono::steady_clock::duration> real;
+    std::map<std::string, NUClear::util::cpu_clock::duration> cpu;
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+Usage usage;
+
+struct DoTest {};
+struct HeavyTask {};
+struct LightTask {};
+
+const std::string heavy_name   = "Heavy";    // NOLINT(cert-err58-cpp)
+const std::string light_name   = "Light";    // NOLINT(cert-err58-cpp)
+const std::string initial_name = "Initial";  // NOLINT(cert-err58-cpp)
+constexpr int scale            = 5;          // Number of time units to sleep/wait for
+
+using NUClear::message::ReactionEvent;
+
+class TestReactor : public test_util::TestBase<TestReactor> {
+public:
+    TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment)) {
+
+        on<Trigger<Step<1>>, Priority::LOW>().then(initial_name + ":" + heavy_name, [this] {
+            code_events.emplace_back("Started " + initial_name + ":" + heavy_name, NUClear::clock::now());
+            code_events.emplace_back("Created " + heavy_name, NUClear::clock::now());
+            emit(std::make_unique<HeavyTask>());
+            code_events.emplace_back("Finished " + initial_name + ":" + heavy_name, NUClear::clock::now());
+        });
+        on<Trigger<HeavyTask>>().then(heavy_name, [] {
+            code_events.emplace_back("Started " + heavy_name, NUClear::clock::now());
+            auto start = NUClear::clock::now();
+            while (NUClear::clock::now() - start < TimeUnit(scale)) {
+            }
+            code_events.emplace_back("Finished " + heavy_name, NUClear::clock::now());
+        });
+
+        on<Trigger<Step<1>>, Priority::LOW>().then(initial_name + ":" + light_name, [this] {
+            code_events.emplace_back("Started " + initial_name + ":" + light_name, NUClear::clock::now());
+            code_events.emplace_back("Created " + light_name, NUClear::clock::now());
+            emit(std::make_unique<LightTask>());
+            code_events.emplace_back("Finished " + initial_name + ":" + light_name, NUClear::clock::now());
+        });
+        on<Trigger<LightTask>>().then(light_name, [] {
+            code_events.emplace_back("Started " + light_name, NUClear::clock::now());
+            std::this_thread::sleep_for(TimeUnit(scale));
+            code_events.emplace_back("Finished " + light_name, NUClear::clock::now());
+        });
+
+        on<Trigger<ReactionEvent>>().then([](const ReactionEvent& event) {
+            const auto& stats = *event.statistics;
+            // Check the name ends with light_name or heavy_name
+            if (stats.identifiers->name.substr(stats.identifiers->name.size() - light_name.size()) == light_name
+                || stats.identifiers->name.substr(stats.identifiers->name.size() - heavy_name.size()) == heavy_name) {
+
+                switch (event.type) {
+                    case ReactionEvent::CREATED:
+                        stat_events.emplace_back("Created " + stats.identifiers->name, stats.created.nuclear_time);
+                        break;
+                    case ReactionEvent::STARTED:
+                        stat_events.emplace_back("Started " + stats.identifiers->name, stats.started.nuclear_time);
+                        break;
+                    case ReactionEvent::FINISHED:
+                        stat_events.emplace_back("Finished " + stats.identifiers->name, stats.finished.nuclear_time);
+                        usage.real[stats.identifiers->name] = stats.finished.realtime - stats.started.realtime;
+                        usage.cpu[stats.identifiers->name]  = stats.finished.cpu_time - stats.started.cpu_time;
+                        break;
+                    default: break;
+                }
+            }
+        });
+
+        on<Startup>().then("Startup", [this] {
+            auto start = NUClear::clock::now();
+            code_events.emplace_back("Created " + initial_name + ":" + heavy_name, start);
+            code_events.emplace_back("Created " + initial_name + ":" + light_name, start);
+            emit(std::make_unique<Step<1>>());
+        });
+    }
+};
+}  // namespace
+
+TEST_CASE("Testing reaction statistics timing", "[api][reactionstatistics][timing]") {
+
+    NUClear::Configuration config;
+    config.thread_count = 1;
+    NUClear::PowerPlant plant(config);
+    plant.install<TestReactor>();
+    plant.start();
+
+    // Sort the stats events by timestamp as they are not always going to be in order due to how stats are processed
+    std::stable_sort(stat_events.begin(), stat_events.end(), [](const auto& lhs, const auto& rhs) {
+        return lhs.second < rhs.second;
+    });
+
+
+    auto make_delta = [](const std::vector<std::pair<std::string, NUClear::clock::time_point>>& events) {
+        std::vector<std::string> delta_events;
+        auto first = events.front().second;
+        for (const auto& event : events) {
+            auto delta = event.second - first;
+            auto units = test_util::round_to_test_units(delta / scale).count();
+            delta_events.push_back(event.first + " @ Step " + std::to_string(units));
+        }
+        return delta_events;
+    };
+
+    // Convert the events to delta strings where 1 unit is 1 step unit
+    std::vector<std::string> delta_code_events = make_delta(code_events);
+    std::vector<std::string> delta_stat_events = make_delta(stat_events);
+
+    const std::vector<std::string> expected = {
+        "Created Initial:Heavy @ Step 0",
+        "Created Initial:Light @ Step 0",
+        "Started Initial:Heavy @ Step 0",
+        "Created Heavy @ Step 0",
+        "Finished Initial:Heavy @ Step 0",
+        "Started Heavy @ Step 0",
+        "Finished Heavy @ Step 1",
+        "Started Initial:Light @ Step 1",
+        "Created Light @ Step 1",
+        "Finished Initial:Light @ Step 1",
+        "Started Light @ Step 1",
+        "Finished Light @ Step 2",
+    };
+
+
+    /* Info Scope */ {
+        INFO("Code Events:\n" << test_util::diff_string(expected, delta_code_events));
+        REQUIRE(delta_code_events == expected);
+    }
+    /* Info Scope */ {
+        INFO("Statistic Events:\n" << test_util::diff_string(expected, delta_stat_events));
+        REQUIRE(delta_stat_events == expected);
+    }
+
+    // Most of heavy real time should be cpu time
+    REQUIRE(usage.cpu[heavy_name] > usage.real[heavy_name] / 2);
+
+    // Most of light real time should be sleeping
+    REQUIRE(usage.cpu[light_name] < usage.real[light_name] / 2);
+}


### PR DESCRIPTION
Changes ReactionStatistics so it no longer only fires at the very end of a reaction. It will now fire progress updates as it goes through to allow monitoring of how reactions are going.

It also better conforms to trace file semantics so that they can be used to track reactions

Superceeds #99 as it integrates those changes too