### PR TITLE
Reduce the number of globals in tests

### DIFF
--- a/src/dsl/word/Pool.hpp
+++ b/src/dsl/word/Pool.hpp
@@ -49,7 +49,7 @@ namespace dsl {
             }
 
             template <typename, typename... A>
-            static constexpr bool check(A&&... /*unused*/) {
+            static constexpr bool check(const A&... /*unused*/) {
                 return true;
             }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,9 @@ FetchContent_Declare(
   SYSTEM DOWNLOAD_EXTRACT_TIMESTAMP TRUE
   URL https://github.com/catchorg/Catch2/archive/refs/tags/v3.6.0.tar.gz
 )
+
+# Add CATCH_CONFIG_CONSOLE_WIDTH=120 to cmake options
+set(CATCH_CONFIG_CONSOLE_WIDTH 120)
 FetchContent_MakeAvailable(Catch2)
 
 # Silence clang-tidy warnings from catch2

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,8 +27,6 @@ FetchContent_Declare(
   SYSTEM DOWNLOAD_EXTRACT_TIMESTAMP TRUE
   URL https://github.com/catchorg/Catch2/archive/refs/tags/v3.6.0.tar.gz
 )
-
-# Add CATCH_CONFIG_CONSOLE_WIDTH=120 to cmake options
 set(CATCH_CONFIG_CONSOLE_WIDTH 120)
 FetchContent_MakeAvailable(Catch2)
 

--- a/tests/networktest.cpp
+++ b/tests/networktest.cpp
@@ -26,7 +26,6 @@
 #include <iostream>
 #include <nuclear>
 
-namespace {
 struct PerformEmits {};
 
 using NUClear::message::CommandLineArguments;
@@ -119,8 +118,6 @@ public:
         });
     }
 };
-}  // namespace
-
 
 // NOLINTNEXTLINE(bugprone-exception-escape)
 int main(int argc, const char* argv[]) {

--- a/tests/tests/api/ReactionStatistics.cpp
+++ b/tests/tests/api/ReactionStatistics.cpp
@@ -26,19 +26,15 @@
 #include "test_util/TestBase.hpp"
 
 // This namespace is named to make things consistent with the reaction statistics test
-namespace stats_test {
-
-/// Events that occur during the test
-std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
-template <int id>
-struct Message {};
-struct LoopMessage {};
 
 using NUClear::message::ReactionEvent;
 
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
+    template <int id>
+    struct Message {};
+    struct LoopMessage {};
+
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment)) {
 
         // This reaction is here to emit something from a ReactionStatistics trigger
@@ -77,7 +73,7 @@ public:
             }
         });
 
-        on<Trigger<Message<1>>>().then("Exception Handler", [] {
+        on<Trigger<Message<1>>>().then("Exception Handler", [this] {
             events.push_back("Running Exception Handler");
             throw std::runtime_error("Text in an exception");
         });
@@ -92,33 +88,36 @@ public:
             emit(std::make_unique<Message<0>>());
         });
     }
+
+    /// Events that occur during the test
+    std::vector<std::string> events;
 };
-}  // namespace stats_test
+
 
 TEST_CASE("Testing reaction statistics functionality", "[api][reactionstatistics]") {
 
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
-    plant.install<stats_test::TestReactor>();
+    const auto& reactor = plant.install<TestReactor>();
     plant.start();
 
     const std::vector<std::string> expected = {
         "Running Startup Handler",
-        "Stats for Startup Handler from stats_test::TestReactor",
+        "Stats for Startup Handler from ::TestReactor",
         "NUClear::Reactor::on<NUClear::dsl::word::Startup>",
         "Running Message Handler",
-        "Stats for Message Handler from stats_test::TestReactor",
-        "NUClear::Reactor::on<NUClear::dsl::word::Trigger<stats_test::Message<0>>>",
+        "Stats for Message Handler from ::TestReactor",
+        "NUClear::Reactor::on<NUClear::dsl::word::Trigger<::Message<0>>>",
         "Running Exception Handler",
-        "Stats for Exception Handler from stats_test::TestReactor",
-        "NUClear::Reactor::on<NUClear::dsl::word::Trigger<stats_test::Message<1>>>",
+        "Stats for Exception Handler from ::TestReactor",
+        "NUClear::Reactor::on<NUClear::dsl::word::Trigger<::Message<1>>>",
         "Exception received: \"Text in an exception\"",
     };
 
     // Make an info print the diff in an easy to read way if we fail
-    INFO(test_util::diff_string(expected, stats_test::events));
+    INFO(test_util::diff_string(expected, reactor.events));
 
     // Check the events fired in order and only those events
-    REQUIRE(stats_test::events == expected);
+    REQUIRE(reactor.events == expected);
 }

--- a/tests/tests/api/ReactionStatistics.cpp
+++ b/tests/tests/api/ReactionStatistics.cpp
@@ -104,14 +104,14 @@ TEST_CASE("Testing reaction statistics functionality", "[api][reactionstatistics
 
     const std::vector<std::string> expected = {
         "Running Startup Handler",
-        "Stats for Startup Handler from ::TestReactor",
+        "Stats for Startup Handler from TestReactor",
         "NUClear::Reactor::on<NUClear::dsl::word::Startup>",
         "Running Message Handler",
-        "Stats for Message Handler from ::TestReactor",
-        "NUClear::Reactor::on<NUClear::dsl::word::Trigger<::Message<0>>>",
+        "Stats for Message Handler from TestReactor",
+        "NUClear::Reactor::on<NUClear::dsl::word::Trigger<TestReactor::Message<0>>>",
         "Running Exception Handler",
-        "Stats for Exception Handler from ::TestReactor",
-        "NUClear::Reactor::on<NUClear::dsl::word::Trigger<::Message<1>>>",
+        "Stats for Exception Handler from TestReactor",
+        "NUClear::Reactor::on<NUClear::dsl::word::Trigger<TestReactor::Message<1>>>",
         "Exception received: \"Text in an exception\"",
     };
 

--- a/tests/tests/api/ReactionStatisticsTiming.cpp
+++ b/tests/tests/api/ReactionStatisticsTiming.cpp
@@ -26,9 +26,6 @@
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 
-// Anonymous namespace to keep everything file local
-namespace {
-
 using TimeUnit = test_util::TimeUnit;
 
 /// Events that occur during the test and the time they occur
@@ -118,7 +115,7 @@ public:
         });
     }
 };
-}  // namespace
+
 
 TEST_CASE("Testing reaction statistics timing", "[api][reactionstatistics][timing]") {
 

--- a/tests/tests/api/ReactorArgs.cpp
+++ b/tests/tests/api/ReactorArgs.cpp
@@ -23,9 +23,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <nuclear>
 
-// Anonymous namespace to keep everything file local
-namespace {
-
 class TestReactorNoArgs : public NUClear::Reactor {
 public:
     TestReactorNoArgs(std::unique_ptr<NUClear::Environment> environment) : NUClear::Reactor(std::move(environment)) {}
@@ -44,7 +41,6 @@ public:
     uint32_t i{0};
 };
 
-}  // namespace
 
 TEST_CASE("Testing Reactor installation arguments", "[api][reactorargs]") {
     NUClear::Configuration config;

--- a/tests/tests/api/TimeTravel.cpp
+++ b/tests/tests/api/TimeTravel.cpp
@@ -5,8 +5,6 @@
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 
-namespace {
-
 using TimeUnit = test_util::TimeUnit;
 
 constexpr int64_t EVENT_1_TIME = 4;
@@ -73,7 +71,6 @@ public:
     Results results;
 };
 
-}  // anonymous namespace
 
 TEST_CASE("Test time travel correctly changes the time for non zero rtf", "[time_travel][chrono_controller]") {
 

--- a/tests/tests/api/TimeTravelFrozen.cpp
+++ b/tests/tests/api/TimeTravelFrozen.cpp
@@ -109,5 +109,5 @@ TEST_CASE("Test time travel correctly changes the time for non zero rtf", "[time
     }
 
     INFO(test_util::diff_string(expected, reactor.events));
-    CHECK(reactor.events, expected);
+    CHECK(reactor.events == expected);
 }

--- a/tests/tests/api/TimeTravelFrozen.cpp
+++ b/tests/tests/api/TimeTravelFrozen.cpp
@@ -5,8 +5,6 @@
 
 #include "test_util/TestBase.hpp"
 
-namespace {
-
 constexpr std::chrono::milliseconds EVENT_1_TIME  = std::chrono::milliseconds(4);
 constexpr std::chrono::milliseconds EVENT_2_TIME  = std::chrono::milliseconds(8);
 constexpr std::chrono::milliseconds SHUTDOWN_TIME = std::chrono::milliseconds(12);
@@ -67,7 +65,6 @@ public:
     std::vector<std::string> events;
 };
 
-}  // anonymous namespace
 
 TEST_CASE("Test time travel correctly changes the time for non zero rtf", "[time_travel][chrono_controller]") {
 
@@ -112,5 +109,5 @@ TEST_CASE("Test time travel correctly changes the time for non zero rtf", "[time
     }
 
     INFO(test_util::diff_string(expected, reactor.events));
-    CHECK(expected == reactor.events);
+    CHECK(reactor.events, expected);
 }

--- a/tests/tests/dsl/Always.cpp
+++ b/tests/tests/dsl/Always.cpp
@@ -25,15 +25,9 @@
 
 #include "test_util/TestBase.hpp"
 
-namespace {
-
-/// Events that occur during the test
-std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
-struct SimpleMessage {};
-
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
+    struct SimpleMessage {};
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment), false) {
 
         on<Always>().then([this] {
@@ -56,15 +50,18 @@ public:
 
     /// Counter for the number of times we have run
     int i = 0;
+
+    /// Events that occur during the test
+    std::vector<std::string> events;
 };
-}  // namespace
+
 
 TEST_CASE("The Always DSL keyword runs continuously when it can", "[api][always]") {
 
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
-    plant.install<TestReactor>();
+    auto& reactor = plant.install<TestReactor>();
     plant.start();
 
     const std::vector<std::string> expected = {
@@ -82,8 +79,8 @@ TEST_CASE("The Always DSL keyword runs continuously when it can", "[api][always]
     };
 
     // Make an info print the diff in an easy to read way if we fail
-    INFO(test_util::diff_string(expected, events));
+    INFO(test_util::diff_string(expected, reactor.events));
 
     // Check the events fired in order and only those events
-    REQUIRE(events == expected);
+    REQUIRE(reactor.events == expected);
 }

--- a/tests/tests/dsl/ArgumentFission.cpp
+++ b/tests/tests/dsl/ArgumentFission.cpp
@@ -26,11 +26,6 @@
 
 #include "test_util/TestBase.hpp"
 
-namespace {
-
-/// Events that occur during the test
-std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
 struct BindExtensionTest1 {
     template <typename DSL>
     static int bind(const std::shared_ptr<NUClear::threading::Reaction>& /*unused*/, const int& v1, const bool& v2) {
@@ -83,15 +78,18 @@ public:
         events.push_back(std::string("Bind2 returned ") + (b ? "true" : "false"));
         events.push_back("Bind3 returned " + c);
     }
+
+    /// Events that occur during the test
+    std::vector<std::string> events;
 };
-}  // namespace
+
 
 TEST_CASE("Testing distributing arguments to multiple bind functions (NUClear Fission)", "[api][dsl][fission]") {
 
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
-    plant.install<TestReactor>();
+    const auto& reactor = plant.install<TestReactor>();
     plant.start();
 
     const std::vector<std::string> expected = {
@@ -104,8 +102,8 @@ TEST_CASE("Testing distributing arguments to multiple bind functions (NUClear Fi
     };
 
     // Make an info print the diff in an easy to read way if we fail
-    INFO(test_util::diff_string(expected, events));
+    INFO(test_util::diff_string(expected, reactor.events));
 
     // Check the events fired in order and only those events
-    REQUIRE(events == expected);
+    REQUIRE(reactor.events == expected);
 }

--- a/tests/tests/dsl/ArgumentFission.cpp
+++ b/tests/tests/dsl/ArgumentFission.cpp
@@ -26,6 +26,9 @@
 
 #include "test_util/TestBase.hpp"
 
+/// Events that occur during the test
+std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
 struct BindExtensionTest1 {
     template <typename DSL>
     static int bind(const std::shared_ptr<NUClear::threading::Reaction>& /*unused*/, const int& v1, const bool& v2) {
@@ -78,9 +81,6 @@ public:
         events.push_back(std::string("Bind2 returned ") + (b ? "true" : "false"));
         events.push_back("Bind3 returned " + c);
     }
-
-    /// Events that occur during the test
-    std::vector<std::string> events;
 };
 
 
@@ -89,7 +89,7 @@ TEST_CASE("Testing distributing arguments to multiple bind functions (NUClear Fi
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
-    const auto& reactor = plant.install<TestReactor>();
+    plant.install<TestReactor>();
     plant.start();
 
     const std::vector<std::string> expected = {
@@ -102,8 +102,8 @@ TEST_CASE("Testing distributing arguments to multiple bind functions (NUClear Fi
     };
 
     // Make an info print the diff in an easy to read way if we fail
-    INFO(test_util::diff_string(expected, reactor.events));
+    INFO(test_util::diff_string(expected, events));
 
     // Check the events fired in order and only those events
-    REQUIRE(reactor.events == expected);
+    REQUIRE(events == expected);
 }

--- a/tests/tests/dsl/BlockNoData.cpp
+++ b/tests/tests/dsl/BlockNoData.cpp
@@ -25,16 +25,11 @@
 
 #include "test_util/TestBase.hpp"
 
-namespace {
-
-/// Events that occur during the test
-std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
-struct MessageA {};
-struct MessageB {};
-
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
+    struct MessageA {};
+    struct MessageB {};
+
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment)) {
 
         on<Trigger<MessageA>>().then([this] {
@@ -43,11 +38,11 @@ public:
             emit(std::make_unique<MessageB>());
         });
 
-        on<Trigger<MessageA>, With<MessageB>>().then([] {  //
+        on<Trigger<MessageA>, With<MessageB>>().then([this] {  //
             events.push_back("MessageA with MessageB triggered");
         });
 
-        on<Trigger<MessageB>, With<MessageA>>().then([] {  //
+        on<Trigger<MessageB>, With<MessageA>>().then([this] {  //
             events.push_back("MessageB with MessageA triggered");
         });
 
@@ -61,8 +56,10 @@ public:
             emit(std::make_unique<Step<1>>());
         });
     }
+
+    /// Events that occur during the test
+    std::vector<std::string> events;
 };
-}  // namespace
 
 
 TEST_CASE("Testing that when an on statement does not have it's data satisfied it does not run", "[api][nodata]") {
@@ -70,7 +67,7 @@ TEST_CASE("Testing that when an on statement does not have it's data satisfied i
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
-    plant.install<TestReactor>();
+    const auto& reactor = plant.install<TestReactor>();
     plant.start();
 
     const std::vector<std::string> expected = {
@@ -81,8 +78,8 @@ TEST_CASE("Testing that when an on statement does not have it's data satisfied i
     };
 
     // Make an info print the diff in an easy to read way if we fail
-    INFO(test_util::diff_string(expected, events));
+    INFO(test_util::diff_string(expected, reactor.events));
 
     // Check the events fired in order and only those events
-    REQUIRE(events == expected);
+    REQUIRE(reactor.events == expected);
 }

--- a/tests/tests/dsl/CustomGet.cpp
+++ b/tests/tests/dsl/CustomGet.cpp
@@ -25,11 +25,6 @@
 
 #include "test_util/TestBase.hpp"
 
-namespace {
-
-/// Events that occur during the test
-std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
 struct CustomGet : NUClear::dsl::operation::TypeBind<CustomGet> {
 
     template <typename DSL>
@@ -42,7 +37,7 @@ class TestReactor : public test_util::TestBase<TestReactor> {
 public:
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment)) {
 
-        on<CustomGet>().then([](const std::string& x) {  //
+        on<CustomGet>().then([this](const std::string& x) {  //
             events.push_back("CustomGet Triggered");
             events.push_back(x);
         });
@@ -53,15 +48,18 @@ public:
             emit(std::make_unique<CustomGet>());
         });
     }
+
+    /// Events that occur during the test
+    std::vector<std::string> events;
 };
-}  // namespace
+
 
 TEST_CASE("Test a custom reactor that returns a type that needs dereferencing", "[api][custom_get]") {
 
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
-    plant.install<TestReactor>();
+    const auto& reactor = plant.install<TestReactor>();
     plant.start();
 
     const std::vector<std::string> expected = {
@@ -71,8 +69,8 @@ TEST_CASE("Test a custom reactor that returns a type that needs dereferencing", 
     };
 
     // Make an info print the diff in an easy to read way if we fail
-    INFO(test_util::diff_string(expected, events));
+    INFO(test_util::diff_string(expected, reactor.events));
 
     // Check the events fired in order and only those events
-    REQUIRE(events == expected);
+    REQUIRE(reactor.events == expected);
 }

--- a/tests/tests/dsl/FlagMessage.cpp
+++ b/tests/tests/dsl/FlagMessage.cpp
@@ -25,20 +25,14 @@
 
 #include "test_util/TestBase.hpp"
 
-namespace {
-
-/// Events that occur during the test
-std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
-struct SimpleMessage {};
-
-struct MessageA {};
-struct MessageB {};
-
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
-    TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment)) {
+    struct SimpleMessage {};
 
+    struct MessageA {};
+    struct MessageB {};
+
+    TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment)) {
 
         on<Trigger<MessageA>>().then([this] {
             events.push_back("MessageA triggered");
@@ -66,8 +60,10 @@ public:
             emit(std::make_unique<Step<1>>());
         });
     }
+
+    /// Events that occur during the test
+    std::vector<std::string> events;
 };
-}  // namespace
 
 
 TEST_CASE("Testing emitting types that are flag types (Have no contents)", "[api][flag]") {
@@ -75,7 +71,7 @@ TEST_CASE("Testing emitting types that are flag types (Have no contents)", "[api
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
-    plant.install<TestReactor>();
+    const auto& reactor = plant.install<TestReactor>();
     plant.start();
 
     const std::vector<std::string> expected = {
@@ -88,8 +84,8 @@ TEST_CASE("Testing emitting types that are flag types (Have no contents)", "[api
     };
 
     // Make an info print the diff in an easy to read way if we fail
-    INFO(test_util::diff_string(expected, events));
+    INFO(test_util::diff_string(expected, reactor.events));
 
     // Check the events fired in order and only those events
-    REQUIRE(events == expected);
+    REQUIRE(reactor.events == expected);
 }

--- a/tests/tests/dsl/FlagMessage.cpp
+++ b/tests/tests/dsl/FlagMessage.cpp
@@ -40,12 +40,12 @@ public:
             emit(std::make_unique<MessageB>());
         });
 
-        on<Trigger<MessageB>>().then([] {  //
+        on<Trigger<MessageB>>().then([this] {  //
             events.push_back("MessageB triggered");
         });
 
         // This should never run
-        on<Trigger<MessageA>, With<MessageB>>().then([](const MessageA&, const MessageB&) {  //
+        on<Trigger<MessageA>, With<MessageB>>().then([this](const MessageA&, const MessageB&) {  //
             events.push_back("MessageA with MessageB triggered");
         });
 

--- a/tests/tests/dsl/FusionInOrder.cpp
+++ b/tests/tests/dsl/FusionInOrder.cpp
@@ -23,7 +23,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <nuclear>
 
-std::vector<int> events;
+std::vector<int> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables,-warnings-as-errors)
 
 template <int i>
 struct Extension {

--- a/tests/tests/dsl/FusionInOrder.cpp
+++ b/tests/tests/dsl/FusionInOrder.cpp
@@ -23,6 +23,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include <nuclear>
 
+std::vector<int> events;
+
 template <int i>
 struct Extension {
     template <typename DSL>
@@ -37,8 +39,6 @@ public:
 
         on<Extension<0>, Extension<1>, Extension<2>, Extension<3>, Extension<4>>().then([] {});
     }
-
-    std::vector<int> events;
 };
 
 
@@ -47,7 +47,7 @@ TEST_CASE("Testing that the bind functions of extensions are executed in order",
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
-    const auto& reactor = plant.install<TestReactor>();
+    plant.install<TestReactor>();
 
-    REQUIRE(reactor.events == std::vector<int>{0, 1, 2, 3, 4});
+    REQUIRE(events == std::vector<int>{0, 1, 2, 3, 4});
 }

--- a/tests/tests/dsl/FusionInOrder.cpp
+++ b/tests/tests/dsl/FusionInOrder.cpp
@@ -23,10 +23,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <nuclear>
 
-namespace {
-
-std::vector<int> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
 template <int i>
 struct Extension {
     template <typename DSL>
@@ -41,9 +37,9 @@ public:
 
         on<Extension<0>, Extension<1>, Extension<2>, Extension<3>, Extension<4>>().then([] {});
     }
-};
 
-}  // namespace
+    std::vector<int> events;
+};
 
 
 TEST_CASE("Testing that the bind functions of extensions are executed in order", "[api][extension][bind]") {
@@ -51,7 +47,7 @@ TEST_CASE("Testing that the bind functions of extensions are executed in order",
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
-    plant.install<TestReactor>();
+    const auto& reactor = plant.install<TestReactor>();
 
-    REQUIRE(events == std::vector<int>{0, 1, 2, 3, 4});
+    REQUIRE(reactor.events == std::vector<int>{0, 1, 2, 3, 4});
 }

--- a/tests/tests/dsl/Idle.cpp
+++ b/tests/tests/dsl/Idle.cpp
@@ -24,21 +24,15 @@
 #include <nuclear>
 
 #include "test_util/TestBase.hpp"
-
-namespace {
-
-/// A vector of events that have happened
-std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
-struct SimpleMessage {
-    SimpleMessage(int data) : data(data) {}
-    int data;
-};
-
-constexpr int time_step = 50;
+#include "test_util/TimeUnit.hpp"
 
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
+    struct SimpleMessage {
+        SimpleMessage(int data) : data(data) {}
+        int data;
+    };
+
     template <int N>
     struct CustomPool {
         static constexpr int thread_count = 2;
@@ -46,7 +40,7 @@ public:
 
     template <int N>
     void do_step(const std::string& name) {
-        std::this_thread::sleep_until(start_time + std::chrono::milliseconds(time_step * N));
+        std::this_thread::sleep_until(start_time + test_util::TimeUnit(2 * N));
         events.push_back(name + " " + std::to_string(N));
         emit(std::make_unique<Step<N + 1>>());
     }
@@ -104,6 +98,9 @@ public:
         });
     }
 
+    /// A vector of events that have happened
+    std::vector<std::string> events;
+
 private:
     NUClear::clock::time_point start_time;
     NUClear::threading::ReactionHandle drh;
@@ -112,15 +109,13 @@ private:
     NUClear::threading::ReactionHandle grh;
 };
 
-}  // namespace
-
 
 TEST_CASE("Test that pool idle triggers when nothing is running", "[api][idle]") {
 
     NUClear::Configuration config;
     config.thread_count = 4;
     NUClear::PowerPlant plant(config);
-    plant.install<TestReactor>();
+    const auto& reactor = plant.install<TestReactor>();
     plant.start();
 
     const std::vector<std::string> expected = {
@@ -133,8 +128,8 @@ TEST_CASE("Test that pool idle triggers when nothing is running", "[api][idle]")
     };
 
     // Make an info print the diff in an easy to read way if we fail
-    INFO(test_util::diff_string(expected, events));
+    INFO(test_util::diff_string(expected, reactor.events));
 
     // Check the events fired in order and only those events
-    REQUIRE(events == expected);
+    REQUIRE(reactor.events == expected);
 }

--- a/tests/tests/dsl/Idle.cpp
+++ b/tests/tests/dsl/Idle.cpp
@@ -40,7 +40,7 @@ public:
 
     template <int N>
     void do_step(const std::string& name) {
-        std::this_thread::sleep_until(start_time + test_util::TimeUnit(2 * N));
+        std::this_thread::sleep_until(start_time + test_util::TimeUnit(N));
         events.push_back(name + " " + std::to_string(N));
         emit(std::make_unique<Step<N + 1>>());
     }

--- a/tests/tests/dsl/IdleCrossPool.cpp
+++ b/tests/tests/dsl/IdleCrossPool.cpp
@@ -26,13 +26,6 @@
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 
-namespace {
-
-/// A vector of events that have happened
-std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
-constexpr int time_step = 50;
-
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
     explicit TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment), false) {
@@ -60,9 +53,10 @@ public:
     std::thread::id main_thread_id;
     std::thread::id idle_thread_id;
     std::thread::id default_thread_id;
-};
 
-}  // namespace
+    /// A vector of events that have happened
+    std::vector<std::string> events;
+};
 
 
 TEST_CASE("Test that idle can fire events for other pools but only runs once", "[api][dsl][Idle][Pool]") {
@@ -86,8 +80,8 @@ TEST_CASE("Test that idle can fire events for other pools but only runs once", "
     };
 
     // Make an info print the diff in an easy to read way if we fail
-    INFO(test_util::diff_string(expected, events));
+    INFO(test_util::diff_string(expected, reactor.events));
 
     // Check the events fired in order and only those events
-    REQUIRE(events == expected);
+    REQUIRE(reactor.events == expected);
 }

--- a/tests/tests/dsl/IdleGlobal.cpp
+++ b/tests/tests/dsl/IdleGlobal.cpp
@@ -26,14 +26,6 @@
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 
-namespace {
-
-void wait_for_set(const std::atomic<bool>& flag) {
-    while (!flag.load(std::memory_order_acquire)) {
-        std::this_thread::sleep_for(test_util::TimeUnit(1));
-    }
-}
-
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
     // A pool to use for monitoring which does not interact with idleness
@@ -105,14 +97,18 @@ public:
         });
     }
 
+    void wait_for_set(const std::atomic<bool>& flag) {
+        while (!flag.load(std::memory_order_acquire)) {
+            std::this_thread::sleep_for(test_util::TimeUnit(1));
+        }
+    }
+
     std::atomic<int> idles_fired{0};
 
     std::atomic<bool> sync_obtained{false};
     std::atomic<bool> main_idle{false};
     std::atomic<bool> default_idle{false};
 };
-
-}  // namespace
 
 
 TEST_CASE("Test that Idle won't fire when an already idle pool goes idle again", "[api][dsl][Idle][Pool]") {

--- a/tests/tests/dsl/IdleGlobal.cpp
+++ b/tests/tests/dsl/IdleGlobal.cpp
@@ -97,7 +97,7 @@ public:
         });
     }
 
-    void wait_for_set(const std::atomic<bool>& flag) {
+    static void wait_for_set(const std::atomic<bool>& flag) {
         while (!flag.load(std::memory_order_acquire)) {
             std::this_thread::sleep_for(test_util::TimeUnit(1));
         }

--- a/tests/tests/dsl/IdleSingle.cpp
+++ b/tests/tests/dsl/IdleSingle.cpp
@@ -39,25 +39,24 @@ struct StringMaker<std::pair<const K, V>> {
 
 }  // namespace Catch
 
-namespace {
-
-constexpr int n_loops = 250;
-
-struct TaskB {
-    explicit TaskB(int i) : i(i) {}
-    int i;
-};
-struct TaskA {
-    explicit TaskA(int i) : i(i) {}
-    int i;
-};
-
-struct IdlePool {
-    static constexpr int thread_count = 1;
-};
 
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
+    static constexpr int n_loops = 250;
+
+    struct TaskB {
+        explicit TaskB(int i) : i(i) {}
+        int i;
+    };
+    struct TaskA {
+        explicit TaskA(int i) : i(i) {}
+        int i;
+    };
+
+    struct IdlePool {
+        static constexpr int thread_count = 1;
+    };
+
     explicit TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment), false) {
 
         /*
@@ -104,8 +103,6 @@ public:
     std::array<std::atomic<int>, n_loops> idle_calls{};
 };
 
-}  // namespace
-
 
 TEST_CASE("Test that when a global idle trigger exists it is triggered only once", "[api][dsl][Idle][Sync]") {
 
@@ -115,6 +112,7 @@ TEST_CASE("Test that when a global idle trigger exists it is triggered only once
     const auto& reactor = plant.install<TestReactor>();
     plant.start();
 
+    constexpr int n_loops = TestReactor::n_loops;
     std::array<std::atomic<int>, n_loops> expected{};
     for (int i = 0; i < n_loops; ++i) {
         expected[i].store(1, std::memory_order_relaxed);

--- a/tests/tests/dsl/IdleSingleGlobal.cpp
+++ b/tests/tests/dsl/IdleSingleGlobal.cpp
@@ -39,10 +39,6 @@ struct StringMaker<std::pair<const K, V>> {
 
 }  // namespace Catch
 
-namespace {
-
-constexpr int n_loops = 10000;
-
 class TestReactor : public test_util::TestBase<TestReactor> {
 private:
     struct Loop {
@@ -51,6 +47,8 @@ private:
     };
 
 public:
+    static constexpr int n_loops = 10000;
+
     explicit TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment), false) {
 
         /*
@@ -84,8 +82,6 @@ public:
     std::array<std::atomic<int>, n_loops> idle_calls{};
 };
 
-}  // namespace
-
 
 TEST_CASE("Test that when a global idle trigger exists it is triggered only once", "[api][dsl][Idle][Sync]") {
 
@@ -95,6 +91,7 @@ TEST_CASE("Test that when a global idle trigger exists it is triggered only once
     const auto& reactor = plant.install<TestReactor>();
     plant.start();
 
+    constexpr int n_loops = TestReactor::n_loops;
     std::array<std::atomic<int>, n_loops> expected{};
     for (int i = 0; i < n_loops; ++i) {
         expected[i].store(1, std::memory_order_relaxed);

--- a/tests/tests/dsl/IdleSync.cpp
+++ b/tests/tests/dsl/IdleSync.cpp
@@ -36,13 +36,13 @@ public:
         });
 
         // Idle testing for default thread
-        on<Trigger<Step<2>>, Sync<TestReactor>>().then([] {
+        on<Trigger<Step<2>>, Sync<TestReactor>>().then([this] {
             events.push_back("Default Start");
             std::this_thread::sleep_for(std::chrono::milliseconds(300));
             events.push_back("Default End");
         });
 
-        on<Trigger<Step<3>>, Sync<TestReactor>, MainThread>().then([] { events.push_back("Main Task"); });
+        on<Trigger<Step<3>>, Sync<TestReactor>, MainThread>().then([this] { events.push_back("Main Task"); });
 
         on<Idle<MainThread>>().then([this] {
             events.push_back("Idle Main Thread");

--- a/tests/tests/dsl/MissingArguments.cpp
+++ b/tests/tests/dsl/MissingArguments.cpp
@@ -25,19 +25,14 @@
 
 #include "test_util/TestBase.hpp"
 
-namespace {
-
-/// Events that occur during the test
-std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
-template <int i>
-struct Message {
-    int val;
-    Message(int val) : val(val) {};
-};
-
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
+    template <int i>
+    struct Message {
+        int val;
+        Message(int val) : val(val) {};
+    };
+
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment)) {
 
         on<Trigger<Message<1>>, With<Message<2>>, With<Message<3>>, With<Message<4>>>().then(
@@ -58,15 +53,18 @@ public:
             emit(std::make_unique<Message<1>>(1 * 1));
         });
     }
+
+    /// Events that occur during the test
+    std::vector<std::string> events;
 };
-}  // namespace
+
 
 TEST_CASE("Testing that when arguments missing from the call it can still run", "[api][missing_arguments]") {
 
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
-    plant.install<TestReactor>();
+    const auto& reactor = plant.install<TestReactor>();
     plant.start();
 
     const std::vector<std::string> expected = {
@@ -79,8 +77,8 @@ TEST_CASE("Testing that when arguments missing from the call it can still run", 
     };
 
     // Make an info print the diff in an easy to read way if we fail
-    INFO(test_util::diff_string(expected, events));
+    INFO(test_util::diff_string(expected, reactor.events));
 
     // Check the events fired in order and only those events
-    REQUIRE(events == expected);
+    REQUIRE(reactor.events == expected);
 }

--- a/tests/tests/dsl/MissingArguments.cpp
+++ b/tests/tests/dsl/MissingArguments.cpp
@@ -36,7 +36,7 @@ public:
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment)) {
 
         on<Trigger<Message<1>>, With<Message<2>>, With<Message<3>>, With<Message<4>>>().then(
-            [](const Message<2>& m2, const Message<4>& m4) {
+            [this](const Message<2>& m2, const Message<4>& m4) {
                 events.push_back("Message<2>: " + std::to_string(m2.val));
                 events.push_back("Message<4>: " + std::to_string(m4.val));
             });

--- a/tests/tests/dsl/Once.cpp
+++ b/tests/tests/dsl/Once.cpp
@@ -35,7 +35,7 @@ public:
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : Reactor(std::move(environment)) {
 
         // Make this priority high so it will always run first if it is able
-        on<Trigger<SimpleMessage>, Priority::HIGH, Once>().then([](const SimpleMessage& msg) {  //
+        on<Trigger<SimpleMessage>, Priority::HIGH, Once>().then([this](const SimpleMessage& msg) {  //
             events.push_back("Once Trigger executed " + std::to_string(msg.run));
         });
 

--- a/tests/tests/dsl/Priority.cpp
+++ b/tests/tests/dsl/Priority.cpp
@@ -34,20 +34,20 @@ public:
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment)) {
 
         // Declare in the order you'd expect them to fire
-        on<Trigger<Message<1>>, Priority::REALTIME>().then([] { events.push_back("Realtime Message<1>"); });
-        on<Trigger<Message<1>>, Priority::HIGH>().then("High", [] { events.push_back("High Message<1>"); });
-        on<Trigger<Message<1>>>().then([] { events.push_back("Default Message<1>"); });
-        on<Trigger<Message<1>>, Priority::NORMAL>().then("Normal", [] { events.push_back("Normal Message<1>"); });
-        on<Trigger<Message<1>>, Priority::LOW>().then("Low", [] { events.push_back("Low Message<1>"); });
-        on<Trigger<Message<1>>, Priority::IDLE>().then([] { events.push_back("Idle Message<1>"); });
+        on<Trigger<Message<1>>, Priority::REALTIME>().then([this] { events.push_back("Realtime Message<1>"); });
+        on<Trigger<Message<1>>, Priority::HIGH>().then("High", [this] { events.push_back("High Message<1>"); });
+        on<Trigger<Message<1>>>().then([this] { events.push_back("Default Message<1>"); });
+        on<Trigger<Message<1>>, Priority::NORMAL>().then("Normal", [this] { events.push_back("Normal Message<1>"); });
+        on<Trigger<Message<1>>, Priority::LOW>().then("Low", [this] { events.push_back("Low Message<1>"); });
+        on<Trigger<Message<1>>, Priority::IDLE>().then([this] { events.push_back("Idle Message<1>"); });
 
         // Declare in the opposite order to what you'd expect them to fire
-        on<Trigger<Message<2>>, Priority::IDLE>().then([] { events.push_back("Idle Message<2>"); });
-        on<Trigger<Message<2>>, Priority::LOW>().then([] { events.push_back("Low Message<2>"); });
-        on<Trigger<Message<2>>, Priority::NORMAL>().then([] { events.push_back("Normal Message<2>"); });
-        on<Trigger<Message<2>>>().then([] { events.push_back("Default Message<2>"); });
-        on<Trigger<Message<2>>, Priority::HIGH>().then([] { events.push_back("High Message<2>"); });
-        on<Trigger<Message<2>>, Priority::REALTIME>().then([] { events.push_back("Realtime Message<2>"); });
+        on<Trigger<Message<2>>, Priority::IDLE>().then([this] { events.push_back("Idle Message<2>"); });
+        on<Trigger<Message<2>>, Priority::LOW>().then([this] { events.push_back("Low Message<2>"); });
+        on<Trigger<Message<2>>, Priority::NORMAL>().then([this] { events.push_back("Normal Message<2>"); });
+        on<Trigger<Message<2>>>().then([this] { events.push_back("Default Message<2>"); });
+        on<Trigger<Message<2>>, Priority::HIGH>().then([this] { events.push_back("High Message<2>"); });
+        on<Trigger<Message<2>>, Priority::REALTIME>().then([this] { events.push_back("Realtime Message<2>"); });
 
         // Declare in a random order
         std::array<int, 5> order = {0, 1, 2, 3, 4};
@@ -55,20 +55,21 @@ public:
         for (const auto& i : order) {
             switch (i) {
                 case 0:
-                    on<Trigger<Message<3>>, Priority::REALTIME>().then([] { events.push_back("Realtime Message<3>"); });
+                    on<Trigger<Message<3>>, Priority::REALTIME>().then(
+                        [this] { events.push_back("Realtime Message<3>"); });
                     break;
                 case 1:
-                    on<Trigger<Message<3>>, Priority::HIGH>().then([] { events.push_back("High Message<3>"); });
+                    on<Trigger<Message<3>>, Priority::HIGH>().then([this] { events.push_back("High Message<3>"); });
                     break;
                 case 2:
-                    on<Trigger<Message<3>>, Priority::NORMAL>().then([] { events.push_back("Normal Message<3>"); });
-                    on<Trigger<Message<3>>>().then([] { events.push_back("Default Message<3>"); });
+                    on<Trigger<Message<3>>, Priority::NORMAL>().then([this] { events.push_back("Normal Message<3>"); });
+                    on<Trigger<Message<3>>>().then([this] { events.push_back("Default Message<3>"); });
                     break;
                 case 3:
-                    on<Trigger<Message<3>>, Priority::LOW>().then([] { events.push_back("Low Message<3>"); });
+                    on<Trigger<Message<3>>, Priority::LOW>().then([this] { events.push_back("Low Message<3>"); });
                     break;
                 case 4:
-                    on<Trigger<Message<3>>, Priority::IDLE>().then([] { events.push_back("Idle Message<3>"); });
+                    on<Trigger<Message<3>>, Priority::IDLE>().then([this] { events.push_back("Idle Message<3>"); });
                     break;
                 default: throw std::invalid_argument("Should be impossible");
             }

--- a/tests/tests/dsl/Raw.cpp
+++ b/tests/tests/dsl/Raw.cpp
@@ -23,22 +23,18 @@
 #include <catch2/catch_test_macros.hpp>
 #include <nuclear>
 
-namespace {
-
-struct TypeA {
-    TypeA(int x) : x(x) {}
-
-    int x;
-};
-
-struct TypeB {
-    TypeB(int x) : x(x) {}
-
-    int x;
-};
-
 class TestReactor : public NUClear::Reactor {
 private:
+    struct TypeA {
+        TypeA(int x) : x(x) {}
+        int x;
+    };
+
+    struct TypeB {
+        TypeB(int x) : x(x) {}
+        int x;
+    };
+
     std::vector<std::shared_ptr<const TypeA>> stored;
 
 public:
@@ -72,7 +68,7 @@ public:
         on<Startup>().then([this] { emit(std::make_unique<TypeA>(0)); });
     }
 };
-}  // namespace
+
 
 TEST_CASE("Testing the raw type conversions work properly", "[api][raw]") {
 

--- a/tests/tests/dsl/RawFunction.cpp
+++ b/tests/tests/dsl/RawFunction.cpp
@@ -25,8 +25,6 @@
 
 #include "test_util/TestBase.hpp"
 
-namespace {
-
 /// Events that occur during the test
 std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
@@ -80,7 +78,6 @@ void raw_function_test_both_args(const Message& msg, const Data& data) {
     events.push_back("Raw function both args: " + msg.data + " " + data.data);
 }
 
-
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment)) {
@@ -103,7 +100,7 @@ public:
         });
     }
 };
-}  // namespace
+
 
 TEST_CASE("Test reaction can take a raw function instead of just a lambda", "[api][raw_function]") {
 

--- a/tests/tests/dsl/Startup.cpp
+++ b/tests/tests/dsl/Startup.cpp
@@ -34,7 +34,7 @@ public:
 
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment)) {
 
-        on<Trigger<SimpleMessage>>().then([](const SimpleMessage& message) {  //
+        on<Trigger<SimpleMessage>>().then([this](const SimpleMessage& message) {  //
             events.push_back("SimpleMessage triggered with " + std::to_string(message.data));
         });
 

--- a/tests/tests/dsl/Startup.cpp
+++ b/tests/tests/dsl/Startup.cpp
@@ -25,18 +25,13 @@
 
 #include "test_util/TestBase.hpp"
 
-namespace {
-
-/// Events that occur during the test
-std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
-struct SimpleMessage {
-    SimpleMessage(int data) : data(data) {}
-    int data{0};
-};
-
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
+    struct SimpleMessage {
+        SimpleMessage(int data) : data(data) {}
+        int data{0};
+    };
+
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment)) {
 
         on<Trigger<SimpleMessage>>().then([](const SimpleMessage& message) {  //
@@ -49,14 +44,17 @@ public:
             emit(std::make_unique<SimpleMessage>(10));
         });
     }
+
+    /// Events that occur during the test
+    std::vector<std::string> events;
 };
-}  // namespace
+
 
 TEST_CASE("Testing the startup event is emitted at the start of the program", "[api][startup]") {
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
-    plant.install<TestReactor>();
+    const auto& reactor = plant.install<TestReactor>();
     plant.start();
 
     const std::vector<std::string> expected = {
@@ -66,8 +64,8 @@ TEST_CASE("Testing the startup event is emitted at the start of the program", "[
     };
 
     // Make an info print the diff in an easy to read way if we fail
-    INFO(test_util::diff_string(expected, events));
+    INFO(test_util::diff_string(expected, reactor.events));
 
     // Check the events fired in order and only those events
-    REQUIRE(events == expected);
+    REQUIRE(reactor.events == expected);
 }

--- a/tests/tests/dsl/SyncOrder.cpp
+++ b/tests/tests/dsl/SyncOrder.cpp
@@ -40,11 +40,11 @@ public:
 
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment)) {
 
-        on<Trigger<Message<'A'>>, Sync<TestReactor>>().then([](const Message<'A'>& m) {  //
+        on<Trigger<Message<'A'>>, Sync<TestReactor>>().then([this](const Message<'A'>& m) {  //
             events.emplace_back('A', m.val);
         });
 
-        on<Trigger<Message<'B'>>, Sync<TestReactor>, MainThread>().then([](const Message<'B'>& m) {  //
+        on<Trigger<Message<'B'>>, Sync<TestReactor>, MainThread>().then([this](const Message<'B'>& m) {  //
             events.emplace_back('B', m.val);
         });
 

--- a/tests/tests/dsl/TCP.cpp
+++ b/tests/tests/dsl/TCP.cpp
@@ -26,8 +26,6 @@
 #include "test_util/TestBase.hpp"
 #include "test_util/has_ipv6.hpp"
 
-namespace {
-
 /// Events that occur during the test
 std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
@@ -200,7 +198,6 @@ private:
     NUClear::util::FileDescriptor ephemeral_port_fd;
 };
 
-}  // namespace
 
 TEST_CASE("Testing listening for TCP connections and receiving data messages", "[api][network][tcp]") {
 

--- a/tests/tests/dsl/Trigger.cpp
+++ b/tests/tests/dsl/Trigger.cpp
@@ -25,21 +25,16 @@
 
 #include "test_util/TestBase.hpp"
 
-namespace {
-
-/// A vector of events that have happened
-std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
-struct SimpleMessage {
-    SimpleMessage(int data) : data(data) {}
-    int data;
-};
-
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
+    struct SimpleMessage {
+        SimpleMessage(int data) : data(data) {}
+        int data;
+    };
+
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment)) {
 
-        on<Trigger<SimpleMessage>>().then([](const SimpleMessage& message) {  //
+        on<Trigger<SimpleMessage>>().then([this](const SimpleMessage& message) {  //
             events.push_back("Trigger " + std::to_string(message.data));
         });
 
@@ -50,8 +45,10 @@ public:
             }
         });
     }
+
+    /// A vector of events that have happened
+    std::vector<std::string> events;
 };
-}  // namespace
 
 
 TEST_CASE("Test that Trigger statements get the correct data", "[api][trigger]") {
@@ -59,7 +56,7 @@ TEST_CASE("Test that Trigger statements get the correct data", "[api][trigger]")
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
-    plant.install<TestReactor>();
+    const auto& reactor = plant.install<TestReactor>();
     plant.start();
 
     const std::vector<std::string> expected = {
@@ -76,8 +73,8 @@ TEST_CASE("Test that Trigger statements get the correct data", "[api][trigger]")
     };
 
     // Make an info print the diff in an easy to read way if we fail
-    INFO(test_util::diff_string(expected, events));
+    INFO(test_util::diff_string(expected, reactor.events));
 
     // Check the events fired in order and only those events
-    REQUIRE(events == expected);
+    REQUIRE(reactor.events == expected);
 }

--- a/tests/tests/dsl/UDP.cpp
+++ b/tests/tests/dsl/UDP.cpp
@@ -26,8 +26,6 @@
 #include "test_util/TestBase.hpp"
 #include "test_util/has_ipv6.hpp"
 
-namespace {
-
 /// Events that occur during the test
 std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
@@ -348,7 +346,6 @@ private:
     size_t test_no = 0;
 };
 
-}  // namespace
 
 TEST_CASE("Testing sending and receiving of UDP messages", "[api][network][udp]") {
 

--- a/tests/tests/dsl/Watchdog.cpp
+++ b/tests/tests/dsl/Watchdog.cpp
@@ -27,16 +27,11 @@
 
 #include "test_util/TestBase.hpp"
 
-namespace {
-
-/// Events that occur during the test
-std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
-template <int I>
-struct Flag {};
-
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
+    template <int I>
+    struct Flag {};
+
     TestReactor(std::unique_ptr<NUClear::Environment> environment)
         : TestBase(std::move(environment), false), start(NUClear::clock::now()) {
 
@@ -92,16 +87,18 @@ public:
     int flag3a{0};
     int flag3b{0};
     int flag4{0};
+
+    /// Events that occur during the test
+    std::vector<std::string> events;
 };
 
-}  // namespace
 
 TEST_CASE("Testing the Watchdog Smart Type", "[api][watchdog]") {
 
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
-    plant.install<TestReactor>();
+    const auto& reactor = plant.install<TestReactor>();
     plant.start();
 
     const std::vector<std::string> expected = {
@@ -121,8 +118,8 @@ TEST_CASE("Testing the Watchdog Smart Type", "[api][watchdog]") {
     };
 
     // Make an info print the diff in an easy to read way if we fail
-    INFO(test_util::diff_string(expected, events));
+    INFO(test_util::diff_string(expected, reactor.events));
 
     // Check the events fired in order and only those events
-    REQUIRE(events == expected);
+    REQUIRE(reactor.events == expected);
 }

--- a/tests/tests/dsl/With.cpp
+++ b/tests/tests/dsl/With.cpp
@@ -38,7 +38,7 @@ public:
 
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment)) {
         // Check that the lists are combined, and that the function args are in order
-        on<Trigger<Message>, With<Data>>().then([](const Message& m, const Data& d) {  //
+        on<Trigger<Message>, With<Data>>().then([this](const Message& m, const Data& d) {  //
             events.push_back("Message: " + m.data + " Data: " + d.data);
         });
 

--- a/tests/tests/dsl/With.cpp
+++ b/tests/tests/dsl/With.cpp
@@ -25,22 +25,17 @@
 
 #include "test_util/TestBase.hpp"
 
-namespace {
-
-/// Events that occur during the test
-std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
-struct Message {
-    Message(std::string data) : data(std::move(data)) {}
-    std::string data;
-};
-struct Data {
-    Data(std::string data) : data(std::move(data)) {}
-    std::string data;
-};
-
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
+    struct Message {
+        Message(std::string data) : data(std::move(data)) {}
+        std::string data;
+    };
+    struct Data {
+        Data(std::string data) : data(std::move(data)) {}
+        std::string data;
+    };
+
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment)) {
         // Check that the lists are combined, and that the function args are in order
         on<Trigger<Message>, With<Data>>().then([](const Message& m, const Data& d) {  //
@@ -80,15 +75,18 @@ public:
             emit(std::make_unique<Step<5>>());
         });
     }
+
+    /// Events that occur during the test
+    std::vector<std::string> events;
 };
-}  // namespace
+
 
 TEST_CASE("Testing the with dsl keyword", "[api][with]") {
 
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
-    plant.install<TestReactor>();
+    const auto& reactor = plant.install<TestReactor>();
     plant.start();
 
     const std::vector<std::string> expected = {
@@ -102,8 +100,8 @@ TEST_CASE("Testing the with dsl keyword", "[api][with]") {
     };
 
     // Make an info print the diff in an easy to read way if we fail
-    INFO(test_util::diff_string(expected, events));
+    INFO(test_util::diff_string(expected, reactor.events));
 
     // Check the events fired in order and only those events
-    REQUIRE(events == expected);
+    REQUIRE(reactor.events == expected);
 }

--- a/tests/tests/dsl/emit/Delay.cpp
+++ b/tests/tests/dsl/emit/Delay.cpp
@@ -50,7 +50,7 @@ public:
         : TestBase(std::move(environment), false, std::chrono::seconds(2)) {
 
         // Measure when messages were sent and received and print those values
-        on<Trigger<DelayedMessage>>().then([](const DelayedMessage& m) {
+        on<Trigger<DelayedMessage>>().then([this](const DelayedMessage& m) {
             auto true_delta = test_util::round_to_test_units(NUClear::clock::now() - m.time);
             auto delta      = test_util::round_to_test_units(m.delay);
 
@@ -59,7 +59,7 @@ public:
                              + std::to_string(delta.count()));
         });
 
-        on<Trigger<TargetTimeMessage>>().then([](const TargetTimeMessage& m) {
+        on<Trigger<TargetTimeMessage>>().then([this](const TargetTimeMessage& m) {
             auto true_delta = test_util::round_to_test_units(NUClear::clock::now() - m.time);
             auto delta      = test_util::round_to_test_units(m.target - m.time);
 

--- a/tests/tests/dsl/emit/Delay.cpp
+++ b/tests/tests/dsl/emit/Delay.cpp
@@ -26,33 +26,26 @@
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 
-// Anonymous namespace to keep everything file local
-namespace {
-
-using TimeUnit = test_util::TimeUnit;
-
-/// Events that occur during the test
-std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
-/// Perform this many different time points for the test
-constexpr int test_loops = 5;
-
-struct DelayedMessage {
-    DelayedMessage(const NUClear::clock::duration& delay) : time(NUClear::clock::now()), delay(delay) {}
-    NUClear::clock::time_point time;
-    NUClear::clock::duration delay;
-};
-
-struct TargetTimeMessage {
-    TargetTimeMessage(const NUClear::clock::time_point& target) : time(NUClear::clock::now()), target(target) {}
-    NUClear::clock::time_point time;
-    NUClear::clock::time_point target;
-};
-
-struct FinishTest {};
-
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
+    using TimeUnit = test_util::TimeUnit;
+
+    /// Perform this many different time points for the test
+    static constexpr int test_loops = 5;
+
+    struct DelayedMessage {
+        DelayedMessage(const NUClear::clock::duration& delay) : time(NUClear::clock::now()), delay(delay) {}
+        NUClear::clock::time_point time;
+        NUClear::clock::duration delay;
+    };
+
+    struct TargetTimeMessage {
+        TargetTimeMessage(const NUClear::clock::time_point& target) : time(NUClear::clock::now()), target(target) {}
+        NUClear::clock::time_point time;
+        NUClear::clock::time_point target;
+    };
+
+    struct FinishTest {};
     TestReactor(std::unique_ptr<NUClear::Environment> environment)
         : TestBase(std::move(environment), false, std::chrono::seconds(2)) {
 
@@ -95,14 +88,17 @@ public:
 
         on<Startup>().then([this] { emit(std::make_unique<Step<1>>()); });
     }
+
+    /// Events that occur during the test
+    std::vector<std::string> events;
 };
-}  // namespace
+
 
 TEST_CASE("Testing the delay emit", "[api][emit][delay]") {
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
-    plant.install<TestReactor>();
+    const auto& reactor = plant.install<TestReactor>();
     plant.start();
 
     const std::vector<std::string> expected = {
@@ -120,8 +116,8 @@ TEST_CASE("Testing the delay emit", "[api][emit][delay]") {
     };
 
     // Make an info print the diff in an easy to read way if we fail
-    INFO(test_util::diff_string(expected, events));
+    INFO(test_util::diff_string(expected, reactor.events));
 
     // Check the events fired in order and only those events
-    REQUIRE(events == expected);
+    REQUIRE(reactor.events == expected);
 }

--- a/tests/tests/dsl/emit/EmitFusion.cpp
+++ b/tests/tests/dsl/emit/EmitFusion.cpp
@@ -26,12 +26,6 @@
 
 #include "test_util/TestBase.hpp"
 
-// Anonymous namespace to keep everything file local
-namespace {
-
-/// Events that occur during the test
-std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
 template <typename T>
 struct E1 {
     static void emit(const NUClear::PowerPlant& /*powerplant*/,
@@ -80,15 +74,18 @@ public:
         emit<E1, E2>(std::make_unique<std::string>("message5"), 5, "test5a", 10, "test5b");  // 1a, 2b
         events.push_back("End test 5");
     }
+
+    /// Events that occur during the test
+    std::vector<std::string> events;
 };
-}  // namespace
+
 
 TEST_CASE("Testing emit function fusion", "[api][emit][fusion]") {
 
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
-    plant.install<TestReactor>();
+    const auto& reactor = plant.install<TestReactor>();
 
     const std::vector<std::string> expected = {
         "E1b message1 test1",
@@ -108,8 +105,8 @@ TEST_CASE("Testing emit function fusion", "[api][emit][fusion]") {
     };
 
     // Make an info print the diff in an easy to read way if we fail
-    INFO(test_util::diff_string(expected, events));
+    INFO(test_util::diff_string(expected, reactor.events));
 
     // Check the events fired in order and only those events
-    REQUIRE(events == expected);
+    REQUIRE(reactor.events == expected);
 }

--- a/tests/tests/dsl/emit/EmitFusion.cpp
+++ b/tests/tests/dsl/emit/EmitFusion.cpp
@@ -27,7 +27,7 @@
 #include "test_util/TestBase.hpp"
 
 /// Events that occur during the test
-std::vector<std::string> events;
+std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables,-warnings-as-errors)
 
 template <typename T>
 struct E1 {

--- a/tests/tests/dsl/emit/EmitFusion.cpp
+++ b/tests/tests/dsl/emit/EmitFusion.cpp
@@ -26,6 +26,9 @@
 
 #include "test_util/TestBase.hpp"
 
+/// Events that occur during the test
+std::vector<std::string> events;
+
 template <typename T>
 struct E1 {
     static void emit(const NUClear::PowerPlant& /*powerplant*/,
@@ -74,9 +77,6 @@ public:
         emit<E1, E2>(std::make_unique<std::string>("message5"), 5, "test5a", 10, "test5b");  // 1a, 2b
         events.push_back("End test 5");
     }
-
-    /// Events that occur during the test
-    std::vector<std::string> events;
 };
 
 
@@ -85,7 +85,7 @@ TEST_CASE("Testing emit function fusion", "[api][emit][fusion]") {
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
-    const auto& reactor = plant.install<TestReactor>();
+    plant.install<TestReactor>();
 
     const std::vector<std::string> expected = {
         "E1b message1 test1",
@@ -105,8 +105,8 @@ TEST_CASE("Testing emit function fusion", "[api][emit][fusion]") {
     };
 
     // Make an info print the diff in an easy to read way if we fail
-    INFO(test_util::diff_string(expected, reactor.events));
+    INFO(test_util::diff_string(expected, events));
 
     // Check the events fired in order and only those events
-    REQUIRE(reactor.events == expected);
+    REQUIRE(events == expected);
 }

--- a/tests/tests/dsl/emit/Initialise.cpp
+++ b/tests/tests/dsl/emit/Initialise.cpp
@@ -36,7 +36,7 @@ public:
         emit<Scope::INITIALIZE>(std::make_unique<TestMessage>("Initialise before trigger"));
         emit(std::make_unique<TestMessage>("Normal before trigger"));
 
-        on<Trigger<TestMessage>>().then([](const TestMessage& v) {  //
+        on<Trigger<TestMessage>>().then([this](const TestMessage& v) {  //
             events.push_back("Triggered " + v.data);
         });
 

--- a/tests/tests/log/Log.cpp
+++ b/tests/tests/log/Log.cpp
@@ -23,9 +23,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <nuclear>
 
-// Anonymous namespace to keep everything file local
-namespace {
-
 // This is a free floating function that we can use to test the log function when not in a reactor
 template <NUClear::LogLevel level, typename... Args>
 void free_floating_log(const Args&... args) {
@@ -38,7 +35,7 @@ struct LogTestOutput {
     bool from_reaction;
 };
 
-// Store all the log messages we received
+/// All the log messages received
 std::vector<LogTestOutput> messages;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 // All the log levels
@@ -134,7 +131,7 @@ public:
         });
     }
 };
-}  // namespace
+
 
 TEST_CASE("Testing the Log<>() function", "[api][log]") {
 

--- a/tests/tests/util/network/resolve.cpp
+++ b/tests/tests/util/network/resolve.cpp
@@ -25,6 +25,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <string>
 
+
 TEST_CASE("resolve function returns expected socket address", "[util][network][resolve]") {
 
     SECTION("IPv4 address") {

--- a/tests/tests/util/serialise/serialise.cpp
+++ b/tests/tests/util/serialise/serialise.cpp
@@ -100,6 +100,7 @@ SCENARIO("Serialisation works correctly on single primitives", "[util][serialise
     }
 }
 
+
 TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of primitives",
                    "[util][serialise][multiple][primitive]",
                    std::vector<uint32_t>,
@@ -177,8 +178,6 @@ TEMPLATE_TEST_CASE("Scenario: Serialisation works correctly on iterables of prim
     }
 }
 
-namespace {
-
 struct TriviallyCopyable {
     uint8_t a;
     int8_t b;
@@ -189,8 +188,6 @@ struct TriviallyCopyable {
     }
 };
 static_assert(std::is_trivially_copyable<TriviallyCopyable>::value, "This type should be trivially copyable");
-
-}  // namespace
 
 SCENARIO("Serialisation works correctly on single trivially copyable types", "[util][serialise][single][trivial]") {
 


### PR DESCRIPTION
There are many globals in the unit tests for handling event lists.

Since reactors are now returned from install, these globals can instead be members of the reactors.

It also removes the anonymous namespaces since each of the tests are built separately and they no longer collide.