### PR TITLE
Rename threadpool to pool

### DIFF
--- a/src/message/ReactionStatistics.cpp
+++ b/src/message/ReactionStatistics.cpp
@@ -44,12 +44,12 @@ namespace message {
     ReactionStatistics::ReactionStatistics(std::shared_ptr<const threading::ReactionIdentifiers> identifiers,
                                            const IDPair& cause,
                                            const IDPair& target,
-                                           std::shared_ptr<const util::ThreadPoolDescriptor> target_threadpool,
+                                           std::shared_ptr<const util::ThreadPoolDescriptor> target_pool,
                                            std::set<std::shared_ptr<const util::GroupDescriptor>> target_groups)
         : identifiers(std::move(identifiers))
         , cause(cause)
         , target(target)
-        , target_threadpool(std::move(target_threadpool))
+        , target_pool(std::move(target_pool))
         , target_groups(std::move(target_groups))
         , created(Event::now()) {}
 

--- a/src/message/ReactionStatistics.hpp
+++ b/src/message/ReactionStatistics.hpp
@@ -79,7 +79,7 @@ namespace message {
         ReactionStatistics(std::shared_ptr<const threading::ReactionIdentifiers> identifiers,
                            const IDPair& cause,
                            const IDPair& target,
-                           std::shared_ptr<const util::ThreadPoolDescriptor> target_threadpool,
+                           std::shared_ptr<const util::ThreadPoolDescriptor> target_pool,
                            std::set<std::shared_ptr<const util::GroupDescriptor>> target_groups);
 
         /// The identifiers for the reaction that was executed
@@ -91,7 +91,7 @@ namespace message {
         IDPair target;
 
         /// The thread pool that this reaction was intended to run on
-        std::shared_ptr<const util::ThreadPoolDescriptor> target_threadpool;
+        std::shared_ptr<const util::ThreadPoolDescriptor> target_pool;
         /// The groups that this reaction was intended to run in
         std::set<std::shared_ptr<const util::GroupDescriptor>> target_groups;
 


### PR DESCRIPTION
The variables representing thread pools are called `pool` throughout the rest of the code, not `threadpool`