### PR TITLE
Make shutdowns more reliable by making poll have its own running flag

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -61,4 +61,4 @@ jobs:
       - name: Test
         timeout-minutes: 3
         working-directory: build/tests
-        run: ctest -j$(nproc) --output-on-failure
+        run: ctest --output-on-failure -j$(nproc)

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -80,4 +80,4 @@ jobs:
       - name: Test
         timeout-minutes: 3
         working-directory: build/tests
-        run: ctest -j$(nproc) --output-on-failure
+        run: ctest --output-on-failure -j$(nproc)

--- a/src/PowerPlant.cpp
+++ b/src/PowerPlant.cpp
@@ -85,9 +85,6 @@ PowerPlant::~PowerPlant() {
 
 void PowerPlant::start() {
 
-    // We are now running
-    is_running.store(true, std::memory_order_release);
-
     // Direct emit startup event and command line arguments
     emit<dsl::word::emit::Direct>(std::make_unique<dsl::word::Startup>());
     emit_shared<dsl::word::emit::Direct>(dsl::store::DataStore<message::CommandLineArguments>::get());
@@ -148,19 +145,11 @@ void PowerPlant::log(const LogLevel& level, std::stringstream& message) {
 
 void PowerPlant::shutdown() {
 
-    // Stop running before we emit the Shutdown event
-    // Some things such as on<Always> depend on this flag and it's possible to miss it
-    is_running.store(false, std::memory_order_release);
-
     // Emit our shutdown event
     emit(std::make_unique<dsl::word::Shutdown>());
 
     // Shutdown the scheduler
     scheduler.shutdown();
-}
-
-bool PowerPlant::running() const {
-    return is_running.load(std::memory_order_acquire);
 }
 
 }  // namespace NUClear

--- a/src/PowerPlant.hpp
+++ b/src/PowerPlant.hpp
@@ -122,13 +122,6 @@ public:
     void shutdown();
 
     /**
-     * Gets the current running state of the PowerPlant.
-     *
-     * @return `true` if the PowerPlant is running, `false` if it is shut down, or is in the process of shutting down.
-     */
-    bool running() const;
-
-    /**
      * Installs a reactor of a particular type to the system.
      *
      * This function constructs a new Reactor of the template type.
@@ -352,8 +345,6 @@ public:
     threading::TaskScheduler scheduler;
     /// Our vector of Reactors, will get destructed when this vector is
     std::vector<std::unique_ptr<NUClear::Reactor>> reactors;
-    /// True if the powerplant is running
-    std::atomic<bool> is_running{false};
 };
 
 /**

--- a/src/dsl/word/UDP.hpp
+++ b/src/dsl/word/UDP.hpp
@@ -341,8 +341,9 @@ namespace dsl {
                 // Get our file descriptor from the magic cache
                 auto event = IO::get<DSL>(task);
 
-                // If our get is being run without an fd (something else triggered) then short circuit
-                if (!event) {
+                // If our get is being run without an fd (something else triggered)
+                // Or if the event is not a read event then short circuit
+                if (!event || (event.events & IO::READ) != IO::READ) {
                     return {};
                 }
 
@@ -366,7 +367,7 @@ namespace dsl {
                 mh.msg_iovlen     = 1;
 
                 // Receive our message
-                ssize_t received = recvmsg(event.fd, &mh, 0);
+                ssize_t received = recvmsg(event.fd, &mh, MSG_DONTWAIT);
                 if (received < 0) {
                     return {};
                 }

--- a/src/extension/IOController.hpp
+++ b/src/extension/IOController.hpp
@@ -125,6 +125,8 @@ namespace extension {
     private:
         /// The event that is used to wake up the WaitForMultipleEvents call
         notifier_t notifier;
+        /// If the IOController should continue running
+        std::atomic<bool> running{true};
 
         /// The mutex that protects the tasks list
         std::mutex tasks_mutex;

--- a/src/util/platform.hpp
+++ b/src/util/platform.hpp
@@ -156,6 +156,9 @@ using socklen_t = int;
     #define msg_controllen Control.len
     #define msg_flags      flags
 
+    // Windows doesn't have this flag, maybe we can implement it later for recvmsg
+    #define MSG_DONTWAIT 0
+
 // Reimplement the recvmsg function
 int recvmsg(fd_t fd, msghdr* msg, int flags);
 

--- a/tests/tests/dsl/UDP.cpp
+++ b/tests/tests/dsl/UDP.cpp
@@ -371,7 +371,6 @@ TEST_CASE("Testing sending and receiving of UDP messages", "[api][network][udp]"
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
-    plant.install<NUClear::extension::IOController>();
     plant.install<TestReactor>();
     plant.start();
 


### PR DESCRIPTION
Currently shutdowns aren't always reliable as when the Shutdown event is emitted, the scheduler itself hasn't been told to stop. Therefore the on<Always> that the IO Controller runs in may decide to start up again before the scheduler stops accepting tasks.

It will then sit on the poll forever