### PR TITLE
 [#56] Fix update current thread priority for linux and make an enum

### DIFF
--- a/src/Reactor.hpp
+++ b/src/Reactor.hpp
@@ -51,6 +51,7 @@ namespace dsl {
 
         struct Once;
 
+        template <util::Priority>
         struct Priority;
 
         template <typename>
@@ -192,7 +193,8 @@ protected:
     using Trigger = dsl::word::Trigger<T>;
 
     /// @copydoc dsl::word::Priority
-    using Priority = dsl::word::Priority;
+    template <util::Priority value>
+    using Priority = dsl::word::Priority<value>;
 
     /// @copydoc dsl::word::Always
     using Always = dsl::word::Always;

--- a/src/dsl/Parse.hpp
+++ b/src/dsl/Parse.hpp
@@ -76,7 +76,7 @@ namespace dsl {
                 Parse<Sentence...>>(task);
         }
 
-        static int priority(threading::ReactionTask& task) {
+        static util::Priority priority(threading::ReactionTask& task) {
             return std::conditional_t<fusion::has_priority<DSL>::value, DSL, fusion::NoOp>::template priority<
                 Parse<Sentence...>>(task);
         }

--- a/src/dsl/fusion/NoOp.hpp
+++ b/src/dsl/fusion/NoOp.hpp
@@ -80,8 +80,8 @@ namespace dsl {
             }
 
             template <typename DSL>
-            static int priority(const threading::ReactionTask& /*task*/) {
-                return word::Priority::NORMAL::value;
+            static util::Priority priority(const threading::ReactionTask& /*task*/) {
+                return util::Priority::NORMAL;
             }
 
             template <typename DSL>

--- a/src/dsl/fusion/PriorityFusion.hpp
+++ b/src/dsl/fusion/PriorityFusion.hpp
@@ -44,7 +44,7 @@ namespace dsl {
         struct PriorityFuser<std::tuple<Word>> {
 
             template <typename DSL>
-            static int priority(threading::ReactionTask& task) {
+            static util::Priority priority(threading::ReactionTask& task) {
 
                 // Return our priority
                 return Word::template priority<DSL>(task);
@@ -56,7 +56,7 @@ namespace dsl {
         struct PriorityFuser<std::tuple<Word1, Word2, WordN...>> {
 
             template <typename DSL>
-            static int priority(threading::ReactionTask& task) {
+            static util::Priority priority(threading::ReactionTask& task) {
 
                 // Choose our maximum priority
                 return std::max(Word1::template priority<DSL>(task),

--- a/src/dsl/word/Always.hpp
+++ b/src/dsl/word/Always.hpp
@@ -131,7 +131,7 @@ namespace dsl {
                 auto idle_task = std::make_unique<threading::ReactionTask>(
                     reaction,
                     false,
-                    [](threading::ReactionTask& task) { return DSL::priority(task) - 1; },
+                    [](threading::ReactionTask& task) { return prev(DSL::priority(task)); },
                     DSL::run_inline,
                     DSL::pool,
                     DSL::group);

--- a/src/dsl/word/Priority.hpp
+++ b/src/dsl/word/Priority.hpp
@@ -24,11 +24,11 @@
 #define NUCLEAR_DSL_WORD_PRIORITY_HPP
 
 #include "../../threading/Reaction.hpp"
+#include "../../util/Priority.hpp"
 
 namespace NUClear {
 namespace dsl {
     namespace word {
-
         /**
          * Task priority can be controlled using an assigned setting.
          *
@@ -67,57 +67,12 @@ namespace dsl {
          * @par Implements
          *  Fusion
          */
+        template <util::Priority value>
         struct Priority {
-
-            struct REALTIME {
-                /// Realtime priority runs with 1000 value
-                static constexpr int value = 1000;
-
-                template <typename DSL>
-                static int priority(const threading::ReactionTask& /*task*/) {
-                    return value;
-                }
-            };
-
-            struct HIGH {
-                /// High priority runs with 750 value
-                static constexpr int value = 750;
-
-                template <typename DSL>
-                static int priority(const threading::ReactionTask& /*task*/) {
-                    return value;
-                }
-            };
-
-            struct NORMAL {
-                /// Normal priority runs with 500 value
-                static constexpr int value = 500;
-
-                template <typename DSL>
-                static int priority(const threading::ReactionTask& /*task*/) {
-                    return value;
-                }
-            };
-
-            struct LOW {
-                /// Low priority runs with 250 value
-                static constexpr int value = 250;
-
-                template <typename DSL>
-                static int priority(const threading::ReactionTask& /*task*/) {
-                    return value;
-                }
-            };
-
-            struct IDLE {
-                /// Idle tasks run with 0 priority, they run when there is free time
-                static constexpr int value = 0;
-
-                template <typename DSL>
-                static int priority(const threading::ReactionTask& /*task*/) {
-                    return value;
-                }
-            };
+            template <typename DSL>
+            static util::Priority priority(const threading::ReactionTask& /*task*/) {
+                return value;
+            }
         };
 
     }  // namespace word

--- a/src/dsl/word/Priority.hpp
+++ b/src/dsl/word/Priority.hpp
@@ -32,36 +32,24 @@ namespace dsl {
         /**
          * Task priority can be controlled using an assigned setting.
          *
-         * @code on<Trigger<T, ...>, Priority::HIGH>() @endcode
+         * @code on<Trigger<T, ...>, Priority<util::Priority::HIGH>>() @endcode
          * The PowerPlant uses this setting to determine the scheduling order in the threadpool, as well as assign a
          * priority to the thread on the OS.
          *
          * The available priority settings are:
          *
-         * <b>REALTIME:</b>  Tasks assigned with this will be queued with all other REALTIME tasks.
-         *
+         * <b>HIGHEST:</b>
          * <b>HIGH:</b>
-         * Tasks assigned with this will be queued with all other HIGH tasks.
-         * They will be scheduled for execution when there are no REALTIME tasks in the queue.
-         *
          * <b>NORMAL:</b>
-         * Tasks assigned with this will be queued with all other NORMAL tasks.
-         * They will be scheduled for execution when there are no REALTIME and HIGH tasks in the queue.
-         *
          * <b>LOW:</b>
-         * Tasks assigned with this will be queued with all other LOW tasks.
-         * They will be scheduled for execution when there are no REALTIME, HIGH and NORMAL tasks in the queue.
-         *
-         * <b>IDLE:</b>
-         * Tasks assigned with this priority will be queued with all other IDLE tasks.
-         * They will be scheduled for execution when there are no other tasks running in the system.
+         * <b>LOWEST:</b>
          *
          * @par Default Behaviour
          *  @code on<Trigger<T>>() @endcode
          *  When the priority is not specified, tasks will be assigned a default setting; NORMAL.
          *
          * @attention
-         *  If the OS allows the user to set thread priority, this word can also be used to assign the priority of the
+         *  If the OS allows the user to set thread priority, this word will also be used to assign the priority of the
          *  thread in its runtime environment.
          *
          * @par Implements

--- a/src/dsl/word/Shutdown.hpp
+++ b/src/dsl/word/Shutdown.hpp
@@ -24,6 +24,7 @@
 #define NUCLEAR_DSL_WORD_SHUTDOWN_HPP
 
 #include "../operation/TypeBind.hpp"
+#include "../../util/Priority.hpp"
 
 namespace NUClear {
 namespace dsl {
@@ -54,7 +55,7 @@ namespace dsl {
          */
         struct Shutdown
             : operation::TypeBind<Shutdown>
-            , Priority::IDLE {};
+            , Priority<util::Priority::LOWEST> {};
 
     }  // namespace word
 }  // namespace dsl

--- a/src/dsl/word/emit/Initialise.hpp
+++ b/src/dsl/word/emit/Initialise.hpp
@@ -59,7 +59,7 @@ namespace dsl {
                     auto emitter = std::make_unique<threading::ReactionTask>(
                         nullptr,
                         false,
-                        [](threading::ReactionTask& /*task*/) { return 1000; },
+                        [](threading::ReactionTask& /*task*/) { return NUClear::util::Priority::HIGHEST; },
                         [](threading::ReactionTask& /*task*/) { return util::Inline::NEVER; },
                         [](threading::ReactionTask& /*task*/) { return Pool<>::descriptor(); },
                         [](threading::ReactionTask& /*task*/) {

--- a/src/extension/ChronoController.cpp
+++ b/src/extension/ChronoController.cpp
@@ -121,7 +121,7 @@ namespace extension {
             wait.notify_all();
         });
 
-        on<Always, Priority::REALTIME>().then("Chrono Controller", [this] {
+        on<Always, Priority<util::Priority::HIGHEST>>().then("Chrono Controller", [this] {
             // Run until we are told to stop
             while (running.load(std::memory_order_acquire)) {
 

--- a/src/threading/ReactionTask.hpp
+++ b/src/threading/ReactionTask.hpp
@@ -32,6 +32,7 @@
 #include "../util/GroupDescriptor.hpp"
 #include "../util/Inline.hpp"
 #include "../util/ThreadPoolDescriptor.hpp"
+#include "../util/Priority.hpp"
 #include "../util/platform.hpp"
 #include "Reaction.hpp"
 
@@ -136,7 +137,7 @@ namespace threading {
         bool run_inline{false};
 
         /// The priority to run this task at
-        int priority;
+        util::Priority priority;
         /// If the task should be executed inline (in the current thread) or not
         util::Inline should_inline{util::Inline::NEUTRAL};
         /// Details about the thread pool that this task will run from, this will also influence what task queue

--- a/src/threading/scheduler/Group.cpp
+++ b/src/threading/scheduler/Group.cpp
@@ -33,7 +33,7 @@ namespace NUClear {
 namespace threading {
     namespace scheduler {
 
-        Group::LockHandle::LockHandle(const NUClear::id_t& task_id, const int& priority, std::function<void()> notify)
+        Group::LockHandle::LockHandle(const NUClear::id_t& task_id, const util::Priority& priority, std::function<void()> notify)
             : task_id(task_id), priority(priority), notify(std::move(notify)) {}
 
         Group::GroupLock::GroupLock(Group& group, std::shared_ptr<LockHandle> handle)
@@ -109,7 +109,7 @@ namespace threading {
         Group::Group(std::shared_ptr<const util::GroupDescriptor> descriptor) : descriptor(std::move(descriptor)) {}
 
         std::unique_ptr<Lock> Group::lock(const NUClear::id_t& task_id,
-                                          const int& priority,
+                                          const util::Priority& priority,
                                           const std::function<void()>& notify) {
 
             auto handle = std::make_shared<LockHandle>(task_id, priority, notify);

--- a/src/threading/scheduler/Group.hpp
+++ b/src/threading/scheduler/Group.hpp
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "../../util/GroupDescriptor.hpp"
+#include "../../util/Priority.hpp"
 #include "Lock.hpp"
 
 namespace NUClear {
@@ -50,7 +51,7 @@ namespace threading {
              * It holds if the lock should currently be locked, as well as ordering which locks should be locked first.
              */
             struct LockHandle {
-                LockHandle(const NUClear::id_t& task_id, const int& priority, std::function<void()> notify);
+                LockHandle(const NUClear::id_t& task_id, const util::Priority& priority, std::function<void()> notify);
 
                 /**
                  * Compare two lock handles by comparing their priority and task id
@@ -78,7 +79,7 @@ namespace threading {
                 /// The task id of the reaction that is waiting, lower task ids run first
                 NUClear::id_t task_id;
                 /// The priority of the reaction that is waiting, higher priorities run first
-                int priority;
+                util::Priority priority;
                 /// If this lock has been successfully locked
                 bool locked{false};
                 /// If this lock has been notified that it can lock
@@ -156,7 +157,7 @@ namespace threading {
              * @return a lock which can be locked once a token is available
              */
             std::unique_ptr<Lock> lock(const NUClear::id_t& task_id,
-                                       const int& priority,
+                                       const util::Priority& priority,
                                        const std::function<void()>& notify);
 
             /// The descriptor for this group

--- a/src/threading/scheduler/Pool.cpp
+++ b/src/threading/scheduler/Pool.cpp
@@ -257,7 +257,7 @@ namespace threading {
             auto task = std::make_unique<ReactionTask>(
                 nullptr,
                 true,
-                [](const ReactionTask&) { return 0; },
+                [](const ReactionTask&) { return util::Priority::LOWEST; },
                 [](const ReactionTask&) { return util::Inline::ALWAYS; },
                 [](const ReactionTask&) { return dsl::word::Pool<>::descriptor(); },
                 [](const ReactionTask&) { return std::set<std::shared_ptr<const util::GroupDescriptor>>{}; });

--- a/src/threading/scheduler/Scheduler.cpp
+++ b/src/threading/scheduler/Scheduler.cpp
@@ -150,7 +150,7 @@ namespace threading {
 
         std::unique_ptr<Lock> Scheduler::get_groups_lock(
             const NUClear::id_t& task_id,
-            const int& priority,
+            const util::Priority& priority,
             const std::shared_ptr<Pool>& pool,
             const std::set<std::shared_ptr<const util::GroupDescriptor>>& descs) {
 

--- a/src/threading/scheduler/Scheduler.hpp
+++ b/src/threading/scheduler/Scheduler.hpp
@@ -126,7 +126,7 @@ namespace threading {
              * @return a combined lock representing the state of all the groups
              */
             std::unique_ptr<Lock> get_groups_lock(const NUClear::id_t& task_id,
-                                                  const int& priority,
+                                                  const util::Priority& priority,
                                                   const std::shared_ptr<Pool>& pool,
                                                   const std::set<std::shared_ptr<const util::GroupDescriptor>>& descs);
 

--- a/src/util/CallbackGenerator.hpp
+++ b/src/util/CallbackGenerator.hpp
@@ -29,6 +29,7 @@
 #include "../message/ReactionStatistics.hpp"
 #include "../util/MergeTransient.hpp"
 #include "../util/TransientDataElements.hpp"
+#include "../util/Priority.hpp"
 #include "../util/apply.hpp"
 #include "../util/unpack.hpp"
 #include "../util/update_current_thread_priority.hpp"

--- a/src/util/Priority.hpp
+++ b/src/util/Priority.hpp
@@ -1,0 +1,44 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 NUClear Contributors
+ *
+ * This file is part of the NUClear codebase.
+ * See https://github.com/Fastcode/NUClear for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef NUCLEAR_UTIL_PRIORITY_HPP
+#define NUCLEAR_UTIL_PRIORITY_HPP
+
+#include <algorithm>
+#include <cstdint>
+#include <type_traits>
+
+namespace NUClear {
+namespace util {
+
+    enum class Priority : uint8_t { LOWEST = 0, LOW = 1, NORMAL = 2, HIGH = 3, HIGHEST = 4 };
+    inline Priority prev(Priority value) {
+        value = static_cast<Priority>(static_cast<std::underlying_type_t<Priority>>(value) - 1);
+        value = std::min(value, Priority::LOWEST);
+        return value;
+    }
+    constexpr Priority MAX_PRIORITY = Priority::HIGHEST;
+
+}  // namespace util
+}  // namespace NUClear
+
+#endif  // NUCLEAR_UTIL_PRIORITY_HPP

--- a/src/util/Priority.hpp
+++ b/src/util/Priority.hpp
@@ -30,13 +30,18 @@
 namespace NUClear {
 namespace util {
 
+    /**
+     * The priority value for Priority dsl word
+     */
     enum class Priority : uint8_t { LOWEST = 0, LOW = 1, NORMAL = 2, HIGH = 3, HIGHEST = 4 };
+    /**
+     * Gets one lower priority unless already lowest
+     */
     inline Priority prev(Priority value) {
         value = static_cast<Priority>(static_cast<std::underlying_type_t<Priority>>(value) - 1);
         value = std::min(value, Priority::LOWEST);
         return value;
     }
-    constexpr Priority MAX_PRIORITY = Priority::HIGHEST;
 
 }  // namespace util
 }  // namespace NUClear

--- a/src/util/update_current_thread_priority.hpp
+++ b/src/util/update_current_thread_priority.hpp
@@ -33,7 +33,7 @@ inline void update_current_thread_priority(NUClear::util::Priority priority) {
     auto priority_int = static_cast<std::underlying_type_t<NUClear::util::Priority>>(priority);
 
     auto step = (sched_get_priority_max(SCHED_RR) - sched_get_priority_min(SCHED_RR))
-                / static_cast<std::underlying_type_t<NUClear::util::Priority>>(NUClear::util::MAX_PRIORITY);
+                / static_cast<std::underlying_type_t<NUClear::util::Priority>>(NUClear::util::Priority::HIGHEST);
     auto sched_priority = priority_int * step;
 
     sched_param p{};

--- a/src/util/update_current_thread_priority.hpp
+++ b/src/util/update_current_thread_priority.hpp
@@ -23,18 +23,18 @@
 #ifndef NUCLEAR_UTIL_UPDATE_CURRENT_THREAD_PRIORITY_HPP
 #define NUCLEAR_UTIL_UPDATE_CURRENT_THREAD_PRIORITY_HPP
 
+#include "../util/Priority.hpp"
+
 #ifndef _WIN32
 
     #include <pthread.h>
 
-inline void update_current_thread_priority(int priority) {
+inline void update_current_thread_priority(NUClear::util::Priority priority) {
+    auto priority_int = static_cast<std::underlying_type_t<NUClear::util::Priority>>(priority);
 
-    // TODO(Trent) SCHED_NORMAL for normal threads
-    // TODO(Trent) SCHED_FIFO for realtime threads
-    // TODO(Trent) SCHED_RR for high priority threads
-
-    auto sched_priority = sched_get_priority_min(SCHED_RR)
-                          + (priority / (sched_get_priority_max(SCHED_RR) - sched_get_priority_min(SCHED_RR)));
+    auto step = (sched_get_priority_max(SCHED_RR) - sched_get_priority_min(SCHED_RR))
+                / static_cast<std::underlying_type_t<NUClear::util::Priority>>(NUClear::util::MAX_PRIORITY);
+    auto sched_priority = priority_int * step;
 
     sched_param p{};
     p.sched_priority = sched_priority;
@@ -46,29 +46,23 @@ inline void update_current_thread_priority(int priority) {
 
     #include "platform.hpp"
 
-inline void update_current_thread_priority(int priority) {
+inline void update_current_thread_priority(NUClear::util::Priority priority) {
 
-    switch ((priority * 7) / 1000) {
-        case 0: {
-            SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_IDLE);
-        } break;
-        case 1: {
+    switch (priority) {
+        case LOWEST: {
             SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_LOWEST);
         } break;
-        case 2: {
+        case LOW: {
             SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_BELOW_NORMAL);
         } break;
-        case 3: {
+        case NORMAL: {
             SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_NORMAL);
         } break;
-        case 4: {
+        case HIGH: {
             SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL);
         } break;
-        case 5: {
+        case HIGHEST: {
             SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST);
-        } break;
-        case 6: {
-            SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
         } break;
     }
 }

--- a/tests/tests/api/ReactionHandle.cpp
+++ b/tests/tests/api/ReactionHandle.cpp
@@ -37,13 +37,13 @@ public:
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment)) {
 
         // Make an always disabled reaction
-        a = on<Trigger<Message>, Priority::HIGH>().then([this](const Message& msg) {  //
+        a = on<Trigger<Message>, Priority<NUClear::util::Priority::HIGH>>().then([this](const Message& msg) {  //
             events.push_back("Executed disabled reaction " + std::to_string(msg.i));
         });
         a.disable();
 
         // Make a reaction that we toggle on and off
-        b = on<Trigger<Message>, Priority::HIGH>().then([this](const Message& msg) {  //
+        b = on<Trigger<Message>, Priority<NUClear::util::Priority::HIGH>>().then([this](const Message& msg) {  //
             events.push_back("Executed toggled reaction " + std::to_string(msg.i));
             b.disable();
             emit(std::make_unique<Message>(1));

--- a/tests/tests/api/ReactionStatistics.cpp
+++ b/tests/tests/api/ReactionStatistics.cpp
@@ -40,13 +40,13 @@ public:
 
         // This reaction is here to emit something from a ReactionStatistics trigger
         // This shouldn't cause reaction statistics of their own otherwise everything would explode
-        on<Trigger<ReactionEvent>, Priority::HIGH>().then("Loop Statistics", [this](const ReactionEvent&) {  //
+        on<Trigger<ReactionEvent>, Priority<NUClear::util::Priority::HIGH>>().then("Loop Statistics", [this](const ReactionEvent&) {  //
             emit(std::make_unique<LoopMessage>());
         });
         on<Trigger<LoopMessage>>().then("No Statistics", [] {});
 
 
-        on<Trigger<ReactionEvent>, Priority::HIGH>().then("Reaction Stats Handler", [this](const ReactionEvent& event) {
+        on<Trigger<ReactionEvent>, Priority<NUClear::util::Priority::HIGH>>().then("Reaction Stats Handler", [this](const ReactionEvent& event) {
             const auto& stats = *event.statistics;
 
             // Other reactions statistics run on this because of built in NUClear reactors (e.g. chrono controller etc)

--- a/tests/tests/api/ReactionStatisticsTiming.cpp
+++ b/tests/tests/api/ReactionStatisticsTiming.cpp
@@ -60,7 +60,7 @@ public:
     TestReactor(std::unique_ptr<NUClear::Environment> environment)
         : TestBase(std::move(environment), true, std::chrono::seconds(2)) {
 
-        on<Trigger<Step<1>>, Priority::LOW>().then(initial_name + ":" + heavy_name, [this] {
+        on<Trigger<Step<1>>, Priority<NUClear::util::Priority::LOW>>().then(initial_name + ":" + heavy_name, [this] {
             code_events.emplace_back("Started " + initial_name + ":" + heavy_name, NUClear::clock::now());
             code_events.emplace_back("Created " + heavy_name, NUClear::clock::now());
             emit(std::make_unique<HeavyTask>());
@@ -74,7 +74,7 @@ public:
             code_events.emplace_back("Finished " + heavy_name, NUClear::clock::now());
         });
 
-        on<Trigger<Step<1>>, Priority::LOW>().then(initial_name + ":" + light_name, [this] {
+        on<Trigger<Step<1>>, Priority<NUClear::util::Priority::LOW>>().then(initial_name + ":" + light_name, [this] {
             code_events.emplace_back("Started " + initial_name + ":" + light_name, NUClear::clock::now());
             code_events.emplace_back("Created " + light_name, NUClear::clock::now());
             emit(std::make_unique<LightTask>());

--- a/tests/tests/dsl/BlockNoData.cpp
+++ b/tests/tests/dsl/BlockNoData.cpp
@@ -47,7 +47,7 @@ public:
             events.push_back("MessageB with MessageA triggered");
         });
 
-        on<Trigger<Step<1>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<1>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Emitting MessageA");
             emit(std::make_unique<MessageA>());
         });

--- a/tests/tests/dsl/Buffer.cpp
+++ b/tests/tests/dsl/Buffer.cpp
@@ -51,29 +51,29 @@ public:
             events.push_back("Buffer<4> reaction " + std::to_string(msg.i));
         });
 
-        on<Trigger<Step<1>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<1>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Step 1");
             emit(std::make_unique<Message>(1));
         });
-        on<Trigger<Step<2>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<2>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Step 2");
             emit(std::make_unique<Message>(2));
             emit(std::make_unique<Message>(3));
         });
-        on<Trigger<Step<3>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<3>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Step 3");
             emit(std::make_unique<Message>(4));
             emit(std::make_unique<Message>(5));
             emit(std::make_unique<Message>(6));
         });
-        on<Trigger<Step<4>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<4>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Step 4");
             emit(std::make_unique<Message>(7));
             emit(std::make_unique<Message>(8));
             emit(std::make_unique<Message>(9));
             emit(std::make_unique<Message>(10));
         });
-        on<Trigger<Step<5>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<5>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Step 5");
             emit(std::make_unique<Message>(11));
             emit(std::make_unique<Message>(12));

--- a/tests/tests/dsl/DSLOrdering.cpp
+++ b/tests/tests/dsl/DSLOrdering.cpp
@@ -47,15 +47,15 @@ public:
             events.push_back("Empty function");
         });
 
-        on<Trigger<Step<1>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<1>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Emitting 1");
             emit(std::make_unique<Message<1>>("1"));
         });
-        on<Trigger<Step<2>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<2>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Emitting 2");
             emit(std::make_unique<Message<2>>("2"));
         });
-        on<Trigger<Step<3>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<3>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Emitting 3");
             emit(std::make_unique<Message<3>>("3"));
         });

--- a/tests/tests/dsl/FlagMessage.cpp
+++ b/tests/tests/dsl/FlagMessage.cpp
@@ -50,7 +50,7 @@ public:
             events.push_back("MessageA with MessageB triggered");
         });
 
-        on<Trigger<Step<1>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<1>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Step<1> triggered");
             events.push_back("Emitting MessageA");
             emit(std::make_unique<MessageA>());

--- a/tests/tests/dsl/IdleGlobal.cpp
+++ b/tests/tests/dsl/IdleGlobal.cpp
@@ -89,7 +89,7 @@ public:
         });
 
         // At low priority shutdown, this will run after all the global idles (should be 1) have been fired
-        on<Trigger<Step<2>>, Priority::LOW>().then([this] { powerplant.shutdown(); });
+        on<Trigger<Step<2>>, Priority<NUClear::util::Priority::LOW>>().then([this] { powerplant.shutdown(); });
 
         // This shutdown is here in case the test times out so all the spinlocks don't hang the test
         on<Shutdown, Pool<NonIdlePool>>().then([this] {

--- a/tests/tests/dsl/IdleSingle.cpp
+++ b/tests/tests/dsl/IdleSingle.cpp
@@ -76,7 +76,7 @@ public:
         // Run this at low priority but have it first
         // This way MainThread will get notified that it has access to Sync but then it will lose it when
         // The other task on the default pool gets created so it'll be notified but unable to act
-        on<Trigger<TaskB>, MainThread, Priority::LOW, Sync<TestReactor>>().then([this](const TaskB& t) {
+        on<Trigger<TaskB>, MainThread, Priority<NUClear::util::Priority::LOW>, Sync<TestReactor>>().then([this](const TaskB& t) {
             main_calls[t.i].fetch_add(1, std::memory_order_relaxed);
 
             if (t.i + 1 < n_loops) {
@@ -87,7 +87,7 @@ public:
             }
         });
         // This is the high priority task that preempts the main thread and makes it go idle again
-        on<Trigger<TaskB>, Pool<>, Priority::HIGH, Sync<TestReactor>>().then([this](const TaskB& t) {  //
+        on<Trigger<TaskB>, Pool<>, Priority<NUClear::util::Priority::HIGH>, Sync<TestReactor>>().then([this](const TaskB& t) {  //
             default_calls[t.i].fetch_add(1, std::memory_order_relaxed);
         });
 

--- a/tests/tests/dsl/Once.cpp
+++ b/tests/tests/dsl/Once.cpp
@@ -36,7 +36,7 @@ public:
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : Reactor(std::move(environment)) {
 
         // Make this priority high so it will always run first if it is able
-        on<Trigger<SimpleMessage>, Priority::HIGH, Once>().then([this](const SimpleMessage& msg) {  //
+        on<Trigger<SimpleMessage>, Priority<NUClear::util::Priority::HIGH>, Once>().then([this](const SimpleMessage& msg) {  //
             events.push_back("Once Trigger executed " + std::to_string(msg.run));
         });
 

--- a/tests/tests/dsl/Priority.cpp
+++ b/tests/tests/dsl/Priority.cpp
@@ -35,20 +35,20 @@ public:
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment)) {
 
         // Declare in the order you'd expect them to fire
-        on<Trigger<Message<1>>, Priority::REALTIME>().then([this] { events.push_back("Realtime Message<1>"); });
-        on<Trigger<Message<1>>, Priority::HIGH>().then("High", [this] { events.push_back("High Message<1>"); });
+        on<Trigger<Message<1>>, Priority<NUClear::util::Priority::HIGHEST>>().then([this] { events.push_back("Highest Message<1>"); });
+        on<Trigger<Message<1>>, Priority<NUClear::util::Priority::HIGH>>().then("High", [this] { events.push_back("High Message<1>"); });
         on<Trigger<Message<1>>>().then([this] { events.push_back("Default Message<1>"); });
-        on<Trigger<Message<1>>, Priority::NORMAL>().then("Normal", [this] { events.push_back("Normal Message<1>"); });
-        on<Trigger<Message<1>>, Priority::LOW>().then("Low", [this] { events.push_back("Low Message<1>"); });
-        on<Trigger<Message<1>>, Priority::IDLE>().then([this] { events.push_back("Idle Message<1>"); });
+        on<Trigger<Message<1>>, Priority<NUClear::util::Priority::NORMAL>>().then("Normal", [this] { events.push_back("Normal Message<1>"); });
+        on<Trigger<Message<1>>, Priority<NUClear::util::Priority::LOW>>().then("Low", [this] { events.push_back("Low Message<1>"); });
+        on<Trigger<Message<1>>, Priority<NUClear::util::Priority::LOWEST>>().then([this] { events.push_back("Lowest Message<1>"); });
 
         // Declare in the opposite order to what you'd expect them to fire
-        on<Trigger<Message<2>>, Priority::IDLE>().then([this] { events.push_back("Idle Message<2>"); });
-        on<Trigger<Message<2>>, Priority::LOW>().then([this] { events.push_back("Low Message<2>"); });
-        on<Trigger<Message<2>>, Priority::NORMAL>().then([this] { events.push_back("Normal Message<2>"); });
+        on<Trigger<Message<2>>, Priority<NUClear::util::Priority::LOWEST>>().then([this] { events.push_back("Lowest Message<2>"); });
+        on<Trigger<Message<2>>, Priority<NUClear::util::Priority::LOW>>().then([this] { events.push_back("Low Message<2>"); });
+        on<Trigger<Message<2>>, Priority<NUClear::util::Priority::NORMAL>>().then([this] { events.push_back("Normal Message<2>"); });
         on<Trigger<Message<2>>>().then([this] { events.push_back("Default Message<2>"); });
-        on<Trigger<Message<2>>, Priority::HIGH>().then([this] { events.push_back("High Message<2>"); });
-        on<Trigger<Message<2>>, Priority::REALTIME>().then([this] { events.push_back("Realtime Message<2>"); });
+        on<Trigger<Message<2>>, Priority<NUClear::util::Priority::HIGH>>().then([this] { events.push_back("High Message<2>"); });
+        on<Trigger<Message<2>>, Priority<NUClear::util::Priority::HIGHEST>>().then([this] { events.push_back("Highest Message<2>"); });
 
         // Declare in a random order
         std::array<int, 5> order = {0, 1, 2, 3, 4};
@@ -56,21 +56,21 @@ public:
         for (const auto& i : order) {
             switch (i) {
                 case 0:
-                    on<Trigger<Message<3>>, Priority::REALTIME>().then(
-                        [this] { events.push_back("Realtime Message<3>"); });
+                    on<Trigger<Message<3>>, Priority<NUClear::util::Priority::HIGHEST>>().then(
+                        [this] { events.push_back("Highest Message<3>"); });
                     break;
                 case 1:
-                    on<Trigger<Message<3>>, Priority::HIGH>().then([this] { events.push_back("High Message<3>"); });
+                    on<Trigger<Message<3>>, Priority<NUClear::util::Priority::HIGH>>().then([this] { events.push_back("High Message<3>"); });
                     break;
                 case 2:
-                    on<Trigger<Message<3>>, Priority::NORMAL>().then([this] { events.push_back("Normal Message<3>"); });
+                    on<Trigger<Message<3>>, Priority<NUClear::util::Priority::NORMAL>>().then([this] { events.push_back("Normal Message<3>"); });
                     on<Trigger<Message<3>>>().then([this] { events.push_back("Default Message<3>"); });
                     break;
                 case 3:
-                    on<Trigger<Message<3>>, Priority::LOW>().then([this] { events.push_back("Low Message<3>"); });
+                    on<Trigger<Message<3>>, Priority<NUClear::util::Priority::LOW>>().then([this] { events.push_back("Low Message<3>"); });
                     break;
                 case 4:
-                    on<Trigger<Message<3>>, Priority::IDLE>().then([this] { events.push_back("Idle Message<3>"); });
+                    on<Trigger<Message<3>>, Priority<NUClear::util::Priority::LOWEST>>().then([this] { events.push_back("Lowest Message<3>"); });
                     break;
                 default: throw std::invalid_argument("Should be impossible");
             }
@@ -98,9 +98,9 @@ TEST_CASE("Tests that priority orders the tasks appropriately", "[api][priority]
     plant.start();
 
     const std::vector<std::string> expected = {
-        "Realtime Message<1>",
-        "Realtime Message<2>",
-        "Realtime Message<3>",
+        "Highest Message<1>",
+        "Highest Message<2>",
+        "Highest Message<3>",
         "High Message<1>",
         "High Message<2>",
         "High Message<3>",
@@ -113,9 +113,9 @@ TEST_CASE("Tests that priority orders the tasks appropriately", "[api][priority]
         "Low Message<1>",
         "Low Message<2>",
         "Low Message<3>",
-        "Idle Message<1>",
-        "Idle Message<2>",
-        "Idle Message<3>",
+        "Lowest Message<1>",
+        "Lowest Message<2>",
+        "Lowest Message<3>",
     };
 
     // Make an info print the diff in an easy to read way if we fail

--- a/tests/tests/dsl/RawFunction.cpp
+++ b/tests/tests/dsl/RawFunction.cpp
@@ -88,10 +88,10 @@ public:
         on<Trigger<Message>, Trigger<Data>>().then(raw_function_test_right_arg);
         on<Trigger<Message>, Trigger<Data>>().then(raw_function_test_both_args);
 
-        on<Trigger<Step<1>>, Priority::LOW>().then([this] { emit(std::make_unique<Data>("D1")); });
-        on<Trigger<Step<2>>, Priority::LOW>().then([this] { emit(std::make_unique<Message>("M2")); });
-        on<Trigger<Step<3>>, Priority::LOW>().then([this] { emit(std::make_unique<Data>("D3")); });
-        on<Trigger<Step<4>>, Priority::LOW>().then([this] { emit(std::make_unique<Message>("M4")); });
+        on<Trigger<Step<1>>, Priority<NUClear::util::Priority::LOW>>().then([this] { emit(std::make_unique<Data>("D1")); });
+        on<Trigger<Step<2>>, Priority<NUClear::util::Priority::LOW>>().then([this] { emit(std::make_unique<Message>("M2")); });
+        on<Trigger<Step<3>>, Priority<NUClear::util::Priority::LOW>>().then([this] { emit(std::make_unique<Data>("D3")); });
+        on<Trigger<Step<4>>, Priority<NUClear::util::Priority::LOW>>().then([this] { emit(std::make_unique<Message>("M4")); });
 
         on<Startup>().then([this] {
             emit(std::make_unique<Step<1>>());

--- a/tests/tests/dsl/Shutdown.cpp
+++ b/tests/tests/dsl/Shutdown.cpp
@@ -34,7 +34,7 @@ public:
             events.push_back("Shutdown task executed");
         });
 
-        on<Trigger<Step<1>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<1>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Requesting shutdown");
             powerplant.shutdown();
         });

--- a/tests/tests/dsl/Transient.cpp
+++ b/tests/tests/dsl/Transient.cpp
@@ -72,39 +72,39 @@ public:
             events.push_back(m.msg + " : " + t.msg);
         });
 
-        on<Trigger<Step<1>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<1>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Emitting Message 1");
             emit(std::make_unique<Message>("S1"));
         });
-        on<Trigger<Step<2>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<2>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Emitting Transient 1");
             emit(std::make_unique<TransientMessage>("T1", true));
         });
-        on<Trigger<Step<3>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<3>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Emitting Message 2");
             emit(std::make_unique<Message>("S2"));
         });
-        on<Trigger<Step<4>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<4>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Emitting Invalid Transient 2");
             emit(std::make_unique<TransientMessage>("T2", false));
         });
-        on<Trigger<Step<5>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<5>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Emitting Message 3");
             emit(std::make_unique<Message>("S3"));
         });
-        on<Trigger<Step<6>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<6>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Emitting Transient 3");
             emit(std::make_unique<TransientMessage>("T3", true));
         });
-        on<Trigger<Step<7>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<7>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Emitting Transient 4");
             emit(std::make_unique<TransientMessage>("T4", true));
         });
-        on<Trigger<Step<8>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<8>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Emitting Invalid Transient 5");
             emit(std::make_unique<TransientMessage>("T5", false));
         });
-        on<Trigger<Step<9>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<9>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Emitting Message 4");
             emit(std::make_unique<Message>("S4"));
         });

--- a/tests/tests/dsl/With.cpp
+++ b/tests/tests/dsl/With.cpp
@@ -43,27 +43,27 @@ public:
             events.push_back("Message: " + m.data + " Data: " + d.data);
         });
 
-        on<Trigger<Step<1>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<1>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Emitting Data 1");
             emit(std::make_unique<Data>("D1"));
         });
 
-        on<Trigger<Step<2>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<2>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Emitting Data 2");
             emit(std::make_unique<Data>("D2"));
         });
 
-        on<Trigger<Step<3>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<3>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Emitting Message 1");
             emit(std::make_unique<Message>("M1"));
         });
 
-        on<Trigger<Step<4>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<4>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Emitting Data 3");
             emit(std::make_unique<Data>("D3"));
         });
 
-        on<Trigger<Step<5>>, Priority::LOW>().then([this] {
+        on<Trigger<Step<5>>, Priority<NUClear::util::Priority::LOW>>().then([this] {
             events.push_back("Emitting Message 2");
             emit(std::make_unique<Message>("M2"));
         });

--- a/tests/tests/threading/Group.cpp
+++ b/tests/tests/threading/Group.cpp
@@ -42,14 +42,14 @@ namespace threading {
                 NUClear::id_t task_id_source = 1;
 
                 WHEN("Creating a lock") {
-                    std::unique_ptr<Lock> lock1 = group->lock(++task_id_source, 1, [] {});
+                    std::unique_ptr<Lock> lock1 = group->lock(++task_id_source, util::Priority::LOW, [] {});
 
                     THEN("The lock should be true") {
                         CHECK(lock1->lock() == true);
                     }
 
                     AND_WHEN("Creating a second lock") {
-                        std::unique_ptr<Lock> lock2 = group->lock(++task_id_source, 1, [] {});
+                        std::unique_ptr<Lock> lock2 = group->lock(++task_id_source, util::Priority::LOW, [] {});
 
                         THEN("The lock should be false") {
                             CHECK(lock1->lock() == true);
@@ -67,7 +67,7 @@ namespace threading {
 
                 WHEN("Creating a lock and locking it") {
                     int notified1               = 0;
-                    std::unique_ptr<Lock> lock1 = group->lock(task_id_source++, 1, [&] { ++notified1; });
+                    std::unique_ptr<Lock> lock1 = group->lock(task_id_source++, util::Priority::LOW, [&] { ++notified1; });
                     lock1->lock();
 
                     THEN("The lock should be true") {
@@ -77,8 +77,8 @@ namespace threading {
                     AND_WHEN("Creating two more locks") {
                         int notified2               = 0;
                         int notified3               = 0;
-                        std::unique_ptr<Lock> lock2 = group->lock(task_id_source++, 1, [&] { ++notified2; });
-                        std::unique_ptr<Lock> lock3 = group->lock(task_id_source++, 1, [&] { ++notified3; });
+                        std::unique_ptr<Lock> lock2 = group->lock(task_id_source++, util::Priority::LOW, [&] { ++notified2; });
+                        std::unique_ptr<Lock> lock3 = group->lock(task_id_source++, util::Priority::LOW, [&] { ++notified3; });
 
                         THEN("The new locks should be false") {
                             CHECK(lock1->lock() == true);
@@ -116,11 +116,11 @@ namespace threading {
 
                 WHEN("Creating a lock and locking it") {
                     int notified1               = 0;
-                    std::unique_ptr<Lock> lock1 = group->lock(1, 1, [&] { ++notified1; });
+                    std::unique_ptr<Lock> lock1 = group->lock(1, util::Priority::LOW, [&] { ++notified1; });
 
                     AND_WHEN("Locking the lock and creating a higher priority task") {
                         lock1->lock();
-                        std::unique_ptr<Lock> lock2 = group->lock(2, 2, [] {});
+                        std::unique_ptr<Lock> lock2 = group->lock(2, util::Priority::NORMAL, [] {});
 
                         THEN("The new lock should be false") {
                             CHECK(lock1->lock() == true);
@@ -128,7 +128,7 @@ namespace threading {
                         }
                     }
                     AND_WHEN("Not locking the lock and creating a higher priority task") {
-                        std::unique_ptr<Lock> lock2 = group->lock(2, 2, [] {});
+                        std::unique_ptr<Lock> lock2 = group->lock(2, util::Priority::NORMAL, [] {});
 
                         THEN("The new lock should be true") {
                             CHECK(lock1->lock() == false);
@@ -151,11 +151,11 @@ namespace threading {
 
                     std::array<int, n_locks> notified = {0, 0, 0, 0, 0};
                     std::array<std::unique_ptr<Lock>, n_locks> locks;
-                    locks[3] = group->lock(3, 1, [&] { ++notified[3]; });
-                    locks[1] = group->lock(1, 1, [&] { ++notified[1]; });
-                    locks[4] = group->lock(4, 1, [&] { ++notified[4]; });
-                    locks[0] = group->lock(0, 1, [&] { ++notified[0]; });
-                    locks[2] = group->lock(2, 1, [&] { ++notified[2]; });
+                    locks[3] = group->lock(3, util::Priority::LOW, [&] { ++notified[3]; });
+                    locks[1] = group->lock(1, util::Priority::LOW, [&] { ++notified[1]; });
+                    locks[4] = group->lock(4, util::Priority::LOW, [&] { ++notified[4]; });
+                    locks[0] = group->lock(0, util::Priority::LOW, [&] { ++notified[0]; });
+                    locks[2] = group->lock(2, util::Priority::LOW, [&] { ++notified[2]; });
 
                     THEN("The locks should be lockable in the proper order") {
                         CHECK(locks[0]->lock() == (0 < n_tokens));
@@ -198,11 +198,11 @@ namespace threading {
                 WHEN("Creating a series of locks") {
                     std::array<int, n_locks> notified                = {0, 0, 0, 0, 0};
                     std::array<std::unique_ptr<Lock>, n_locks> locks = {
-                        group->lock(0, 1, [&] { ++notified[0]; }),
-                        group->lock(1, 1, [&] { ++notified[1]; }),
-                        group->lock(2, 1, [&] { ++notified[2]; }),
-                        group->lock(3, 1, [&] { ++notified[3]; }),
-                        group->lock(4, 1, [&] { ++notified[4]; }),
+                        group->lock(0, util::Priority::LOW, [&] { ++notified[0]; }),
+                        group->lock(1, util::Priority::LOW, [&] { ++notified[1]; }),
+                        group->lock(2, util::Priority::LOW, [&] { ++notified[2]; }),
+                        group->lock(3, util::Priority::LOW, [&] { ++notified[3]; }),
+                        group->lock(4, util::Priority::LOW, [&] { ++notified[4]; }),
                     };
 
                     // Note that because this is in a scope, for the rest of the AND_WHEN calls, no locks have been
@@ -291,9 +291,9 @@ namespace threading {
                 WHEN("Creating a series of locks") {
                     std::array<int, 3> notified                = {0, 0, 0};
                     std::array<std::unique_ptr<Lock>, 3> locks = {
-                        group->lock(0, 1, [&] { ++notified[0]; }),
-                        group->lock(1, 1, [&] { ++notified[1]; }),
-                        group->lock(2, 1, [&] { ++notified[2]; }),
+                        group->lock(0, util::Priority::LOW, [&] { ++notified[0]; }),
+                        group->lock(1, util::Priority::LOW, [&] { ++notified[1]; }),
+                        group->lock(2, util::Priority::LOW, [&] { ++notified[2]; }),
                     };
 
                     THEN("Locking and then unlocking the second lock") {
@@ -316,7 +316,7 @@ namespace threading {
 
                 WHEN("Creating a lock and locking it") {
                     int notified1               = 0;
-                    std::unique_ptr<Lock> lock1 = group->lock(1, 1, [&] { ++notified1; });
+                    std::unique_ptr<Lock> lock1 = group->lock(1, util::Priority::LOW, [&] { ++notified1; });
                     lock1->lock();
 
                     THEN("The lock should be true") {
@@ -325,7 +325,7 @@ namespace threading {
 
                     AND_WHEN("Creating a second lock with a higher priority") {
                         int notified2               = 0;
-                        std::unique_ptr<Lock> lock2 = group->lock(2, 2, [&] { ++notified2; });
+                        std::unique_ptr<Lock> lock2 = group->lock(2, util::Priority::NORMAL, [&] { ++notified2; });
 
                         THEN("The new lock should be false") {
                             CHECK(lock1->lock() == true);
@@ -352,7 +352,7 @@ namespace threading {
 
                 WHEN("Creating a lock and locking it") {
                     int notified1               = 0;
-                    std::unique_ptr<Lock> lock1 = group->lock(1, 1, [&] { ++notified1; });
+                    std::unique_ptr<Lock> lock1 = group->lock(1, util::Priority::LOW, [&] { ++notified1; });
                     lock1->lock();
 
                     THEN("The lock should be true") {
@@ -361,7 +361,7 @@ namespace threading {
 
                     AND_WHEN("Adding a second lock") {
                         int notified2               = 0;
-                        std::unique_ptr<Lock> lock2 = group->lock(2, 1, [&] { ++notified2; });
+                        std::unique_ptr<Lock> lock2 = group->lock(2, util::Priority::LOW, [&] { ++notified2; });
 
                         THEN("The second lock should be false") {
                             CHECK(lock2->lock() == false);
@@ -378,7 +378,7 @@ namespace threading {
 
                             AND_WHEN("Adding a third lock with higher priority") {
                                 int notified3               = 0;
-                                std::unique_ptr<Lock> lock3 = group->lock(3, 2, [&] { ++notified3; });
+                                std::unique_ptr<Lock> lock3 = group->lock(3, util::Priority::NORMAL, [&] { ++notified3; });
 
                                 THEN("The third lock should be lockable and second lock should not") {
                                     CHECK(lock3->lock() == true);


### PR DESCRIPTION
`src/util/update_current_thread_priority.hpp`
pthread implementation always set thread priority to 0.
windows implementation will skip setting priority when REALTIME.

Setting priority to a value [0:1000] seemed strange, changed to enum.