### PR TITLE
Add a new thread pool option to allow the pool to live and accept tasks after shutdown

### DIFF
--- a/src/dsl/word/MainThread.hpp
+++ b/src/dsl/word/MainThread.hpp
@@ -34,9 +34,8 @@ namespace dsl {
              * This struct is here to define the main thread pool.
              */
             struct Main {
-                static constexpr const char* name     = "Main";
-                static constexpr int thread_count     = 1;
-                static constexpr bool counts_for_idle = true;
+                static constexpr const char* name = "Main";
+                static constexpr int thread_count = 1;
             };
         }  // namespace pool
 

--- a/src/dsl/word/Pool.hpp
+++ b/src/dsl/word/Pool.hpp
@@ -40,9 +40,8 @@ namespace dsl {
              * Thread pool descriptor for the default thread pool
              */
             struct Default {
-                static constexpr const char* name     = "Default";
-                static constexpr int thread_count     = 0;
-                static constexpr bool counts_for_idle = true;
+                static constexpr const char* name = "Default";
+                static constexpr int thread_count = 0;
             };
         }  // namespace pool
 
@@ -83,7 +82,8 @@ namespace dsl {
                 static const auto pool_descriptor =
                     std::make_shared<const util::ThreadPoolDescriptor>(name<PoolType>(),
                                                                        thread_count<PoolType>(),
-                                                                       counts_for_idle<PoolType>());
+                                                                       counts_for_idle<PoolType>(),
+                                                                       continue_on_shutdown<PoolType>());
                 return pool_descriptor;
             }
 
@@ -115,6 +115,15 @@ namespace dsl {
             template <typename U, typename... A>
             static constexpr bool counts_for_idle(const A&... /*unused*/) {
                 return true;
+            }
+
+            template <typename U>
+            static constexpr auto continue_on_shutdown() -> decltype(U::continue_on_shutdown) {
+                return U::continue_on_shutdown;
+            }
+            template <typename U, typename... A>
+            static constexpr bool continue_on_shutdown(const A&... /*unused*/) {
+                return false;
             }
         };
 

--- a/src/threading/scheduler/Pool.hpp
+++ b/src/threading/scheduler/Pool.hpp
@@ -42,7 +42,7 @@ namespace threading {
 
         class Pool : public std::enable_shared_from_this<Pool> {
         public:
-            enum StopType {
+            enum class StopType : uint8_t {
                 /// Normal stop, wait for all tasks to finish and accept no more tasks
                 /// Pools which ignore shutdown will continue to accept tasks
                 NORMAL,

--- a/src/threading/scheduler/Pool.hpp
+++ b/src/threading/scheduler/Pool.hpp
@@ -42,6 +42,17 @@ namespace threading {
 
         class Pool : public std::enable_shared_from_this<Pool> {
         public:
+            enum StopType {
+                /// Normal stop, wait for all tasks to finish and accept no more tasks
+                /// Pools which ignore shutdown will continue to accept tasks
+                NORMAL,
+                /// Final stop request, pools which ignore shutdown will finish when all tasks are done
+                /// However they will continue to accept tasks
+                FINAL,
+                /// Force stop, the queue will be cleared and all threads will be woken
+                FORCE
+            };
+
             struct Task {
                 /**
                  * @brief Construct a new Task object
@@ -103,8 +114,10 @@ namespace threading {
             /**
              * Stops the thread pool, all threads are woken and once the task queue is empty the threads will exit.
              * This function returns immediately, use join to wait for the threads to exit.
+             *
+             * @param type the type of stop to perform
              */
-            void stop(bool force = false);
+            void stop(const StopType& type);
 
             /**
              * Notify a thread in this pool that there is work to do.
@@ -204,6 +217,8 @@ namespace threading {
 
             /// If running is false this means the pool is shutting down and no more tasks will be accepted
             bool running = true;
+            /// If accept is false this pool will no longer accept new tasks
+            bool accept = true;
 
             /// The threads which are running in this thread pool
             std::vector<std::unique_ptr<std::thread>> threads;

--- a/src/threading/scheduler/Scheduler.cpp
+++ b/src/threading/scheduler/Scheduler.cpp
@@ -57,6 +57,7 @@ namespace threading {
             // The main thread will reach this point when the PowerPlant is shutting down
             // Sort the pools so that the pools that ignore shutdown are last to be forced to stop
             std::vector<std::shared_ptr<Pool>> pools_to_stop;
+            pools_to_stop.reserve(pools.size());
             for (const auto& pool : pools) {
                 pools_to_stop.push_back(pool.second);
             }

--- a/src/threading/scheduler/Scheduler.cpp
+++ b/src/threading/scheduler/Scheduler.cpp
@@ -54,9 +54,20 @@ namespace threading {
             get_pool(dsl::word::MainThread::descriptor())->start();
 
             // The main thread will reach this point when the PowerPlant is shutting down
-            // Calling stop on each pool will wait for each pool to finish processing all tasks before returning
+            // Sort the pools so that the pools that ignore shutdown are last to be forced to stop
+            std::vector<std::shared_ptr<Pool>> pools_to_stop;
             for (const auto& pool : pools) {
-                pool.second->join();
+                pools_to_stop.push_back(pool.second);
+            }
+            std::sort(pools_to_stop.begin(), pools_to_stop.end(), [](const auto& a, const auto& b) {
+                return a->descriptor->continue_on_shutdown < b->descriptor->continue_on_shutdown;
+            });
+            for (const auto& pool : pools_to_stop) {
+                // This is the final stop call
+                // By this point we have waited for all tasks to finish on the pools that don't ignore shutdown
+                // So now we can tell the pools that ignore shutdown to stop
+                pool->stop(Pool::StopType::FINAL);
+                pool->join();
             }
         }
 
@@ -64,7 +75,7 @@ namespace threading {
             running.store(false, std::memory_order_release);
             const std::lock_guard<std::mutex> lock(pools_mutex);
             for (const auto& pool : pools) {
-                pool.second->stop(force);
+                pool.second->stop(force ? Pool::StopType::FORCE : Pool::StopType::NORMAL);
             }
         }
 
@@ -103,6 +114,11 @@ namespace threading {
             const std::lock_guard<std::mutex> lock(pools_mutex);
             // If the pool does not exist, create it
             if (pools.count(desc) == 0) {
+                // Don't make new pools if we are shutting down
+                if (!running.load(std::memory_order_acquire)) {
+                    throw std::runtime_error("Cannot create new pools after the scheduler has started shutting down");
+                }
+
                 // Create the pool
                 auto pool   = std::make_shared<Pool>(*this, desc);
                 pools[desc] = pool;
@@ -163,11 +179,9 @@ namespace threading {
             // If this task should run immediately and not limited by the group lock
             if (task->run_inline && (group_lock == nullptr || group_lock->lock())) {
                 task->run();
-                return;
             }
-
-            // Submit the task to the appropriate pool
-            if (running.load(std::memory_order_acquire)) {
+            else {
+                // Submit the task to the appropriate pool
                 // Clear the idle status only if the current pool is not idle
                 // This hands the job of managing global idle tasks to this other pool if we were about to do it
                 // That way the other pool can decide if it is idle or not

--- a/src/threading/scheduler/Scheduler.cpp
+++ b/src/threading/scheduler/Scheduler.cpp
@@ -61,8 +61,10 @@ namespace threading {
             for (const auto& pool : pools) {
                 pools_to_stop.push_back(pool.second);
             }
-            std::sort(pools_to_stop.begin(), pools_to_stop.end(), [](const auto& a, const auto& b) {
-                return a->descriptor->continue_on_shutdown < b->descriptor->continue_on_shutdown;
+            std::sort(pools_to_stop.begin(), pools_to_stop.end(), [](const auto& lhs, const auto& rhs) {
+                const bool& a = lhs->descriptor->continue_on_shutdown;
+                const bool& b = rhs->descriptor->continue_on_shutdown;
+                return !a && b;
             });
             for (const auto& pool : pools_to_stop) {
                 // This is the final stop call

--- a/src/threading/scheduler/Scheduler.cpp
+++ b/src/threading/scheduler/Scheduler.cpp
@@ -22,6 +22,7 @@
 #include "Scheduler.hpp"
 
 #include <algorithm>
+#include <stdexcept>
 
 #include "../../dsl/word/MainThread.hpp"
 #include "../../dsl/word/Pool.hpp"
@@ -116,7 +117,8 @@ namespace threading {
             if (pools.count(desc) == 0) {
                 // Don't make new pools if we are shutting down
                 if (!running.load(std::memory_order_acquire)) {
-                    throw std::runtime_error("Cannot create new pools after the scheduler has started shutting down");
+                    throw std::invalid_argument(
+                        "Cannot create new pools after the scheduler has started shutting down");
                 }
 
                 // Create the pool

--- a/src/threading/scheduler/Scheduler.hpp
+++ b/src/threading/scheduler/Scheduler.hpp
@@ -133,7 +133,7 @@ namespace threading {
             /// The number of threads that will be in the default thread pool
             const int default_thread_count;
 
-            /// If running is false this means the scheduler is shutting down and no more tasks will be accepted
+            /// If running is false this means the scheduler is shutting down and no new pools will be created
             std::atomic<bool> running{true};
 
             /// A mutex for when we are modifying groups

--- a/src/util/ThreadPoolDescriptor.hpp
+++ b/src/util/ThreadPoolDescriptor.hpp
@@ -37,15 +37,23 @@ namespace util {
      */
     struct ThreadPoolDescriptor {
 
-        ThreadPoolDescriptor(std::string name, const int& thread_count = 1, const bool& counts_for_idle = true) noexcept
-            : name(std::move(name)), thread_count(thread_count), counts_for_idle(counts_for_idle) {}
+        ThreadPoolDescriptor(std::string name,
+                             const int& thread_count          = 1,
+                             const bool& counts_for_idle      = true,
+                             const bool& continue_on_shutdown = false) noexcept
+            : name(std::move(name))
+            , thread_count(thread_count)
+            , counts_for_idle(counts_for_idle)
+            , continue_on_shutdown(continue_on_shutdown) {}
 
         /// The name of this pool
         std::string name;
         /// The number of threads this thread pool will use
-        int thread_count{0};
+        int thread_count;
         /// If these threads count towards system idle
-        bool counts_for_idle{true};
+        bool counts_for_idle;
+        /// If this thread pool will continue to accept tasks after shutdown and only stop on scheduler destruction
+        bool continue_on_shutdown;
     };
 
 }  // namespace util


### PR DESCRIPTION
Currently when the system shuts down it will stop any new tasks from being added to the thread pools.

For some tasks like tracing, we want to be able to see tasks and accept tasks even after all the other pools have finished so we can trace events like Shutdown and emits that happen during the shutdown process.

This adds a new flag to custom pools that let them ignore the first shutdown state, and instead wait until the other pools have shut down before they stop running.