### PR TITLE
Remove partially received packets over NUClearNet after timeout

### DIFF
--- a/src/extension/network/NUClearNetwork.cpp
+++ b/src/extension/network/NUClearNetwork.cpp
@@ -851,6 +851,15 @@ namespace extension {
                                     // We have completed this packet, discard the data
                                     assemblers.erase(assemblers.find(packet.packet_id));
                                 }
+
+                                // Check for and delete any timed out packets
+                                for (auto it = assemblers.begin(); it != assemblers.end();) {
+                                    const auto now              = std::chrono::steady_clock::now();
+                                    const auto timeout          = remote->round_trip_time * 10.0;
+                                    const auto& last_chunk_time = it->second.first;
+
+                                    it = now > last_chunk_time + timeout ? assemblers.erase(it) : std::next(it);
+                                }
                             }
                         }
                     } break;


### PR DESCRIPTION
Fix for memory issue in NUClearNet due to partially received messages never being cleaned up. This resulted in the process eventually crashing due to being out of memory.

This fix checks all the packet assemblers each time a packet chunk is received and removes any packets that have not had a new chunk in a while.