### PR TITLE
Fixes null dereference if there is ever an exception thrown in submit()

### DIFF
--- a/src/PowerPlant.cpp
+++ b/src/PowerPlant.cpp
@@ -115,15 +115,16 @@ void PowerPlant::submit(const NUClear::id_t& id,
 void PowerPlant::submit(std::unique_ptr<threading::ReactionTask>&& task, const bool& immediate) noexcept {
     // Only submit non null tasks
     if (task) {
+        auto& reactor = task->parent->reactor;
         try {
             const std::shared_ptr<threading::ReactionTask> t(std::move(task));
             submit(t->id, t->priority, t->group_descriptor, t->pool_descriptor, immediate, [t]() { t->run(); });
         }
         catch (const std::exception& ex) {
-            task->parent->reactor.log<NUClear::ERROR>("There was an exception while submitting a reaction", ex.what());
+            reactor.log<NUClear::ERROR>("There was an exception while submitting a reaction", ex.what());
         }
         catch (...) {
-            task->parent->reactor.log<NUClear::ERROR>("There was an unknown exception while submitting a reaction");
+            reactor.log<NUClear::ERROR>("There was an unknown exception while submitting a reaction");
         }
     }
 }


### PR DESCRIPTION
`std::move` on line 120 nullifies `task` for a guaranteed crash if an exception is thrown.