### PR TITLE
Change test timeouts to be in realtime

### DIFF
--- a/src/PowerPlant.cpp
+++ b/src/PowerPlant.cpp
@@ -143,13 +143,13 @@ void PowerPlant::log(const LogLevel& level, std::stringstream& message) {
     log(level, message.str());
 }
 
-void PowerPlant::shutdown() {
+void PowerPlant::shutdown(bool force) {
 
     // Emit our shutdown event
     emit(std::make_unique<dsl::word::Shutdown>());
 
     // Shutdown the scheduler
-    scheduler.shutdown();
+    scheduler.shutdown(force);
 }
 
 }  // namespace NUClear

--- a/src/PowerPlant.hpp
+++ b/src/PowerPlant.hpp
@@ -118,8 +118,10 @@ public:
 
     /**
      * Shuts down the PowerPlant, tells all component threads to terminate and waits for them to finish.
+     *
+     * @param force If true, the PowerPlant will shutdown immediately without waiting for tasks to finish
      */
-    void shutdown();
+    void shutdown(bool force = false);
 
     /**
      * Installs a reactor of a particular type to the system.

--- a/src/threading/TaskScheduler.cpp
+++ b/src/threading/TaskScheduler.cpp
@@ -167,11 +167,14 @@ namespace threading {
         }
     }
 
-    void TaskScheduler::shutdown() {
+    void TaskScheduler::shutdown(bool force) {
         started.store(false, std::memory_order_release);
         running.store(false, std::memory_order_release);
         for (auto& pool : pool_queues) {
             const std::lock_guard<std::recursive_mutex> lock(pool.second->mutex);
+            if (force) {
+                pool.second->queue.clear();
+            }
             pool.second->condition.notify_all();
         }
     }

--- a/src/threading/TaskScheduler.hpp
+++ b/src/threading/TaskScheduler.hpp
@@ -163,9 +163,11 @@ namespace threading {
         /**
          *
          *  Shuts down the scheduler, all waiting threads are woken, and any attempt to get a task results in an
-         *  exception
+         *  exception.
+         *
+         * @param force If true, the scheduler will be shutdown immediately, and all tasks will be dropped
          */
-        void shutdown();
+        void shutdown(bool force = false);
 
         /**
          * Submit a new task to be executed to the Scheduler.

--- a/tests/test_util/TestBase.hpp
+++ b/tests/test_util/TestBase.hpp
@@ -65,7 +65,7 @@ public:
         }
 
         on<Shutdown>().then([this] {
-            std::lock_guard<std::mutex> lock(timeout_mutex);
+            const std::lock_guard<std::mutex> lock(timeout_mutex);
             clean_shutdown = true;
             timeout_cv.notify_all();
         });

--- a/tests/tests/api/TimeTravel.cpp
+++ b/tests/tests/api/TimeTravel.cpp
@@ -23,7 +23,7 @@ struct Results {
     std::array<TimePair, 2> events;
 };
 
-class TestReactor : public test_util::TestBase<TestReactor, 5000> {
+class TestReactor : public test_util::TestBase<TestReactor> {
 public:
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment), false) {
 

--- a/tests/tests/api/TimeTravelFrozen.cpp
+++ b/tests/tests/api/TimeTravelFrozen.cpp
@@ -13,7 +13,7 @@ constexpr std::chrono::milliseconds SHUTDOWN_TIME = std::chrono::milliseconds(12
 
 struct WaitForShutdown {};
 
-class TestReactor : public test_util::TestBase<TestReactor, 5000> {
+class TestReactor : public test_util::TestBase<TestReactor> {
 public:
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment), false) {
 

--- a/tests/tests/dsl/Every.cpp
+++ b/tests/tests/dsl/Every.cpp
@@ -37,7 +37,7 @@ class TestReactor : public test_util::TestBase<TestReactor> {
 
 public:
     TestReactor(std::unique_ptr<NUClear::Environment> environment)
-        : TestBase(std::move(environment), false, std::chrono::milliseconds(10000)) {
+        : TestBase(std::move(environment), false, std::chrono::seconds(10)) {
 
         // Trigger on 3 different types of every
         on<Every<1000, Per<std::chrono::seconds>>>().then([]() { every_times.push_back(NUClear::clock::now()); });

--- a/tests/tests/dsl/Every.cpp
+++ b/tests/tests/dsl/Every.cpp
@@ -33,10 +33,11 @@ std::vector<NUClear::clock::time_point> every_times;    // NOLINT(cppcoreguideli
 std::vector<NUClear::clock::time_point> per_times;      // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 std::vector<NUClear::clock::time_point> dynamic_times;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-class TestReactor : public test_util::TestBase<TestReactor, 20000> {
+class TestReactor : public test_util::TestBase<TestReactor> {
 
 public:
-    TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment), false) {
+    TestReactor(std::unique_ptr<NUClear::Environment> environment)
+        : TestBase(std::move(environment), false, std::chrono::milliseconds(10000)) {
 
         // Trigger on 3 different types of every
         on<Every<1000, Per<std::chrono::seconds>>>().then([]() { every_times.push_back(NUClear::clock::now()); });

--- a/tests/tests/dsl/Idle.cpp
+++ b/tests/tests/dsl/Idle.cpp
@@ -37,7 +37,7 @@ struct SimpleMessage {
 
 constexpr int time_step = 50;
 
-class TestReactor : public test_util::TestBase<TestReactor, 10000> {
+class TestReactor : public test_util::TestBase<TestReactor> {
 public:
     template <int N>
     struct CustomPool {

--- a/tests/tests/dsl/Idle.cpp
+++ b/tests/tests/dsl/Idle.cpp
@@ -51,7 +51,8 @@ public:
         emit(std::make_unique<Step<N + 1>>());
     }
 
-    TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment), false) {
+    TestReactor(std::unique_ptr<NUClear::Environment> environment)
+        : TestBase(std::move(environment), false, std::chrono::seconds(2)) {
 
         start_time = NUClear::clock::now();
 

--- a/tests/tests/dsl/IdleSync.cpp
+++ b/tests/tests/dsl/IdleSync.cpp
@@ -30,7 +30,7 @@ namespace {
 /// A vector of events that have happened
 std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-class TestReactor : public test_util::TestBase<TestReactor, 1000> {
+class TestReactor : public test_util::TestBase<TestReactor> {
 public:
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment), false) {
 

--- a/tests/tests/dsl/TCP.cpp
+++ b/tests/tests/dsl/TCP.cpp
@@ -57,7 +57,7 @@ struct TestConnection {
 
 struct Finished {};
 
-class TestReactor : public test_util::TestBase<TestReactor, 2000> {
+class TestReactor : public test_util::TestBase<TestReactor> {
 public:
     void handle_data(const std::string& name, const IO::Event& event) {
         // We have data to read
@@ -78,7 +78,8 @@ public:
         }
     }
 
-    TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment), false) {
+    TestReactor(std::unique_ptr<NUClear::Environment> environment)
+        : TestBase(std::move(environment), false, std::chrono::milliseconds(2000)) {
 
         for (const auto& t : active_tests) {
             switch (t) {

--- a/tests/tests/dsl/TCP.cpp
+++ b/tests/tests/dsl/TCP.cpp
@@ -79,7 +79,7 @@ public:
     }
 
     TestReactor(std::unique_ptr<NUClear::Environment> environment)
-        : TestBase(std::move(environment), false, std::chrono::milliseconds(2000)) {
+        : TestBase(std::move(environment), false, std::chrono::seconds(2)) {
 
         for (const auto& t : active_tests) {
             switch (t) {

--- a/tests/tests/dsl/Watchdog.cpp
+++ b/tests/tests/dsl/Watchdog.cpp
@@ -38,7 +38,7 @@ struct Flag {};
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
     TestReactor(std::unique_ptr<NUClear::Environment> environment)
-        : TestBase(std::move(environment), false, std::chrono::milliseconds(10000)), start(NUClear::clock::now()) {
+        : TestBase(std::move(environment), false), start(NUClear::clock::now()) {
 
         on<Watchdog<Flag<1>, 50, std::chrono::milliseconds>>().then([this] {
             events.push_back("Watchdog 1  triggered @ " + floored_time());

--- a/tests/tests/dsl/Watchdog.cpp
+++ b/tests/tests/dsl/Watchdog.cpp
@@ -35,10 +35,10 @@ std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-gl
 template <int I>
 struct Flag {};
 
-class TestReactor : public test_util::TestBase<TestReactor, 10000> {
+class TestReactor : public test_util::TestBase<TestReactor> {
 public:
     TestReactor(std::unique_ptr<NUClear::Environment> environment)
-        : TestBase(std::move(environment), false), start(NUClear::clock::now()) {
+        : TestBase(std::move(environment), false, std::chrono::milliseconds(10000)), start(NUClear::clock::now()) {
 
         on<Watchdog<Flag<1>, 50, std::chrono::milliseconds>>().then([this] {
             events.push_back("Watchdog 1  triggered @ " + floored_time());

--- a/tests/tests/dsl/emit/Delay.cpp
+++ b/tests/tests/dsl/emit/Delay.cpp
@@ -51,9 +51,10 @@ struct TargetTimeMessage {
 
 struct FinishTest {};
 
-class TestReactor : public test_util::TestBase<TestReactor, 2000> {
+class TestReactor : public test_util::TestBase<TestReactor> {
 public:
-    TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment), false) {
+    TestReactor(std::unique_ptr<NUClear::Environment> environment)
+        : TestBase(std::move(environment), false, std::chrono::milliseconds(2000)) {
 
         // Measure when messages were sent and received and print those values
         on<Trigger<DelayedMessage>>().then([](const DelayedMessage& m) {

--- a/tests/tests/dsl/emit/Delay.cpp
+++ b/tests/tests/dsl/emit/Delay.cpp
@@ -54,7 +54,7 @@ struct FinishTest {};
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
     TestReactor(std::unique_ptr<NUClear::Environment> environment)
-        : TestBase(std::move(environment), false, std::chrono::milliseconds(2000)) {
+        : TestBase(std::move(environment), false, std::chrono::seconds(2)) {
 
         // Measure when messages were sent and received and print those values
         on<Trigger<DelayedMessage>>().then([](const DelayedMessage& m) {


### PR DESCRIPTION
The current tests use on<Watchdog> for timing out tests.
This doesn't work if you manipulate the clock as the watchdog may never fire.

This changes it to just waiting for a specific amount of real time before ending the test.

Also makes the following other changes
- Makes the amount of time to wait a constuctor arugment rather than a template argument
- Makes a Fail struct that can be emitted to fail the test with a message (used by timeout)
- Adds a force option to powerplant shutdown to make it remove all queued tasks