### PR TITLE
Stop installing extensions by default

### DIFF
--- a/src/PowerPlant.cpp
+++ b/src/PowerPlant.cpp
@@ -58,18 +58,13 @@ PowerPlant::PowerPlant(Configuration config, int argc, const char* argv[]) : sch
     // Store our static variable
     powerplant = this;
 
-    // Install the extension controllers
-    install<extension::ChronoController>();
-    install<extension::IOController>();
-    install<extension::NetworkController>();
-
     // Emit our arguments if any.
     message::CommandLineArguments args;
     for (int i = 0; i < argc; ++i) {
         args.emplace_back(argv[i]);
     }
 
-    // Emit our command line arguments
+    // Emit the command line arguments so they are available for any With clauses.
     emit(std::make_unique<message::CommandLineArguments>(args));
 }
 

--- a/tests/tests/api/TimeTravel.cpp
+++ b/tests/tests/api/TimeTravel.cpp
@@ -77,8 +77,9 @@ TEST_CASE("Test time travel correctly changes the time for non zero rtf", "[time
     using Action = NUClear::message::TimeTravel::Action;
 
     const NUClear::Configuration config;
-    auto plant    = std::make_shared<NUClear::PowerPlant>(config);
-    auto& reactor = plant->install<TestReactor>();
+    NUClear::PowerPlant plant(config);
+    plant.install<NUClear::extension::ChronoController>();
+    auto& reactor = plant.install<TestReactor>();
 
     // Set the reactor fields to the values we want to test
     const Action action      = GENERATE(Action::RELATIVE, Action::ABSOLUTE, Action::NEAREST);
@@ -90,7 +91,7 @@ TEST_CASE("Test time travel correctly changes the time for non zero rtf", "[time
     reactor.rtf        = rtf;
 
     // Start the powerplant
-    plant->start();
+    plant.start();
 
     // Expected results
     std::array<int64_t, 2> expected{};

--- a/tests/tests/api/TimeTravelFrozen.cpp
+++ b/tests/tests/api/TimeTravelFrozen.cpp
@@ -79,8 +79,9 @@ TEST_CASE("Test time travel correctly changes the time for non zero rtf", "[time
     using Action = NUClear::message::TimeTravel::Action;
 
     const NUClear::Configuration config;
-    auto plant    = std::make_shared<NUClear::PowerPlant>(config);
-    auto& reactor = plant->install<TestReactor>();
+    NUClear::PowerPlant plant(config);
+    plant.install<NUClear::extension::ChronoController>();
+    auto& reactor = plant.install<TestReactor>();
 
     // Set the reactor fields to the values we want to test
     const Action action      = GENERATE(Action::RELATIVE, Action::ABSOLUTE, Action::NEAREST);
@@ -91,7 +92,7 @@ TEST_CASE("Test time travel correctly changes the time for non zero rtf", "[time
     reactor.rtf        = 0.0;
 
     // Start the powerplant
-    plant->start();
+    plant.start();
 
     // Expected results
     std::vector<std::string> expected;

--- a/tests/tests/dsl/Every.cpp
+++ b/tests/tests/dsl/Every.cpp
@@ -78,6 +78,7 @@ TEST_CASE("Testing the Every<> DSL word", "[api][every][per]") {
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
+    plant.install<NUClear::extension::ChronoController>();
     const auto& reactor = plant.install<TestReactor>();
     plant.start();
 

--- a/tests/tests/dsl/IO.cpp
+++ b/tests/tests/dsl/IO.cpp
@@ -101,6 +101,7 @@ TEST_CASE("Testing the IO extension", "[api][io]") {
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
+    plant.install<NUClear::extension::IOController>();
     const auto& reactor = plant.install<TestReactor>();
     plant.start();
 

--- a/tests/tests/dsl/TCP.cpp
+++ b/tests/tests/dsl/TCP.cpp
@@ -212,6 +212,7 @@ TEST_CASE("Testing listening for TCP connections and receiving data messages", "
     NUClear::Configuration config;
     config.thread_count = 2;
     NUClear::PowerPlant plant(config);
+    plant.install<NUClear::extension::IOController>();
     plant.install<TestReactor>();
     plant.start();
 

--- a/tests/tests/dsl/UDP.cpp
+++ b/tests/tests/dsl/UDP.cpp
@@ -368,6 +368,7 @@ TEST_CASE("Testing sending and receiving of UDP messages", "[api][network][udp]"
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
+    plant.install<NUClear::extension::IOController>();
     plant.install<TestReactor>();
     plant.start();
 

--- a/tests/tests/dsl/Watchdog.cpp
+++ b/tests/tests/dsl/Watchdog.cpp
@@ -96,6 +96,7 @@ TEST_CASE("Testing the Watchdog Smart Type", "[api][watchdog]") {
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
+    plant.install<NUClear::extension::ChronoController>();
     const auto& reactor = plant.install<TestReactor>();
     plant.start();
 

--- a/tests/tests/dsl/emit/Delay.cpp
+++ b/tests/tests/dsl/emit/Delay.cpp
@@ -98,6 +98,7 @@ TEST_CASE("Testing the delay emit", "[api][emit][delay]") {
     NUClear::Configuration config;
     config.thread_count = 1;
     NUClear::PowerPlant plant(config);
+    plant.install<NUClear::extension::ChronoController>();
     const auto& reactor = plant.install<TestReactor>();
     plant.start();
 


### PR DESCRIPTION
This PR stops the installation of NUClear extensions by default.
They will need to instead be installed manually after powerplant creation.

In order for tracing to be effective, it needs to be installed early in the process.
Having these always installed extensions made it difficult to inject tracing at the right moment.

Additionally often these extensions weren't even needed and would still run, this way only the extensions that are required will be installed. 