### PR TITLE
Improve the reliability of windows time based actions

### DIFF
--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -84,7 +84,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: traces-macos
+          name: traces-sonar
           path: build/tests/**/*.trace
           retention-days: 1 # This sets the artifact TTL to 1 day (minimum is 1 day)
           overwrite: true

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -56,6 +56,8 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Configure CMake
+        env:
+          CXXFLAGS: -DNUCLEAR_TEST_TIME_UNIT_DEN=10
         shell: cmd
         run: |
           cmake -E make_directory build

--- a/src/extension/ChronoController.cpp
+++ b/src/extension/ChronoController.cpp
@@ -90,8 +90,8 @@ namespace extension {
 
         // When we shutdown we notify so we quit now
         on<Shutdown>().then("Shutdown Chrono Controller", [this] {
-            const std::lock_guard<std::mutex> lock(mutex);
             running.store(false, std::memory_order_release);
+            const std::lock_guard<std::mutex> lock(mutex);
             wait.notify_all();
         });
 

--- a/src/util/precise_sleep.cpp
+++ b/src/util/precise_sleep.cpp
@@ -38,8 +38,17 @@ namespace util {
         // Negative for relative time, positive for absolute time
         // Measures in 100ns increments so divide by 100
         ft.QuadPart = -static_cast<int64_t>(ns.count() / 100);
+        // Create a waitable timer with as high resolution as possible
+        ::HANDLE timer{};
+        if (
+    #ifdef CREATE_WAITABLE_TIMER_HIGH_RESOLUTION
+            (timer = CreateWaitableTimerEx(NULL, NULL, CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS)) == NULL
+            &&
+    #endif
+            (timer = CreateWaitableTimer(NULL, TRUE, NULL)) == NULL) {
+            throw std::runtime_error("Failed to create waitable timer");
+        }
 
-        ::HANDLE timer = ::CreateWaitableTimer(nullptr, TRUE, nullptr);
         ::SetWaitableTimer(timer, &ft, 0, nullptr, nullptr, 0);
         ::WaitForSingleObject(timer, INFINITE);
         ::CloseHandle(timer);

--- a/src/util/precise_sleep.cpp
+++ b/src/util/precise_sleep.cpp
@@ -26,6 +26,7 @@
 
     #include <chrono>
     #include <cstdint>
+    #include <stdexcept>
 
     #include "platform.hpp"
 

--- a/tests/test_util/TestBase.hpp
+++ b/tests/test_util/TestBase.hpp
@@ -82,7 +82,8 @@ public:
 
             if (!clean_shutdown) {
                 powerplant.shutdown(true);
-                emit<Scope::INLINE>(std::make_unique<Fail>("Test timed out"));
+                emit<Scope::INLINE>(
+                    std::make_unique<Fail>("Test timed out after " + std::to_string(timeout.count()) + " ms"));
             }
         });
 

--- a/tests/tests/api/ReactionStatisticsTiming.cpp
+++ b/tests/tests/api/ReactionStatisticsTiming.cpp
@@ -26,6 +26,7 @@
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"
+#include "util/precise_sleep.hpp"
 
 using TimeUnit = test_util::TimeUnit;
 
@@ -81,7 +82,7 @@ public:
         });
         on<Trigger<LightTask>>().then(light_name, [] {
             code_events.emplace_back("Started " + light_name, NUClear::clock::now());
-            std::this_thread::sleep_for(TimeUnit(scale));
+            NUClear::util::precise_sleep(TimeUnit(scale));
             code_events.emplace_back("Finished " + light_name, NUClear::clock::now());
         });
 

--- a/tests/tests/api/TimeTravelFrozen.cpp
+++ b/tests/tests/api/TimeTravelFrozen.cpp
@@ -5,6 +5,7 @@
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
+#include "util/precise_sleep.hpp"
 
 constexpr std::chrono::milliseconds EVENT_1_TIME  = std::chrono::milliseconds(4);
 constexpr std::chrono::milliseconds EVENT_2_TIME  = std::chrono::milliseconds(8);
@@ -48,7 +49,7 @@ public:
         });
 
         on<Trigger<WaitForShutdown>>().then([this] {
-            std::this_thread::sleep_for(SHUTDOWN_TIME);
+            NUClear::util::precise_sleep(SHUTDOWN_TIME);
             add_event("Finished");
             powerplant.shutdown();
         });

--- a/tests/tests/dsl/IdleCrossPool.cpp
+++ b/tests/tests/dsl/IdleCrossPool.cpp
@@ -26,6 +26,7 @@
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"
+#include "util/precise_sleep.hpp"
 
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
@@ -44,7 +45,7 @@ public:
             default_thread_id = std::this_thread::get_id();
             events.push_back("Step<2>");
             // Sleep for a bit to coax out any more idle triggers
-            std::this_thread::sleep_for(test_util::TimeUnit(2));
+            NUClear::util::precise_sleep(test_util::TimeUnit(2));
             powerplant.shutdown();
         });
 

--- a/tests/tests/dsl/IdleGlobal.cpp
+++ b/tests/tests/dsl/IdleGlobal.cpp
@@ -26,6 +26,7 @@
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"
+#include "util/precise_sleep.hpp"
 
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
@@ -100,7 +101,7 @@ public:
 
     static void wait_for_set(const std::atomic<bool>& flag) {
         while (!flag.load(std::memory_order_acquire)) {
-            std::this_thread::sleep_for(test_util::TimeUnit(1));
+            NUClear::util::precise_sleep(test_util::TimeUnit(1));
         }
     }
 

--- a/tests/tests/dsl/IdleSingle.cpp
+++ b/tests/tests/dsl/IdleSingle.cpp
@@ -58,7 +58,8 @@ public:
         static constexpr int thread_count = 1;
     };
 
-    explicit TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment), false) {
+    explicit TestReactor(std::unique_ptr<NUClear::Environment> environment)
+        : TestBase(std::move(environment), false, std::chrono::seconds(2)) {
 
         /*
          * Runs a sync task so that a task can be triggered while the pool is idle.

--- a/tests/tests/dsl/IdleSingle.cpp
+++ b/tests/tests/dsl/IdleSingle.cpp
@@ -26,6 +26,7 @@
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"
+#include "util/precise_sleep.hpp"
 
 namespace Catch {
 
@@ -58,8 +59,7 @@ public:
         static constexpr int thread_count = 1;
     };
 
-    explicit TestReactor(std::unique_ptr<NUClear::Environment> environment)
-        : TestBase(std::move(environment), false, std::chrono::seconds(2)) {
+    explicit TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment), false) {
 
         /*
          * Runs a sync task so that a task can be triggered while the pool is idle.
@@ -70,7 +70,7 @@ public:
         on<Trigger<TaskA>, Pool<>, Sync<TestReactor>>().then([this](const TaskA& t) {
             entry_calls[t.i].fetch_add(1, std::memory_order_relaxed);
             emit(std::make_unique<TaskB>(t.i));
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            NUClear::util::precise_sleep(std::chrono::milliseconds(1));
         });
 
         // Run this at low priority but have it first

--- a/tests/tests/dsl/IdleSingleGlobal.cpp
+++ b/tests/tests/dsl/IdleSingleGlobal.cpp
@@ -50,7 +50,8 @@ private:
 public:
     static constexpr int n_loops = 10000;
 
-    explicit TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment), false) {
+    explicit TestReactor(std::unique_ptr<NUClear::Environment> environment)
+        : TestBase(std::move(environment), false, std::chrono::seconds(2)) {
 
         /*
          * Run idle on the default pool, and a task on the main pool.

--- a/tests/tests/dsl/IdleSync.cpp
+++ b/tests/tests/dsl/IdleSync.cpp
@@ -24,7 +24,9 @@
 #include <nuclear>
 
 #include "test_util/TestBase.hpp"
+#include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"
+#include "util/precise_sleep.hpp"
 
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
@@ -32,14 +34,14 @@ public:
 
         on<Trigger<Step<1>>, MainThread>().then([this] {
             emit(std::make_unique<Step<2>>());
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            NUClear::util::precise_sleep(test_util::TimeUnit(1));
             emit(std::make_unique<Step<3>>());
         });
 
         // Idle testing for default thread
         on<Trigger<Step<2>>, Sync<TestReactor>>().then([this] {
             add_event("Default Start");
-            std::this_thread::sleep_for(std::chrono::milliseconds(300));
+            NUClear::util::precise_sleep(test_util::TimeUnit(3));
             add_event("Default End");
         });
 

--- a/tests/tests/dsl/Inline.cpp
+++ b/tests/tests/dsl/Inline.cpp
@@ -26,6 +26,7 @@
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"
+#include "util/precise_sleep.hpp"
 
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
@@ -60,12 +61,12 @@ public:
         on<Trigger<Step<1>>, MainThread>().then([this] {
             emit(std::make_unique<SimpleMessage>("Main Local"));
             emit<Scope::INLINE>(std::make_unique<SimpleMessage>("Main Inline"));
-            std::this_thread::sleep_for(test_util::TimeUnit(2));  // Sleep for a bit to give other threads a chance
+            NUClear::util::precise_sleep(test_util::TimeUnit(2));  // Sleep for a bit to give other threads a chance
         });
         on<Trigger<Step<2>>, Pool<>>().then([this] {
             emit(std::make_unique<SimpleMessage>("Default Local"));
             emit<Scope::INLINE>(std::make_unique<SimpleMessage>("Default Inline"));
-            std::this_thread::sleep_for(test_util::TimeUnit(2));  // Sleep for a bit to give other threads a chance
+            NUClear::util::precise_sleep(test_util::TimeUnit(2));  // Sleep for a bit to give other threads a chance
         });
 
         on<Startup>().then([this] {

--- a/tests/tests/dsl/Sync.cpp
+++ b/tests/tests/dsl/Sync.cpp
@@ -24,7 +24,9 @@
 #include <nuclear>
 
 #include "test_util/TestBase.hpp"
+#include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"
+#include "util/precise_sleep.hpp"
 
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
@@ -40,14 +42,14 @@ public:
             events.push_back("Sync A " + m.data);
 
             // Sleep for some time to be safe
-            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            NUClear::util::precise_sleep(test_util::TimeUnit(1));
 
             // Emit a message 1 here, it should not run yet
             events.push_back("Sync A emitting");
             emit(std::make_unique<Message<1>>("From Sync A"));
 
             // Sleep for some time again
-            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            NUClear::util::precise_sleep(test_util::TimeUnit(1));
 
             events.push_back("Sync A " + m.data + " finished");
         });
@@ -56,14 +58,14 @@ public:
             events.push_back("Sync B " + m.data);
 
             // Sleep for some time to be safe
-            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            NUClear::util::precise_sleep(test_util::TimeUnit(1));
 
             // Emit a message 1 here, it should not run yet
             events.push_back("Sync B emitting");
             emit(std::make_unique<Message<1>>("From Sync B"));
 
             // Sleep for some time again
-            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            NUClear::util::precise_sleep(test_util::TimeUnit(1));
 
             events.push_back("Sync B " + m.data + " finished");
         });
@@ -72,13 +74,13 @@ public:
             events.push_back("Sync C " + m.data);
 
             // Sleep for some time to be safe
-            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            NUClear::util::precise_sleep(test_util::TimeUnit(1));
 
             // Emit a message 1 here, it should not run yet
             events.push_back("Sync C waiting");
 
             // Sleep for some time again
-            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            NUClear::util::precise_sleep(test_util::TimeUnit(1));
 
             events.push_back("Sync C " + m.data + " finished");
 

--- a/tests/tests/dsl/SyncMulti.cpp
+++ b/tests/tests/dsl/SyncMulti.cpp
@@ -26,6 +26,7 @@
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"
+#include "util/precise_sleep.hpp"
 
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
@@ -36,7 +37,7 @@ public:
         auto start = test_util::round_to_test_units(std::chrono::steady_clock::now() - start_time);
         events.push_back(event + " started @ " + std::to_string(start.count()));
         // Sleep for a bit to give a chance for the other threads to cause problems
-        std::this_thread::sleep_for(test_util::TimeUnit(2));
+        NUClear::util::precise_sleep(test_util::TimeUnit(2));
         auto end = test_util::round_to_test_units(std::chrono::steady_clock::now() - start_time);
         events.push_back(event + " finished @ " + std::to_string(end.count()));
     }


### PR DESCRIPTION
Occasionally in CI, the chrono controller would fail to stop and continue to run even after shutdown had happened.

Looking at the traces it seems that the shutdown from chrono controller stays running forever as well as chrono controller continuing to emit tasks.

The only way this could happen is if shutdown failed to acquire the mutex forever.

By setting running to false first outside of the mutex the main chrono thread should stop emitting tasks if it's looping.

If it's sleeping on the condition variable then locking the mutex then notifying should ensure it wakes up.

Also when windows ran tests, often they would time out.
This was because the timer that was used for sleeping would often vastly overestimate the amount of sleep time.
For example, the sleep for 1ms tests were often sleeping for 15 to 30ms instead.