### PR TITLE
Fix some issues that occur when compiling with c++17 or c++20

### DIFF
--- a/src/dsl/word/UDP.hpp
+++ b/src/dsl/word/UDP.hpp
@@ -132,7 +132,7 @@ namespace dsl {
                 // We can cast ourselves to a reference type so long as
                 // that reference type is plain old data
                 template <typename T>
-                operator std::enable_if_t<std::is_pod<T>::value, const T&>() {
+                operator std::enable_if_t<std::is_trivially_copyable<T>::value, const T&>() {
                     return *reinterpret_cast<const T*>(payload.data());
                 }
             };

--- a/src/threading/ReactionTask.hpp
+++ b/src/threading/ReactionTask.hpp
@@ -57,7 +57,7 @@ namespace threading {
 
     public:
         /// Type of the functions that ReactionTasks execute
-        using TaskFunction = std::function<void(ReactionTask&) noexcept>;
+        using TaskFunction = std::function<void(ReactionTask&)>;
 
         /**
          * Gets the current executing task, or nullptr if there isn't one.

--- a/src/util/TypeMap.hpp
+++ b/src/util/TypeMap.hpp
@@ -86,7 +86,7 @@ namespace util {
          */
         static std::shared_ptr<Value> get() {
 #if __cplusplus >= 202002L
-       return     data.load(std::memory_order_acquire);
+            return data.load(std::memory_order_acquire);
 #else
             return std::atomic_load_explicit(&data, std::memory_order_acquire);
 #endif
@@ -96,8 +96,10 @@ namespace util {
     /// Initialize our shared_ptr data
     template <typename MapID, typename Key, typename Value>
 #if __cplusplus >= 202002L
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     std::atomic<std::shared_ptr<Value>> TypeMap<MapID, Key, Value>::data;
 #else
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     std::shared_ptr<Value> TypeMap<MapID, Key, Value>::data;
 #endif
 


### PR DESCRIPTION
- The `noexcept` specifier on an std::function will not compile in c++17 or c++20
- In c++20 is_pod is deprecated
- In c++20 the separate functions for atomic shared pointers are deprecated