### PR TITLE
Bring the dsl word filtering into a common metaprogram

### DIFF
--- a/src/dsl/fusion/BindFusion.hpp
+++ b/src/dsl/fusion/BindFusion.hpp
@@ -25,6 +25,7 @@
 
 #include "../../threading/Reaction.hpp"
 #include "../../util/FunctionFusion.hpp"
+#include "../../util/meta/Filter.hpp"
 #include "../operation/DSLProxy.hpp"
 #include "has_bind.hpp"
 
@@ -85,37 +86,13 @@ namespace dsl {
             }
         };
 
-        template <typename, typename = std::tuple<>>
-        struct BindWords;
-
-        /**
-         * Metafunction that extracts all of the Words with a bind function.
-         *
-         * @tparam Word1      The word we are looking at
-         * @tparam WordN      The words we have yet to look at
-         * @tparam FoundWords The words we have found with bind functions
-         */
-        template <typename Word1, typename... WordN, typename... FoundWords>
-        struct BindWords<std::tuple<Word1, WordN...>, std::tuple<FoundWords...>>
-            : std::conditional_t<has_bind<Word1>::value,
-                                 /*T*/ BindWords<std::tuple<WordN...>, std::tuple<FoundWords..., Word1>>,
-                                 /*F*/ BindWords<std::tuple<WordN...>, std::tuple<FoundWords...>>> {};
-
-        /**
-         * Termination case for the BindWords metafunction
-         *
-         * @tparam FoundWords The words we have found with bind functions
-         */
-        template <typename... FoundWords>
-        struct BindWords<std::tuple<>, std::tuple<FoundWords...>> {
-            using type = std::tuple<FoundWords...>;
-        };
-
-        /// Type that redirects types without a bind function to their proxy type
+        /// Redirect types without a bind function to their proxy type
         template <typename Word>
-        struct Bind {
-            using type = std::conditional_t<has_bind<Word>::value, Word, operation::DSLProxy<Word>>;
-        };
+        using Bind = std::conditional_t<has_bind<Word>::value, Word, operation::DSLProxy<Word>>;
+
+        /// Filter down DSL words to only those that have a bind function
+        template <typename... Words>
+        using BindWords = Filter<has_bind, Bind<Words>...>;
 
         // Default case where there are no bind words
         template <typename Words>
@@ -144,9 +121,7 @@ namespace dsl {
         };
 
         template <typename Word1, typename... WordN>
-        struct BindFusion
-            : BindFuser<
-                  typename BindWords<std::tuple<typename Bind<Word1>::type, typename Bind<WordN>::type...>>::type> {};
+        struct BindFusion : BindFuser<BindWords<Word1, WordN...>> {};
 
     }  // namespace fusion
 }  // namespace dsl

--- a/src/dsl/fusion/BindFusion.hpp
+++ b/src/dsl/fusion/BindFusion.hpp
@@ -25,8 +25,8 @@
 
 #include "../../threading/Reaction.hpp"
 #include "../../util/FunctionFusion.hpp"
-#include "../../util/meta/Filter.hpp"
 #include "../operation/DSLProxy.hpp"
+#include "FindWords.hpp"
 #include "has_bind.hpp"
 
 namespace NUClear {
@@ -86,14 +86,6 @@ namespace dsl {
             }
         };
 
-        /// Redirect types without a bind function to their proxy type
-        template <typename Word>
-        using Bind = std::conditional_t<has_bind<Word>::value, Word, operation::DSLProxy<Word>>;
-
-        /// Filter down DSL words to only those that have a bind function
-        template <typename... Words>
-        using BindWords = Filter<has_bind, Bind<Words>...>;
-
         // Default case where there are no bind words
         template <typename Words>
         struct BindFuser {};
@@ -121,7 +113,7 @@ namespace dsl {
         };
 
         template <typename Word1, typename... WordN>
-        struct BindFusion : BindFuser<BindWords<Word1, WordN...>> {};
+        struct BindFusion : BindFuser<FindWords<has_bind, Word1, WordN...>> {};
 
     }  // namespace fusion
 }  // namespace dsl

--- a/src/dsl/fusion/FindWords.hpp
+++ b/src/dsl/fusion/FindWords.hpp
@@ -1,0 +1,50 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 NUClear Contributors
+ *
+ * This file is part of the NUClear codebase.
+ * See https://github.com/Fastcode/NUClear for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef NUCLEAR_DSL_FUSION_FIND_WORDS_HPP
+#define NUCLEAR_DSL_FUSION_FIND_WORDS_HPP
+
+#include "../../util/meta/Filter.hpp"
+
+namespace NUClear {
+namespace dsl {
+    namespace fusion {
+
+        /**
+         * Filters the DSL words to only those that have the correct function.
+         *
+         * It will:
+         * - Attempt to use the word directly
+         * - If the word does not have the correct function, it will try the DSLProxy for that word
+         * - If neither have the correct function, it will remove the word from the list
+         *
+         * @tparam Check The function to check for
+         * @tparam Ts    The words to check
+         */
+        template <template <typename> class Check, typename... Ts>
+        using FindWords = Filter<Check, std::conditional_t<Check<Ts>::value, Ts, operation::DSLProxy<Ts>>...>;
+
+    }  // namespace fusion
+}  // namespace dsl
+}  // namespace NUClear
+
+#endif  // NUCLEAR_DSL_FUSION_FIND_WORDS_HPP

--- a/src/dsl/fusion/GetFusion.hpp
+++ b/src/dsl/fusion/GetFusion.hpp
@@ -24,9 +24,9 @@
 #define NUCLEAR_DSL_FUSION_GET_FUSION_HPP
 
 #include "../../threading/Reaction.hpp"
-#include "../../util/meta/Filter.hpp"
 #include "../../util/tuplify.hpp"
 #include "../operation/DSLProxy.hpp"
+#include "FindWords.hpp"
 #include "has_get.hpp"
 
 namespace NUClear {
@@ -45,14 +45,6 @@ namespace dsl {
                 return Function::template get<DSL>(task);
             }
         };
-
-        /// Redirect types without a get function to their proxy type
-        template <typename Word>
-        using Get = std::conditional_t<has_get<Word>::value, Word, operation::DSLProxy<Word>>;
-
-        /// Filter down DSL words to only those that have a get function
-        template <typename... Words>
-        using GetWords = Filter<has_get, Get<Words>...>;
 
         // Default case where there are no get words
         template <typename Words>
@@ -80,7 +72,7 @@ namespace dsl {
         };
 
         template <typename Word1, typename... WordN>
-        struct GetFusion : GetFuser<GetWords<Word1, WordN...>> {};
+        struct GetFusion : GetFuser<FindWords<has_get, Word1, WordN...>> {};
 
     }  // namespace fusion
 }  // namespace dsl

--- a/src/dsl/fusion/GroupFusion.hpp
+++ b/src/dsl/fusion/GroupFusion.hpp
@@ -28,21 +28,13 @@
 #include <stdexcept>
 
 #include "../../threading/Reaction.hpp"
-#include "../../util/meta/Filter.hpp"
 #include "../operation/DSLProxy.hpp"
+#include "FindWords.hpp"
 #include "has_group.hpp"
 
 namespace NUClear {
 namespace dsl {
     namespace fusion {
-
-        /// Redirect types without a group function to their proxy type
-        template <typename Word>
-        using Group = std::conditional_t<has_group<Word>::value, Word, operation::DSLProxy<Word>>;
-
-        /// Filter down DSL words to only those that have a group function
-        template <typename... Words>
-        using GroupWords = Filter<has_group, Group<Words>...>;
 
         // Default case where there are no group words
         template <typename Words>
@@ -76,7 +68,7 @@ namespace dsl {
         };
 
         template <typename Word1, typename... WordN>
-        struct GroupFusion : GroupFuser<GroupWords<Word1, WordN...>> {};
+        struct GroupFusion : GroupFuser<FindWords<has_group, Word1, WordN...>> {};
 
     }  // namespace fusion
 }  // namespace dsl

--- a/src/dsl/fusion/PoolFusion.hpp
+++ b/src/dsl/fusion/PoolFusion.hpp
@@ -27,21 +27,13 @@
 #include <stdexcept>
 
 #include "../../threading/ReactionTask.hpp"
-#include "../../util/meta/Filter.hpp"
 #include "../operation/DSLProxy.hpp"
+#include "FindWords.hpp"
 #include "has_pool.hpp"
 
 namespace NUClear {
 namespace dsl {
     namespace fusion {
-
-        /// Redirect types without a pool function to their proxy type
-        template <typename Word>
-        using Pool = std::conditional_t<has_pool<Word>::value, Word, operation::DSLProxy<Word>>;
-
-        /// Filter down DSL words to only those that have a pool function
-        template <typename... Words>
-        using PoolWords = Filter<has_pool, Pool<Words>...>;
 
         // Default case where there are no pool words
         template <typename Words>
@@ -70,7 +62,7 @@ namespace dsl {
         };
 
         template <typename Word1, typename... WordN>
-        struct PoolFusion : PoolFuser<PoolWords<Word1, WordN...>> {};
+        struct PoolFusion : PoolFuser<FindWords<has_pool, Word1, WordN...>> {};
 
     }  // namespace fusion
 }  // namespace dsl

--- a/src/dsl/fusion/PostconditionFusion.hpp
+++ b/src/dsl/fusion/PostconditionFusion.hpp
@@ -24,6 +24,7 @@
 #define NUCLEAR_DSL_FUSION_POSTCONDITION_FUSION_HPP
 
 #include "../../threading/ReactionTask.hpp"
+#include "../../util/meta/Filter.hpp"
 #include "../operation/DSLProxy.hpp"
 #include "has_postcondition.hpp"
 
@@ -31,40 +32,13 @@ namespace NUClear {
 namespace dsl {
     namespace fusion {
 
-        /// Type that redirects types without a postcondition function to their proxy type
+        /// Redirect types without a postcondition function to their proxy type
         template <typename Word>
-        struct Postcondition {
-            using type = std::conditional_t<has_postcondition<Word>::value, Word, operation::DSLProxy<Word>>;
-        };
+        using Postcondition = std::conditional_t<has_postcondition<Word>::value, Word, operation::DSLProxy<Word>>;
 
-        template <typename, typename = std::tuple<>>
-        struct PostconditionWords;
-
-        /**
-         * Metafunction that extracts all of the Words with a postcondition function.
-         *
-         * @tparam Word1      The word we are looking at
-         * @tparam WordN      The words we have yet to look at
-         * @tparam FoundWords The words we have found with postcondition functions
-         */
-        template <typename Word1, typename... WordN, typename... FoundWords>
-        struct PostconditionWords<std::tuple<Word1, WordN...>, std::tuple<FoundWords...>>
-            : std::conditional_t<has_postcondition<typename Postcondition<Word1>::type>::value,
-                                 /*T*/
-                                 PostconditionWords<std::tuple<WordN...>,
-                                                    std::tuple<FoundWords..., typename Postcondition<Word1>::type>>,
-                                 /*F*/ PostconditionWords<std::tuple<WordN...>, std::tuple<FoundWords...>>> {};
-
-        /**
-         * Termination case for the PostconditionWords metafunction.
-         *
-         * @tparam PostconditionWords The words we have found with postcondition functions
-         */
-        template <typename... FoundWords>
-        struct PostconditionWords<std::tuple<>, std::tuple<FoundWords...>> {
-            using type = std::tuple<FoundWords...>;
-        };
-
+        /// Filter down DSL words to only those that have a postcondition function
+        template <typename... Words>
+        using PostconditionWords = Filter<has_postcondition, Postcondition<Words>...>;
 
         // Default case where there are no postcondition words
         template <typename Words>
@@ -98,8 +72,7 @@ namespace dsl {
         };
 
         template <typename Word1, typename... WordN>
-        struct PostconditionFusion
-            : PostconditionFuser<typename PostconditionWords<std::tuple<Word1, WordN...>>::type> {};
+        struct PostconditionFusion : PostconditionFuser<PostconditionWords<Word1, WordN...>> {};
 
     }  // namespace fusion
 }  // namespace dsl

--- a/src/dsl/fusion/PostconditionFusion.hpp
+++ b/src/dsl/fusion/PostconditionFusion.hpp
@@ -24,21 +24,13 @@
 #define NUCLEAR_DSL_FUSION_POSTCONDITION_FUSION_HPP
 
 #include "../../threading/ReactionTask.hpp"
-#include "../../util/meta/Filter.hpp"
 #include "../operation/DSLProxy.hpp"
+#include "FindWords.hpp"
 #include "has_postcondition.hpp"
 
 namespace NUClear {
 namespace dsl {
     namespace fusion {
-
-        /// Redirect types without a postcondition function to their proxy type
-        template <typename Word>
-        using Postcondition = std::conditional_t<has_postcondition<Word>::value, Word, operation::DSLProxy<Word>>;
-
-        /// Filter down DSL words to only those that have a postcondition function
-        template <typename... Words>
-        using PostconditionWords = Filter<has_postcondition, Postcondition<Words>...>;
 
         // Default case where there are no postcondition words
         template <typename Words>
@@ -72,7 +64,7 @@ namespace dsl {
         };
 
         template <typename Word1, typename... WordN>
-        struct PostconditionFusion : PostconditionFuser<PostconditionWords<Word1, WordN...>> {};
+        struct PostconditionFusion : PostconditionFuser<FindWords<has_postcondition, Word1, WordN...>> {};
 
     }  // namespace fusion
 }  // namespace dsl

--- a/src/dsl/fusion/PreconditionFusion.hpp
+++ b/src/dsl/fusion/PreconditionFusion.hpp
@@ -24,21 +24,13 @@
 #define NUCLEAR_DSL_FUSION_PRECONDITION_FUSION_HPP
 
 #include "../../threading/ReactionTask.hpp"
-#include "../../util/meta/Filter.hpp"
 #include "../operation/DSLProxy.hpp"
+#include "FindWords.hpp"
 #include "has_precondition.hpp"
 
 namespace NUClear {
 namespace dsl {
     namespace fusion {
-
-        /// Redirect types without a precondition function to their proxy type
-        template <typename Word>
-        using Precondition = std::conditional_t<has_precondition<Word>::value, Word, operation::DSLProxy<Word>>;
-
-        /// Filter down DSL words to only those that have a precondition function
-        template <typename... Words>
-        using PreconditionWords = Filter<has_precondition, Precondition<Words>...>;
 
         // Default case where there are no precondition words
         template <typename Words>
@@ -70,7 +62,7 @@ namespace dsl {
         };
 
         template <typename Word1, typename... WordN>
-        struct PreconditionFusion : PreconditionFuser<PreconditionWords<Word1, WordN...>> {};
+        struct PreconditionFusion : PreconditionFuser<FindWords<has_precondition, Word1, WordN...>> {};
 
     }  // namespace fusion
 }  // namespace dsl

--- a/src/dsl/fusion/PreconditionFusion.hpp
+++ b/src/dsl/fusion/PreconditionFusion.hpp
@@ -24,6 +24,7 @@
 #define NUCLEAR_DSL_FUSION_PRECONDITION_FUSION_HPP
 
 #include "../../threading/ReactionTask.hpp"
+#include "../../util/meta/Filter.hpp"
 #include "../operation/DSLProxy.hpp"
 #include "has_precondition.hpp"
 
@@ -31,40 +32,13 @@ namespace NUClear {
 namespace dsl {
     namespace fusion {
 
-        /// Type that redirects types without a precondition function to their proxy type
+        /// Redirect types without a precondition function to their proxy type
         template <typename Word>
-        struct Precondition {
-            using type = std::conditional_t<has_precondition<Word>::value, Word, operation::DSLProxy<Word>>;
-        };
+        using Precondition = std::conditional_t<has_precondition<Word>::value, Word, operation::DSLProxy<Word>>;
 
-        template <typename, typename = std::tuple<>>
-        struct PreconditionWords;
-
-        /**
-         * Metafunction that extracts all of the Words with a precondition function.
-         *
-         * @tparam Word1      The word we are looking at
-         * @tparam WordN      The words we have yet to look at
-         * @tparam FoundWords The words we have found with precondition functions
-         */
-        template <typename Word1, typename... WordN, typename... FoundWords>
-        struct PreconditionWords<std::tuple<Word1, WordN...>, std::tuple<FoundWords...>>
-            : std::conditional_t<has_precondition<typename Precondition<Word1>::type>::value,
-                                 /*T*/
-                                 PreconditionWords<std::tuple<WordN...>,
-                                                   std::tuple<FoundWords..., typename Precondition<Word1>::type>>,
-                                 /*F*/ PreconditionWords<std::tuple<WordN...>, std::tuple<FoundWords...>>> {};
-
-        /**
-         * Termination case for the PreconditionWords metafunction.
-         *
-         * @tparam FoundWords The words we have found with precondition functions
-         */
-        template <typename... FoundWords>
-        struct PreconditionWords<std::tuple<>, std::tuple<FoundWords...>> {
-            using type = std::tuple<FoundWords...>;
-        };
-
+        /// Filter down DSL words to only those that have a precondition function
+        template <typename... Words>
+        using PreconditionWords = Filter<has_precondition, Precondition<Words>...>;
 
         // Default case where there are no precondition words
         template <typename Words>
@@ -96,7 +70,7 @@ namespace dsl {
         };
 
         template <typename Word1, typename... WordN>
-        struct PreconditionFusion : PreconditionFuser<typename PreconditionWords<std::tuple<Word1, WordN...>>::type> {};
+        struct PreconditionFusion : PreconditionFuser<PreconditionWords<Word1, WordN...>> {};
 
     }  // namespace fusion
 }  // namespace dsl

--- a/src/dsl/fusion/PriorityFusion.hpp
+++ b/src/dsl/fusion/PriorityFusion.hpp
@@ -24,6 +24,7 @@
 #define NUCLEAR_DSL_FUSION_PRIORITY_FUSION_HPP
 
 #include "../../threading/ReactionTask.hpp"
+#include "../../util/meta/Filter.hpp"
 #include "../operation/DSLProxy.hpp"
 #include "has_priority.hpp"
 
@@ -33,37 +34,11 @@ namespace dsl {
 
         /// Type that redirects types without a priority function to their proxy type
         template <typename Word>
-        struct Priority {
-            using type = std::conditional_t<has_priority<Word>::value, Word, operation::DSLProxy<Word>>;
-        };
+        using Priority = std::conditional_t<has_priority<Word>::value, Word, operation::DSLProxy<Word>>;
 
-        template <typename, typename = std::tuple<>>
-        struct PriorityWords;
-
-        /**
-         * Metafunction that extracts all of the Words with a priority function.
-         *
-         * @tparam Word1      The word we are looking at
-         * @tparam WordN      The words we have yet to look at
-         * @tparam FoundWords The words we have found with priority functions
-         */
-        template <typename Word1, typename... WordN, typename... FoundWords>
-        struct PriorityWords<std::tuple<Word1, WordN...>, std::tuple<FoundWords...>>
-            : std::conditional_t<
-                  has_priority<typename Priority<Word1>::type>::value,
-                  /*T*/ PriorityWords<std::tuple<WordN...>, std::tuple<FoundWords..., typename Priority<Word1>::type>>,
-                  /*F*/ PriorityWords<std::tuple<WordN...>, std::tuple<FoundWords...>>> {};
-
-        /**
-         * Termination case for the PriorityWords metafunction.
-         *
-         * @tparam FoundWords The words we have found with priority functions
-         */
-        template <typename... FoundWords>
-        struct PriorityWords<std::tuple<>, std::tuple<FoundWords...>> {
-            using type = std::tuple<FoundWords...>;
-        };
-
+        /// Filter down DSL words to only those that have a priority function
+        template <typename... Words>
+        using PriorityWords = Filter<has_priority, Priority<Words>...>;
 
         // Default case where there are no priority words
         template <typename Words>
@@ -95,7 +70,7 @@ namespace dsl {
         };
 
         template <typename Word1, typename... WordN>
-        struct PriorityFusion : PriorityFuser<typename PriorityWords<std::tuple<Word1, WordN...>>::type> {};
+        struct PriorityFusion : PriorityFuser<PriorityWords<Word1, WordN...>> {};
 
     }  // namespace fusion
 }  // namespace dsl

--- a/src/dsl/fusion/PriorityFusion.hpp
+++ b/src/dsl/fusion/PriorityFusion.hpp
@@ -24,21 +24,13 @@
 #define NUCLEAR_DSL_FUSION_PRIORITY_FUSION_HPP
 
 #include "../../threading/ReactionTask.hpp"
-#include "../../util/meta/Filter.hpp"
 #include "../operation/DSLProxy.hpp"
+#include "FindWords.hpp"
 #include "has_priority.hpp"
 
 namespace NUClear {
 namespace dsl {
     namespace fusion {
-
-        /// Type that redirects types without a priority function to their proxy type
-        template <typename Word>
-        using Priority = std::conditional_t<has_priority<Word>::value, Word, operation::DSLProxy<Word>>;
-
-        /// Filter down DSL words to only those that have a priority function
-        template <typename... Words>
-        using PriorityWords = Filter<has_priority, Priority<Words>...>;
 
         // Default case where there are no priority words
         template <typename Words>
@@ -70,7 +62,7 @@ namespace dsl {
         };
 
         template <typename Word1, typename... WordN>
-        struct PriorityFusion : PriorityFuser<PriorityWords<Word1, WordN...>> {};
+        struct PriorityFusion : PriorityFuser<FindWords<has_priority, Word1, WordN...>> {};
 
     }  // namespace fusion
 }  // namespace dsl

--- a/src/util/meta/Filter.hpp
+++ b/src/util/meta/Filter.hpp
@@ -1,0 +1,79 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 NUClear Contributors
+ *
+ * This file is part of the NUClear codebase.
+ * See https://github.com/Fastcode/NUClear for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef NUCLEAR_UTIL_META_FILTER_HPP
+#define NUCLEAR_UTIL_META_FILTER_HPP
+
+#include <tuple>
+#include <type_traits>
+
+namespace NUClear {
+
+namespace util {
+    namespace meta {
+
+        template <template <typename> class Check, typename Current, typename Found = std::tuple<>>
+        struct DoFilter;
+
+        /**
+         * Metafunction that extracts all of the types which pass the check from the tuple
+         *
+         * @tparam Check   The check to perform on each of the types
+         * @tparam T       The current type being inspected
+         * @tparam Ts      The remainder of the types to check
+         * @tparam Found   The list of types which have already passed the check
+         *
+         * @return A tuple of the types which passed the check
+         */
+        template <template <typename> class Check, typename T1, typename... Ts, typename... Found>
+        struct DoFilter<Check, std::tuple<T1, Ts...>, std::tuple<Found...>>
+            : std::conditional_t<Check<T1>::value,
+                                 DoFilter<Check, std::tuple<Ts...>, std::tuple<Found..., T1>>,
+                                 DoFilter<Check, std::tuple<Ts...>, std::tuple<Found...>>> {};
+
+        /**
+         * Termination case for the Filter metafunction.
+         *
+         * @tparam Found The words that passed the filter check
+         */
+        template <template <typename> class Check, typename... Found>
+        struct DoFilter<Check, std::tuple<>, std::tuple<Found...>> {
+            using type = std::tuple<Found...>;
+        };
+
+    }  // namespace meta
+}  // namespace util
+
+/**
+ * Metafunction that extracts all of the types which pass the check from the tuple
+ *
+ * @tparam Check The check to perform on each of the types
+ * @tparam Ts    The types to check
+ *
+ * @return A tuple of the types which passed the check
+ */
+template <template <typename> class Check, typename... Ts>
+using Filter = typename util::meta::DoFilter<Check, std::tuple<Ts...>>::type;
+
+}  // namespace NUClear
+
+#endif  // NUCLEAR_UTIL_META_FILTER_HPP

--- a/tests/tests/dsl/GroupPool.cpp
+++ b/tests/tests/dsl/GroupPool.cpp
@@ -33,7 +33,7 @@ std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-gl
 /// @brief Add an event to the event list
 void add_event(const std::string& event) {
     static std::mutex events_mutex;
-    std::lock_guard<std::mutex> lock(events_mutex);
+    const std::lock_guard<std::mutex> lock(events_mutex);
     events.push_back(event);
 }
 
@@ -42,7 +42,7 @@ struct Synced {};
 template <int id>
 struct PoolFinished {};
 
-static constexpr int POOL_COUNT = 10;
+constexpr int POOL_COUNT = 10;
 
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
@@ -52,7 +52,7 @@ public:
     };
 
     template <int... ID>
-    void register_callbacks(NUClear::util::Sequence<ID...>) {
+    void register_callbacks(NUClear::util::Sequence<ID...> /*unused*/) {
 
         NUClear::util::unpack(on<Trigger<Synced>, Pool<TestPool<ID>>, Sync<TestReactor>>().then([this] {
             add_event("Pool Message");

--- a/tests/tests/dsl/GroupPool.cpp
+++ b/tests/tests/dsl/GroupPool.cpp
@@ -51,15 +51,23 @@ public:
         static constexpr int thread_count = 1;
     };
 
-    template <int... ID>
-    void register_callbacks(NUClear::util::Sequence<ID...> /*unused*/) {
+    void register_pool_callbacks(NUClear::util::Sequence<> /*unused*/) {}
 
-        NUClear::util::unpack(on<Trigger<Synced>, Pool<TestPool<ID>>, Sync<TestReactor>>().then([this] {
+    template <int ID, int... IDs>
+    void register_pool_callbacks(NUClear::util::Sequence<ID, IDs...> /*unused*/) {
+        on<Trigger<Synced>, Pool<TestPool<ID>>, Sync<TestReactor>>().then([this] {
             add_event("Pool Message");
             emit(std::make_unique<PoolFinished<ID>>());
-        })...);
+        });
 
-        on<Trigger<PoolFinished<ID>>...>().then([this] {
+        register_pool_callbacks(NUClear::util::Sequence<IDs...>());
+    }
+
+    template <int... IDs>
+    void register_callbacks(NUClear::util::Sequence<IDs...> /*unused*/) {
+        register_pool_callbacks(NUClear::util::Sequence<IDs...>());
+
+        on<Trigger<PoolFinished<IDs>>...>().then([this] {
             add_event("Finished");
             powerplant.shutdown();
         });


### PR DESCRIPTION
All of the DSL fusions were using the exact same structure to filter their words down to those that had the functions they wanted.

This pulls that common logic out into a metafunction and uses it to simplify the code.