### PR TITLE
Store trace events that mark the start of the trace

### DIFF
--- a/src/extension/TraceController.cpp
+++ b/src/extension/TraceController.cpp
@@ -275,6 +275,11 @@ namespace extension {
             }
             write_trace_packet(data);
 
+            // Write the trace events that happened before the trace started
+            auto current_stats = threading::ReactionTask::get_current_task()->statistics;
+            encode_event(ReactionEvent(ReactionEvent::CREATED, current_stats));
+            encode_event(ReactionEvent(ReactionEvent::STARTED, current_stats));
+
             // Bind new handles
             event_handle = on<Trigger<ReactionEvent>, Pool<TracePool>>().then([this](const ReactionEvent& e) {  //
                 encode_event(e);


### PR DESCRIPTION
The trigger that starts the trace itself wasn't logged properly. This made it difficult to get a "zero time" for the trace.

Logging the BeginTrace reaction itself means you get to see when the begin trace was requested