### PR TITLE
Swap to using hidden friends for operators

### DIFF
--- a/src/dsl/operation/ChronoTask.hpp
+++ b/src/dsl/operation/ChronoTask.hpp
@@ -69,8 +69,8 @@ namespace dsl {
              *
              * @return `true` if the other task is after this task
              */
-            bool operator<(const ChronoTask& other) const {
-                return time < other.time;
+            friend bool operator<(const ChronoTask& lhs, const ChronoTask& rhs) {
+                return lhs.time < rhs.time;
             }
 
             /**
@@ -80,8 +80,8 @@ namespace dsl {
              *
              * @return `true` if the other task is before this task
              */
-            bool operator>(const ChronoTask& other) const {
-                return time > other.time;
+            friend bool operator>(const ChronoTask& lhs, const ChronoTask& rhs) {
+                return lhs.time > rhs.time;
             }
 
             /**
@@ -91,8 +91,8 @@ namespace dsl {
              *
              * @return `true` if the other task is at the same time as this task
              */
-            bool operator==(const ChronoTask& other) const {
-                return time == other.time;
+            friend bool operator==(const ChronoTask& lhs, const ChronoTask& rhs) {
+                return lhs.time == rhs.time;
             }
 
             /// The task function, takes the time as a reference so it can be updated for multiple runs

--- a/src/extension/IOController.hpp
+++ b/src/extension/IOController.hpp
@@ -80,12 +80,13 @@ namespace extension {
              * can assume that if the same file descriptor shows up multiple times it will be next to each other.
              * This allows the events that are being watched to be or'ed together.
              *
-             * @param other  the other task to compare to
+             * @param lhs The left hand side of the comparison
+             * @param rhs The right hand side of the comparison
              *
              * @return `true` if this task is less than the other
              */
-            bool operator<(const Task& other) const {
-                return fd == other.fd ? listening_events < other.listening_events : fd < other.fd;
+            friend bool operator<(const Task& lhs, const Task& rhs) {
+                return lhs.fd == rhs.fd ? lhs.listening_events < rhs.listening_events : lhs.fd < rhs.fd;
             }
         };
 

--- a/src/threading/ReactionTask.hpp
+++ b/src/threading/ReactionTask.hpp
@@ -155,12 +155,13 @@ namespace threading {
          * The task with higher priority is considered less.
          * If two tasks have equal priority, the one with the lower ID is considered less.
          *
-         * @param other The other ReactionTask object to compare with.
+         * @param lhs The left hand side of the comparison
+         * @param rhs The right hand side of the comparison
          *
          * @return true if the current object is less than the other object, false otherwise.
          */
-        bool operator<(const ReactionTask& other) const {
-            return priority == other.priority ? id < other.id : priority > other.priority;
+        friend bool operator<(const ReactionTask& lhs, const ReactionTask& rhs) {
+            return lhs.priority == rhs.priority ? lhs.id < rhs.id : lhs.priority > rhs.priority;
         }
     };
 

--- a/src/threading/TaskScheduler.hpp
+++ b/src/threading/TaskScheduler.hpp
@@ -109,12 +109,13 @@ namespace threading {
             /**
              * Compare tasks based on their priority.
              *
-             * @param other the other task to compare to
+             * @param lhs The first task to compare
+             * @param rhs The second task to compare
              *
              * @return `true` if this task has a higher priority than the other task
              */
-            bool operator<(const Task& other) const {
-                return priority == other.priority ? id < other.id : priority > other.priority;
+            friend bool operator<(const Task& lhs, const Task& rhs) {
+                return lhs.priority == rhs.priority ? lhs.id < rhs.id : lhs.priority > rhs.priority;
             }
         };
 

--- a/src/util/GroupDescriptor.hpp
+++ b/src/util/GroupDescriptor.hpp
@@ -59,12 +59,13 @@ namespace util {
         /**
          * Compare two group descriptors by their group_id to allow for sorting and uniqueness
          *
-         * @param other the other group descriptor to compare to
+         * @param lhs the left hand side of the comparison
+         * @param rhs the right hand side of the comparison
          *
          * @return true if this group_id is less than the other group_id
          */
-        bool operator<(const GroupDescriptor& other) const {
-            return group_id < other.group_id;
+        friend bool operator<(const GroupDescriptor& lhs, const GroupDescriptor& rhs) {
+            return lhs.group_id < rhs.group_id;
         }
     };
 

--- a/tests/tests/util/serialise/serialise.cpp
+++ b/tests/tests/util/serialise/serialise.cpp
@@ -184,8 +184,8 @@ struct TriviallyCopyable {
     int8_t b;
     std::array<uint8_t, 2> c;
 
-    bool operator==(const TriviallyCopyable& rhs) const {
-        return a == rhs.a && b == rhs.b && c[0] == rhs.c[0] && c[1] == rhs.c[1];
+    friend bool operator==(const TriviallyCopyable& lhs, const TriviallyCopyable& rhs) {
+        return lhs.a == rhs.a && lhs.b == rhs.b && lhs.c[0] == rhs.c[0] && lhs.c[1] == rhs.c[1];
     }
 };
 static_assert(std::is_trivially_copyable<TriviallyCopyable>::value, "This type should be trivially copyable");


### PR DESCRIPTION
Swaps to using hidden friends for operators.

They are superior as they allow conversions to apply to both sides of the comparision.
Also the comparision is only considered if one of the sides of the comparision is of the correct class type.