### PR TITLE
Swap back to using mutexes to protect the type map

### DIFF
--- a/src/util/TypeMap.hpp
+++ b/src/util/TypeMap.hpp
@@ -81,7 +81,7 @@ namespace util {
          * @param d A pointer to the data to be stored (the map takes ownership)
          */
         static void set(std::shared_ptr<Value> d) {
-            std::lock_guard<std::mutex> lock(data_mutex);
+            const std::lock_guard<std::mutex> lock(data_mutex);
             data = d;
         }
 
@@ -91,7 +91,7 @@ namespace util {
          * @return A shared_ptr to the data that was previously stored
          */
         static std::shared_ptr<Value> get() {
-            std::lock_guard<std::mutex> lock(data_mutex);
+            const std::lock_guard<std::mutex> lock(data_mutex);
             return data;
         }
     };


### PR DESCRIPTION
You would think that you should use an atomic shared pointer rather than a mutex protected shared pointer.
That would make sense, then you would potentially have a lock free implementation!

However the implementation as seen in libc++ and libstdc++ is to use a mutex protected shared pointer anyway.
But worse than that, it just uses a hashmap of mutexes to protect the shared pointers.
Specifically it looks like they just have 0xF mutexes and they hash the pointer addresses to pick one.
Having only a few mutexes for the entire map is a terrible idea and causes a lot of contention.
This is strictly worse than the already separated mutex per type that is achieved by this implementation.