### PR TITLE
Rename some variables to more sensible/consistent names

### DIFF
--- a/docs/startup.rst
+++ b/docs/startup.rst
@@ -23,7 +23,7 @@ file for the process.
 .. code-block:: C++
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
 
 .. todo::

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,7 +41,7 @@ target_compile_features(nuclear PUBLIC cxx_std_14)
 if(MSVC)
   target_compile_options(nuclear PRIVATE /W4 /WX)
 else()
-  target_compile_options(nuclear PRIVATE -Wall -Wextra -pedantic -Werror)
+  target_compile_options(nuclear PRIVATE -Wall -Wextra -pedantic)
 endif(MSVC)
 
 # Make the NUClearConfig files

--- a/src/Configuration.hpp
+++ b/src/Configuration.hpp
@@ -32,8 +32,9 @@ namespace NUClear {
  * This class holds the configuration for a PowerPlant.
  */
 struct Configuration {
-    /// The number of threads the system will use
-    int thread_count = std::thread::hardware_concurrency() == 0 ? 2 : int(std::thread::hardware_concurrency());
+    /// The number of threads the system will use for the default thread pool
+    int default_pool_concurrency =
+        std::thread::hardware_concurrency() == 0 ? 2 : int(std::thread::hardware_concurrency());
 };
 
 }  // namespace NUClear

--- a/src/PowerPlant.cpp
+++ b/src/PowerPlant.cpp
@@ -48,7 +48,8 @@ PowerPlant* PowerPlant::powerplant = nullptr;
 
 // This is taking argc and argv as given by main so this should not take an array
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-PowerPlant::PowerPlant(Configuration config, int argc, const char* argv[]) : scheduler(config.thread_count) {
+PowerPlant::PowerPlant(Configuration config, int argc, const char* argv[])
+    : scheduler(config.default_pool_concurrency) {
 
     // Stop people from making more then one powerplant
     if (powerplant != nullptr) {
@@ -111,7 +112,7 @@ void PowerPlant::log(const LogLevel& level, std::string message) {
         level,
         current_task != nullptr ? current_task->parent->reactor.log_level : LogLevel::UNKNOWN,
         std::move(message),
-        current_task != nullptr ? current_task->stats : nullptr));
+        current_task != nullptr ? current_task->statistics : nullptr));
 }
 void PowerPlant::log(const LogLevel& level, std::stringstream& message) {
     log(level, message.str());

--- a/src/dsl/word/Group.hpp
+++ b/src/dsl/word/Group.hpp
@@ -67,7 +67,7 @@ namespace dsl {
             // This must be a separate function, otherwise each instance of DSL will be a separate pool
             static std::shared_ptr<const util::GroupDescriptor> descriptor() {
                 static const auto group_descriptor =
-                    std::make_shared<const util::GroupDescriptor>(name<GroupType>(), thread_count<GroupType>());
+                    std::make_shared<const util::GroupDescriptor>(name<GroupType>(), concurrency<GroupType>());
                 return group_descriptor;
             }
 
@@ -88,11 +88,11 @@ namespace dsl {
             }
 
             template <typename U>
-            static constexpr auto thread_count() -> decltype(U::thread_count) {
-                return U::thread_count;
+            static constexpr auto concurrency() -> decltype(U::concurrency) {
+                return U::concurrency;
             }
             template <typename U, typename... A>
-            static constexpr int thread_count(const A&... /*unused*/) {
+            static constexpr int concurrency(const A&... /*unused*/) {
                 return 1;
             }
         };

--- a/src/dsl/word/MainThread.hpp
+++ b/src/dsl/word/MainThread.hpp
@@ -35,7 +35,7 @@ namespace dsl {
              */
             struct Main {
                 static constexpr const char* name = "Main";
-                static constexpr int thread_count = 1;
+                static constexpr int concurrency  = 1;
             };
         }  // namespace pool
 

--- a/src/dsl/word/Pool.hpp
+++ b/src/dsl/word/Pool.hpp
@@ -41,7 +41,7 @@ namespace dsl {
              */
             struct Default {
                 static constexpr const char* name = "Default";
-                static constexpr int thread_count = 0;
+                static constexpr int concurrency  = 0;
             };
         }  // namespace pool
 
@@ -70,7 +70,7 @@ namespace dsl {
          * should be allocated to this pool.
          *  @code
          *  struct ThreadPool {
-         *      static constexpr int thread_count = 2;
+         *      static constexpr int concurrency = 2;
          *  };
          *  @endcode
          */
@@ -81,9 +81,9 @@ namespace dsl {
             static std::shared_ptr<const util::ThreadPoolDescriptor> descriptor() {
                 static const auto pool_descriptor =
                     std::make_shared<const util::ThreadPoolDescriptor>(name<PoolType>(),
-                                                                       thread_count<PoolType>(),
+                                                                       concurrency<PoolType>(),
                                                                        counts_for_idle<PoolType>(),
-                                                                       continue_on_shutdown<PoolType>());
+                                                                       persistent<PoolType>());
                 return pool_descriptor;
             }
 
@@ -103,8 +103,8 @@ namespace dsl {
             }
 
             template <typename U>
-            static constexpr auto thread_count() -> decltype(U::thread_count) {
-                return U::thread_count;
+            static constexpr auto concurrency() -> decltype(U::concurrency) {
+                return U::concurrency;
             }
             // No default for thread count
 
@@ -118,11 +118,11 @@ namespace dsl {
             }
 
             template <typename U>
-            static constexpr auto continue_on_shutdown() -> decltype(U::continue_on_shutdown) {
-                return U::continue_on_shutdown;
+            static constexpr auto persistent() -> decltype(U::persistent) {
+                return U::persistent;
             }
             template <typename U, typename... A>
-            static constexpr bool continue_on_shutdown(const A&... /*unused*/) {
+            static constexpr bool persistent(const A&... /*unused*/) {
                 return false;
             }
         };

--- a/src/extension/TraceController.hpp
+++ b/src/extension/TraceController.hpp
@@ -42,11 +42,11 @@ namespace extension {
         struct TracePool {
             static constexpr const char* name = "Trace";
             /// Single thread to avoid multithreading concerns
-            static constexpr int thread_count = 1;
+            static constexpr int concurrency = 1;
             /// This pool shouldn't interfere with the system idle time
             static constexpr bool counts_for_idle = false;
             /// So we can trace events all the way to after shutdown, this pool must not shut down until destruction
-            static constexpr bool continue_on_shutdown = true;
+            static constexpr bool persistent = true;
         };
 
         /**

--- a/src/message/ReactionStatistics.hpp
+++ b/src/message/ReactionStatistics.hpp
@@ -64,9 +64,9 @@ namespace message {
             /// The time that this event occurred in NUClear time
             NUClear::clock::time_point nuclear_time;
             /// The time that this event occurred in real time
-            std::chrono::steady_clock::time_point realtime;
+            std::chrono::steady_clock::time_point real_time;
             /// The time that this event occurred in CPU thread time
-            util::cpu_clock::time_point cpu_time;
+            util::cpu_clock::time_point thread_time;
 
             /**
              * Creates a new Event object with the current time and thread information.

--- a/src/threading/ReactionTask.cpp
+++ b/src/threading/ReactionTask.cpp
@@ -68,10 +68,11 @@ namespace threading {
         return id_source.fetch_add(1, std::memory_order_seq_cst);
     }
 
-    std::shared_ptr<message::ReactionStatistics> ReactionTask::make_stats() {
+    std::shared_ptr<message::ReactionStatistics> ReactionTask::make_statistics() {
 
         // Stats are disabled if they are disabled in the parent or in the causing task
-        if ((parent != nullptr && !parent->emit_stats) || (current_task != nullptr && current_task->stats == nullptr)) {
+        if ((parent != nullptr && !parent->emit_stats)
+            || (current_task != nullptr && current_task->statistics == nullptr)) {
             return nullptr;
         }
 

--- a/src/threading/ReactionTask.hpp
+++ b/src/threading/ReactionTask.hpp
@@ -89,7 +89,7 @@ namespace threading {
             , should_inline(inline_fn(*this))
             , pool_descriptor(thread_pool_fn(*this))
             , group_descriptors(groups_fn(*this))
-            , stats(make_stats()) {
+            , statistics(make_statistics()) {
             // Increment the number of active tasks
             if (parent != nullptr) {
                 parent->active_tasks.fetch_add(1, std::memory_order_release);
@@ -147,8 +147,7 @@ namespace threading {
 
         /// The statistics object that records run details about this reaction task
         /// This will be nullptr if this task is ineligible to emit stats (e.g. it would cause a loop)
-        std::shared_ptr<message::ReactionStatistics> stats;
-
+        std::shared_ptr<message::ReactionStatistics> statistics;
 
         /// The data bound callback to be executed
         /// @attention note this must be last in the list as the this pointer is passed to the callback generator
@@ -179,7 +178,7 @@ namespace threading {
          *
          * @return A new ReactionStatistics object for this task
          */
-        std::shared_ptr<message::ReactionStatistics> make_stats();
+        std::shared_ptr<message::ReactionStatistics> make_statistics();
     };
 
 }  // namespace threading

--- a/src/threading/scheduler/Group.hpp
+++ b/src/threading/scheduler/Group.hpp
@@ -166,7 +166,7 @@ namespace threading {
             /// The mutex which protects the queue
             std::mutex mutex;
             /// The number of tokens that are available for this group
-            int tokens = descriptor->thread_count;
+            int tokens = descriptor->concurrency;
             /// The queue of tasks for this specific thread pool and if they are group blocked
             std::vector<std::shared_ptr<LockHandle>> queue;
         };

--- a/src/threading/scheduler/Pool.cpp
+++ b/src/threading/scheduler/Pool.cpp
@@ -58,8 +58,8 @@ namespace threading {
 
         void Pool::start() {
             // Default thread pool gets its thread count from the configuration rather than the descriptor
-            const int n_threads = descriptor == dsl::word::Pool<>::descriptor() ? scheduler.default_thread_count
-                                                                                : descriptor->thread_count;
+            const int n_threads = descriptor == dsl::word::Pool<>::descriptor() ? scheduler.default_pool_concurrency
+                                                                                : descriptor->concurrency;
 
             // Set the number of active threads to the number of threads in the pool
             active = descriptor->counts_for_idle ? n_threads : 0;
@@ -81,12 +81,12 @@ namespace threading {
         void Pool::stop(const StopType& type) {
             const std::lock_guard<std::mutex> lock(mutex);
 
-            live   = true;                              // Live so the thread will wake from sleep
-            accept = descriptor->continue_on_shutdown;  // Always accept if continue on shutdown otherwise stop
+            live   = true;                    // Live so the thread will wake from sleep
+            accept = descriptor->persistent;  // Always accept if persistent otherwise stop
 
             switch (type) {
                 case StopType::NORMAL: {
-                    running = descriptor->continue_on_shutdown;  // Keep running if we continue on shutdown
+                    running = descriptor->persistent;  // Keep running if we persistent
                 } break;
                 case StopType::FINAL: {
                     running = false;  // Always stop running on the final stop

--- a/src/threading/scheduler/Scheduler.cpp
+++ b/src/threading/scheduler/Scheduler.cpp
@@ -32,7 +32,7 @@ namespace NUClear {
 namespace threading {
     namespace scheduler {
 
-        Scheduler::Scheduler(const int& thread_count) : default_thread_count(thread_count) {
+        Scheduler::Scheduler(const int& default_pool_concurrency) : default_pool_concurrency(default_pool_concurrency) {
             // Create the main thread pool and assign it as our "current pool" so things we do pre startup are assigned
             Pool::current_pool = get_pool(dsl::word::MainThread::descriptor()).get();
         }
@@ -62,8 +62,8 @@ namespace threading {
                 pools_to_stop.push_back(pool.second);
             }
             std::sort(pools_to_stop.begin(), pools_to_stop.end(), [](const auto& lhs, const auto& rhs) {
-                const bool& a = lhs->descriptor->continue_on_shutdown;
-                const bool& b = rhs->descriptor->continue_on_shutdown;
+                const bool& a = lhs->descriptor->persistent;
+                const bool& b = rhs->descriptor->persistent;
                 return !a && b;
             });
             for (const auto& pool : pools_to_stop) {

--- a/src/threading/scheduler/Scheduler.hpp
+++ b/src/threading/scheduler/Scheduler.hpp
@@ -45,7 +45,7 @@ namespace threading {
 
         class Scheduler {
         public:
-            explicit Scheduler(const int& thread_count);
+            explicit Scheduler(const int& default_pool_concurrency);
 
             /**
              * Starts the scheduler, and begins executing tasks.
@@ -131,7 +131,7 @@ namespace threading {
                                                   const std::set<std::shared_ptr<const util::GroupDescriptor>>& descs);
 
             /// The number of threads that will be in the default thread pool
-            const int default_thread_count;
+            const int default_pool_concurrency;
 
             /// If running is false this means the scheduler is shutting down and no new pools will be created
             std::atomic<bool> running{true};

--- a/src/util/CallbackGenerator.hpp
+++ b/src/util/CallbackGenerator.hpp
@@ -71,6 +71,9 @@ namespace util {
         std::unique_ptr<threading::ReactionTask> operator()(const std::shared_ptr<threading::Reaction>& r,
                                                             const bool& request_inline) {
 
+            using ReactionEvent = message::ReactionEvent;
+            using Event         = message::ReactionEvent::Event;
+
             auto task = std::make_unique<threading::ReactionTask>(r,
                                                                   request_inline,
                                                                   DSL::priority,
@@ -82,9 +85,8 @@ namespace util {
             if (!DSL::precondition(*task)) {
 
                 // Set the created status as rejected and emit it
-                if (task->stats != nullptr) {
-                    PowerPlant::powerplant->emit(
-                        std::make_unique<message::ReactionEvent>(message::ReactionEvent::BLOCKED, task->stats));
+                if (task->statistics != nullptr) {
+                    PowerPlant::powerplant->emit(std::make_unique<ReactionEvent>(Event::BLOCKED, task->statistics));
                 }
 
                 // Nothing to run
@@ -103,9 +105,9 @@ namespace util {
             if (!check_data(data)) {
 
                 // Set the created status as no data and emit it
-                if (task->stats != nullptr) {
+                if (task->statistics != nullptr) {
                     PowerPlant::powerplant->emit(
-                        std::make_unique<message::ReactionEvent>(message::ReactionEvent::MISSING_DATA, task->stats));
+                        std::make_unique<ReactionEvent>(Event::MISSING_DATA, task->statistics));
                 }
 
                 // Nothing to run
@@ -113,9 +115,8 @@ namespace util {
             }
 
             // Set the created status as no data and emit it
-            if (task->stats != nullptr) {
-                PowerPlant::powerplant->emit(
-                    std::make_unique<message::ReactionEvent>(message::ReactionEvent::CREATED, task->stats));
+            if (task->statistics != nullptr) {
+                PowerPlant::powerplant->emit(std::make_unique<ReactionEvent>(Event::CREATED, task->statistics));
             }
 
             // We have to make a copy of the callback because the "this" variable can go out of scope
@@ -124,10 +125,9 @@ namespace util {
                 // Update our thread's priority to the correct level
                 update_current_thread_priority(task.priority);
 
-                if (task.stats != nullptr) {
-                    task.stats->started = message::ReactionStatistics::Event::now();
-                    PowerPlant::powerplant->emit(
-                        std::make_unique<message::ReactionEvent>(message::ReactionEvent::STARTED, task.stats));
+                if (task.statistics != nullptr) {
+                    task.statistics->started = message::ReactionStatistics::Event::now();
+                    PowerPlant::powerplant->emit(std::make_unique<ReactionEvent>(Event::STARTED, task.statistics));
                 }
 
                 // We have to catch any exceptions
@@ -137,18 +137,18 @@ namespace util {
                 }
                 catch (...) {
                     // Catch our exception if it happens
-                    if (task.stats != nullptr) {
-                        task.stats->exception = std::current_exception();
+                    if (task.statistics != nullptr) {
+                        task.statistics->exception = std::current_exception();
                     }
                 }
 
                 // Run our postconditions
                 DSL::postcondition(task);
 
-                if (task.stats != nullptr) {
-                    task.stats->finished = message::ReactionStatistics::Event::now();
-                    PowerPlant::powerplant->emit(
-                        std::make_unique<message::ReactionEvent>(message::ReactionEvent::FINISHED, task.stats));
+                if (task.statistics != nullptr) {
+                    task.statistics->finished = message::ReactionStatistics::Event::now();
+                    PowerPlant::powerplant->emit(std::make_unique<ReactionEvent>(Event::FINISHED, task.statistics));
+                    PowerPlant::powerplant->emit_shared<dsl::word::emit::Local>(task.statistics);
                 }
             };
 

--- a/src/util/GroupDescriptor.hpp
+++ b/src/util/GroupDescriptor.hpp
@@ -38,13 +38,12 @@ namespace util {
      * A description of a group.
      */
     struct GroupDescriptor {
-        GroupDescriptor(std::string name, const int& thread_count)
-            : name(std::move(name)), thread_count(thread_count) {}
+        GroupDescriptor(std::string name, const int& concurrency) : name(std::move(name)), concurrency(concurrency) {}
 
         /// The name of this group
         std::string name;
         /// The maximum number of threads that can run concurrently in this group
-        int thread_count;
+        int concurrency;
     };
 
 }  // namespace util

--- a/src/util/ThreadPoolDescriptor.hpp
+++ b/src/util/ThreadPoolDescriptor.hpp
@@ -38,22 +38,22 @@ namespace util {
     struct ThreadPoolDescriptor {
 
         ThreadPoolDescriptor(std::string name,
-                             const int& thread_count          = 1,
-                             const bool& counts_for_idle      = true,
-                             const bool& continue_on_shutdown = false) noexcept
+                             const int& concurrency      = 1,
+                             const bool& counts_for_idle = true,
+                             const bool& persistent      = false) noexcept
             : name(std::move(name))
-            , thread_count(thread_count)
+            , concurrency(concurrency)
             , counts_for_idle(counts_for_idle)
-            , continue_on_shutdown(continue_on_shutdown) {}
+            , persistent(persistent) {}
 
         /// The name of this pool
         std::string name;
         /// The number of threads this thread pool will use
-        int thread_count;
+        int concurrency;
         /// If these threads count towards system idle
         bool counts_for_idle;
-        /// If this thread pool will continue to accept tasks after shutdown and only stop on scheduler destruction
-        bool continue_on_shutdown;
+        /// If this thread pool will continue to accept tasks after shutdown and only stop when there are no more tasks
+        bool persistent;
     };
 
 }  // namespace util

--- a/tests/networktest.cpp
+++ b/tests/networktest.cpp
@@ -129,7 +129,7 @@ int main(int argc, const char* argv[]) {
     }
 
     NUClear::Configuration config;
-    config.thread_count = 4;
+    config.default_pool_concurrency = 4;
     NUClear::PowerPlant plant(config, argc, argv);
     plant.install<TestReactor>();
 

--- a/tests/tests/api/ReactionHandle.cpp
+++ b/tests/tests/api/ReactionHandle.cpp
@@ -69,7 +69,7 @@ public:
 
 TEST_CASE("Testing reaction handle functionality", "[api][reactionhandle]") {
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/api/ReactionStatistics.cpp
+++ b/tests/tests/api/ReactionStatistics.cpp
@@ -98,7 +98,7 @@ public:
 TEST_CASE("Testing reaction statistics functionality", "[api][reactionstatistics]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/api/ReactionStatisticsTiming.cpp
+++ b/tests/tests/api/ReactionStatisticsTiming.cpp
@@ -101,8 +101,8 @@ public:
                         break;
                     case ReactionEvent::FINISHED:
                         stat_events.emplace_back("Finished " + stats.identifiers->name, stats.finished.nuclear_time);
-                        usage.real[stats.identifiers->name] = stats.finished.realtime - stats.started.realtime;
-                        usage.cpu[stats.identifiers->name]  = stats.finished.cpu_time - stats.started.cpu_time;
+                        usage.real[stats.identifiers->name] = stats.finished.real_time - stats.started.real_time;
+                        usage.cpu[stats.identifiers->name]  = stats.finished.thread_time - stats.started.thread_time;
                         break;
                     default: break;
                 }
@@ -122,7 +122,7 @@ public:
 TEST_CASE("Testing reaction statistics timing", "[api][reactionstatistics][timing]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     plant.install<TestReactor>();

--- a/tests/tests/api/ReactorArgs.cpp
+++ b/tests/tests/api/ReactorArgs.cpp
@@ -44,7 +44,7 @@ public:
 
 TEST_CASE("Testing Reactor installation arguments", "[api][reactorargs]") {
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     const TestReactorArgs& r1   = plant.install<TestReactorArgs>("Hello NUClear", true, 0x00E298A2);
     const TestReactorNoArgs& r2 = plant.install<TestReactorNoArgs>();

--- a/tests/tests/dsl/Always.cpp
+++ b/tests/tests/dsl/Always.cpp
@@ -60,7 +60,7 @@ public:
 TEST_CASE("The Always DSL keyword runs continuously when it can", "[api][always]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     auto& reactor = plant.install<TestReactor>();
     plant.start();

--- a/tests/tests/dsl/ArgumentFission.cpp
+++ b/tests/tests/dsl/ArgumentFission.cpp
@@ -88,7 +88,7 @@ public:
 TEST_CASE("Testing distributing arguments to multiple bind functions (NUClear Fission)", "[api][dsl][fission]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     plant.install<TestReactor>();

--- a/tests/tests/dsl/BlockNoData.cpp
+++ b/tests/tests/dsl/BlockNoData.cpp
@@ -66,7 +66,7 @@ public:
 TEST_CASE("Testing that when an on statement does not have it's data satisfied it does not run", "[api][nodata]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/Buffer.cpp
+++ b/tests/tests/dsl/Buffer.cpp
@@ -99,7 +99,7 @@ public:
 TEST_CASE("Test that Buffer and Single limit the number of concurrent executions", "[api][precondition][single]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/CommandLineArguments.cpp
+++ b/tests/tests/dsl/CommandLineArguments.cpp
@@ -52,7 +52,7 @@ TEST_CASE("Testing the Command Line argument capturing", "[api][command_line_arg
     const int argc     = 2;
     const char* argv[] = {"Hello", "World"};  // NOLINT(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config, argc, argv);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/CustomGet.cpp
+++ b/tests/tests/dsl/CustomGet.cpp
@@ -58,7 +58,7 @@ public:
 TEST_CASE("Test a custom reactor that returns a type that needs dereferencing", "[api][custom_get]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/DSLOrdering.cpp
+++ b/tests/tests/dsl/DSLOrdering.cpp
@@ -75,7 +75,7 @@ public:
 TEST_CASE("Testing poorly ordered on arguments", "[api][dsl][order][with]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/DSLProxy.cpp
+++ b/tests/tests/dsl/DSLProxy.cpp
@@ -72,7 +72,7 @@ public:
 TEST_CASE("Testing that the DSL proxy works as expected for binding unmodifyable types", "[api][dsl][proxy]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/Every.cpp
+++ b/tests/tests/dsl/Every.cpp
@@ -77,7 +77,7 @@ void test_results(const std::vector<NUClear::clock::time_point>& times) {
 TEST_CASE("Testing the Every<> DSL word", "[api][every][per]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     plant.install<NUClear::extension::ChronoController>();

--- a/tests/tests/dsl/FlagMessage.cpp
+++ b/tests/tests/dsl/FlagMessage.cpp
@@ -70,7 +70,7 @@ public:
 TEST_CASE("Testing emitting types that are flag types (Have no contents)", "[api][flag]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/FusionInOrder.cpp
+++ b/tests/tests/dsl/FusionInOrder.cpp
@@ -45,7 +45,7 @@ public:
 TEST_CASE("Testing that the bind functions of extensions are executed in order", "[api][extension][bind]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     plant.install<TestReactor>();
 

--- a/tests/tests/dsl/GroupPool.cpp
+++ b/tests/tests/dsl/GroupPool.cpp
@@ -37,7 +37,7 @@ public:
 
     template <int id>
     struct TestPool {
-        static constexpr int thread_count = 1;
+        static constexpr int concurrency = 1;
     };
 
     void register_pool_callbacks(NUClear::util::Sequence<> /*unused*/) {}
@@ -94,7 +94,7 @@ public:
 TEST_CASE("Test that if a pool has nothing to do because of a sync group it will recover", "[api][pool][group]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/IO.cpp
+++ b/tests/tests/dsl/IO.cpp
@@ -100,7 +100,7 @@ public:
 TEST_CASE("Testing the IO extension", "[api][io]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     plant.install<NUClear::extension::IOController>();

--- a/tests/tests/dsl/Idle.cpp
+++ b/tests/tests/dsl/Idle.cpp
@@ -36,7 +36,7 @@ public:
 
     template <int N>
     struct CustomPool {
-        static constexpr int thread_count = 2;
+        static constexpr int concurrency = 2;
     };
 
     template <int N>
@@ -118,7 +118,7 @@ private:
 TEST_CASE("Test that pool idle triggers when nothing is running", "[api][idle]") {
 
     NUClear::Configuration config;
-    config.thread_count = 4;
+    config.default_pool_concurrency = 4;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/IdleCrossPool.cpp
+++ b/tests/tests/dsl/IdleCrossPool.cpp
@@ -64,7 +64,7 @@ public:
 TEST_CASE("Test that idle can fire events for other pools but only runs once", "[api][dsl][Idle][Pool]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/IdleGlobal.cpp
+++ b/tests/tests/dsl/IdleGlobal.cpp
@@ -32,7 +32,7 @@ class TestReactor : public test_util::TestBase<TestReactor> {
 public:
     // A pool to use for monitoring which does not interact with idleness
     struct NonIdlePool {
-        static constexpr int thread_count     = 2;
+        static constexpr int concurrency      = 2;
         static constexpr bool counts_for_idle = false;
     };
 
@@ -116,7 +116,7 @@ public:
 TEST_CASE("Test that Idle won't fire when an already idle pool goes idle again", "[api][dsl][Idle][Pool]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/IdleSingle.cpp
+++ b/tests/tests/dsl/IdleSingle.cpp
@@ -56,7 +56,7 @@ public:
     };
 
     struct IdlePool {
-        static constexpr int thread_count = 1;
+        static constexpr int concurrency = 1;
     };
 
     explicit TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment), false) {
@@ -109,7 +109,7 @@ public:
 TEST_CASE("Test that when a global idle trigger exists it is triggered only once", "[api][dsl][Idle][Sync]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/IdleSingleGlobal.cpp
+++ b/tests/tests/dsl/IdleSingleGlobal.cpp
@@ -88,7 +88,7 @@ public:
 TEST_CASE("Test that when a global idle trigger exists it is triggered only once", "[api][dsl][Idle][Sync]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/IdleSync.cpp
+++ b/tests/tests/dsl/IdleSync.cpp
@@ -70,7 +70,7 @@ public:
 TEST_CASE("Test that pool idle triggers when a waiting task prevents running", "[api][idle]") {
 
     NUClear::Configuration config;
-    config.thread_count = 4;
+    config.default_pool_concurrency = 4;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/Inline.cpp
+++ b/tests/tests/dsl/Inline.cpp
@@ -92,7 +92,7 @@ public:
 TEST_CASE("Test the interactions between inline emits and the Inline dsl keyword") {
 
     NUClear::Configuration config;
-    config.thread_count = 4;
+    config.default_pool_concurrency = 4;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/Last.cpp
+++ b/tests/tests/dsl/Last.cpp
@@ -60,7 +60,7 @@ public:
 TEST_CASE("Testing the last n feature", "[api][last]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/MainThread.cpp
+++ b/tests/tests/dsl/MainThread.cpp
@@ -71,7 +71,7 @@ private:
 
 TEST_CASE("Testing that the MainThread keyword runs tasks on the main thread", "[api][dsl][main_thread]") {
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/MissingArguments.cpp
+++ b/tests/tests/dsl/MissingArguments.cpp
@@ -63,7 +63,7 @@ public:
 TEST_CASE("Testing that when arguments missing from the call it can still run", "[api][missing_arguments]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/Once.cpp
+++ b/tests/tests/dsl/Once.cpp
@@ -66,7 +66,7 @@ public:
 TEST_CASE("Reactions with the Once DSL keyword only execute once", "[api][once]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/Optional.cpp
+++ b/tests/tests/dsl/Optional.cpp
@@ -70,7 +70,7 @@ public:
 TEST_CASE("Testing that optional is able to let data through even if it's invalid", "[api][optional]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/Priority.cpp
+++ b/tests/tests/dsl/Priority.cpp
@@ -91,7 +91,7 @@ public:
 TEST_CASE("Tests that priority orders the tasks appropriately", "[api][priority]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/Raw.cpp
+++ b/tests/tests/dsl/Raw.cpp
@@ -73,7 +73,7 @@ public:
 TEST_CASE("Testing the raw type conversions work properly", "[api][raw]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     plant.install<TestReactor>();

--- a/tests/tests/dsl/RawFunction.cpp
+++ b/tests/tests/dsl/RawFunction.cpp
@@ -106,7 +106,7 @@ public:
 TEST_CASE("Test reaction can take a raw function instead of just a lambda", "[api][raw_function]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     plant.install<TestReactor>();

--- a/tests/tests/dsl/Shutdown.cpp
+++ b/tests/tests/dsl/Shutdown.cpp
@@ -53,7 +53,7 @@ public:
 TEST_CASE("A test that a shutdown message is emitted when the system shuts down", "[api][shutdown]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/Startup.cpp
+++ b/tests/tests/dsl/Startup.cpp
@@ -53,7 +53,7 @@ public:
 
 TEST_CASE("Testing the startup event is emitted at the start of the program", "[api][startup]") {
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/Sync.cpp
+++ b/tests/tests/dsl/Sync.cpp
@@ -101,7 +101,7 @@ public:
 
 TEST_CASE("Testing that the Sync word works correctly", "[api][sync]") {
     NUClear::Configuration config;
-    config.thread_count = 4;
+    config.default_pool_concurrency = 4;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/SyncMulti.cpp
+++ b/tests/tests/dsl/SyncMulti.cpp
@@ -65,7 +65,7 @@ public:
 
 TEST_CASE("Test that sync works when one thread has multiple groups", "[api][sync][multi]") {
     NUClear::Configuration config;
-    config.thread_count = 4;
+    config.default_pool_concurrency = 4;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/SyncOrder.cpp
+++ b/tests/tests/dsl/SyncOrder.cpp
@@ -64,7 +64,7 @@ public:
 
 TEST_CASE("Sync events execute in order", "[api][sync][priority]") {
     NUClear::Configuration config;
-    config.thread_count = 4;
+    config.default_pool_concurrency = 4;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/TCP.cpp
+++ b/tests/tests/dsl/TCP.cpp
@@ -211,7 +211,7 @@ TEST_CASE("Testing listening for TCP connections and receiving data messages", "
     }
 
     NUClear::Configuration config;
-    config.thread_count = 2;
+    config.default_pool_concurrency = 2;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     plant.install<NUClear::extension::IOController>();

--- a/tests/tests/dsl/Transient.cpp
+++ b/tests/tests/dsl/Transient.cpp
@@ -129,7 +129,7 @@ public:
 
 TEST_CASE("Testing whether getters that return transient data can cache between calls", "[api][transient]") {
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/Trigger.cpp
+++ b/tests/tests/dsl/Trigger.cpp
@@ -55,7 +55,7 @@ public:
 TEST_CASE("Test that Trigger statements get the correct data", "[api][trigger]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/UDP.cpp
+++ b/tests/tests/dsl/UDP.cpp
@@ -367,7 +367,7 @@ TEST_CASE("Testing sending and receiving of UDP messages", "[api][network][udp]"
     }
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     plant.install<NUClear::extension::IOController>();

--- a/tests/tests/dsl/Watchdog.cpp
+++ b/tests/tests/dsl/Watchdog.cpp
@@ -95,7 +95,7 @@ public:
 TEST_CASE("Testing the Watchdog Smart Type", "[api][watchdog]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     plant.install<NUClear::extension::ChronoController>();

--- a/tests/tests/dsl/With.cpp
+++ b/tests/tests/dsl/With.cpp
@@ -85,7 +85,7 @@ public:
 TEST_CASE("Testing the with dsl keyword", "[api][with]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/dsl/emit/Delay.cpp
+++ b/tests/tests/dsl/emit/Delay.cpp
@@ -97,7 +97,7 @@ public:
 
 TEST_CASE("Testing the delay emit", "[api][emit][delay]") {
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     plant.install<NUClear::extension::ChronoController>();

--- a/tests/tests/dsl/emit/EmitFusion.cpp
+++ b/tests/tests/dsl/emit/EmitFusion.cpp
@@ -84,7 +84,7 @@ public:
 TEST_CASE("Testing emit function fusion", "[api][emit][fusion]") {
 
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     plant.install<TestReactor>();
 

--- a/tests/tests/dsl/emit/Initialise.cpp
+++ b/tests/tests/dsl/emit/Initialise.cpp
@@ -63,7 +63,7 @@ public:
 
 TEST_CASE("Testing the Initialize scope", "[api][emit][initialize]") {
     NUClear::Configuration config;
-    config.thread_count = 1;
+    config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();

--- a/tests/tests/log/Log.cpp
+++ b/tests/tests/log/Log.cpp
@@ -148,7 +148,7 @@ TEST_CASE("Testing the Log<>() function", "[api][log]") {
     {
         // Build with one thread
         NUClear::Configuration config;
-        config.thread_count = 1;
+        config.default_pool_concurrency = 1;
         NUClear::PowerPlant plant(config);
 
         // Install the test reactor


### PR DESCRIPTION
Taking the opportunity as many things are changing to rename some variables to more sensible names