### PR TITLE
Prevent multiple values in Trigger and With

### DIFF
--- a/src/Reactor.hpp
+++ b/src/Reactor.hpp
@@ -75,10 +75,10 @@ namespace dsl {
 
         struct NetworkSource;
 
-        template <typename...>
+        template <typename>
         struct Trigger;
 
-        template <typename...>
+        template <typename>
         struct With;
 
         struct Startup;
@@ -183,8 +183,8 @@ protected:
      **************************************************************************************************************/
 
     /// @copydoc dsl::word::Trigger
-    template <typename... Ts>
-    using Trigger = dsl::word::Trigger<Ts...>;
+    template <typename T>
+    using Trigger = dsl::word::Trigger<T>;
 
     /// @copydoc dsl::word::Priority
     using Priority = dsl::word::Priority;
@@ -209,8 +209,8 @@ protected:
     using TCP = dsl::word::TCP;
 
     /// @copydoc dsl::word::With
-    template <typename... Ts>
-    using With = dsl::word::With<Ts...>;
+    template <typename T>
+    using With = dsl::word::With<T>;
 
     /// @copydoc dsl::word::Optional
     template <typename... DSL>

--- a/src/dsl/word/Trigger.hpp
+++ b/src/dsl/word/Trigger.hpp
@@ -38,19 +38,14 @@ namespace dsl {
          * This will enact the execution of a task whenever T is emitted into the system.
          * When this occurs, read-only access to T will be provided to the triggering unit via a callback.
          *
-         * @code on<Trigger<T1, T2, ... >>() @endcode
-         * Note that a this request can handle triggers on multiple types.
-         * When using multiple types in the request the reaction will only be triggered once <b>all</b> of the trigger
-         * types have been emitted (at least once) since the last occurrence of the event.
-         *
          * @par Implements
          *  Bind, Get
          *
          * @tparam Ts The datatype on which a reaction callback will be triggered.
          *            Emission of this datatype into the system will trigger the subscribing reaction.
          */
-        template <typename... Ts>
-        struct Trigger : Fusion<operation::TypeBind<Ts>..., operation::CacheGet<Ts>...> {};
+        template <typename T>
+        struct Trigger : Fusion<operation::TypeBind<T>, operation::CacheGet<T>> {};
 
     }  // namespace word
 }  // namespace dsl

--- a/src/dsl/word/With.hpp
+++ b/src/dsl/word/With.hpp
@@ -55,8 +55,8 @@ namespace dsl {
          *
          * @tparam T The datatype/s which will be provided to a subscribing reaction when the reaction is triggered.
          */
-        template <typename... T>
-        struct With : Fusion<operation::CacheGet<T>...> {};
+        template <typename T>
+        struct With : Fusion<operation::CacheGet<T>> {};
 
     }  // namespace word
 }  // namespace dsl

--- a/tests/tests/dsl/DSLOrdering.cpp
+++ b/tests/tests/dsl/DSLOrdering.cpp
@@ -46,7 +46,7 @@ public:
             });
 
         // Make sure we can pass an empty function in here
-        on<Trigger<Message<1>>, With<Message<1>, Message<2>>>().then([] { events.push_back("Empty function"); });
+        on<Trigger<Message<1>>, With<Message<1>>, With<Message<2>>>().then([] { events.push_back("Empty function"); });
 
         on<Trigger<Step<1>>, Priority::LOW>().then([this] {
             events.push_back("Emitting 1");


### PR DESCRIPTION
Alllowing multiple values in Trigger and With
e.g.
```cpp
on<Trigger<A, B>>
```

It was never needed as you can have two trigger statements.

It also often lead to bugs where a misplaced `>` would make the Trigger take future DSL keywords.