### PR TITLE
Refactor logging and allow setting a minimum log level that should not be emitted

### DIFF
--- a/src/PowerPlant.cpp
+++ b/src/PowerPlant.cpp
@@ -49,7 +49,7 @@ PowerPlant* PowerPlant::powerplant = nullptr;
 // This is taking argc and argv as given by main so this should not take an array
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 PowerPlant::PowerPlant(Configuration config, int argc, const char* argv[])
-    : scheduler(config.default_pool_concurrency) {
+    : scheduler(config.default_pool_concurrency), logger(*this) {
 
     // Stop people from making more then one powerplant
     if (powerplant != nullptr) {
@@ -101,21 +101,6 @@ void PowerPlant::remove_idle_task(const NUClear::id_t& id,
 
 void PowerPlant::submit(std::unique_ptr<threading::ReactionTask>&& task) noexcept {
     scheduler.submit(std::move(task));
-}
-
-void PowerPlant::log(const LogLevel& level, std::string message) {
-    // Get the current task
-    const auto* current_task = threading::ReactionTask::get_current_task();
-
-    // Inline emit the log message to default handlers to pause the current task until the log message is processed
-    emit<dsl::word::emit::Inline>(std::make_unique<message::LogMessage>(
-        level,
-        current_task != nullptr ? current_task->parent->reactor.log_level : LogLevel::UNKNOWN,
-        std::move(message),
-        current_task != nullptr ? current_task->statistics : nullptr));
-}
-void PowerPlant::log(const LogLevel& level, std::stringstream& message) {
-    log(level, message.str());
 }
 
 void PowerPlant::shutdown(bool force) {

--- a/src/PowerPlant.hpp
+++ b/src/PowerPlant.hpp
@@ -38,6 +38,7 @@
 #include "threading/ReactionTask.hpp"
 #include "threading/scheduler/Scheduler.hpp"
 #include "util/FunctionFusion.hpp"
+#include "util/Logger.hpp"
 #include "util/demangle.hpp"
 
 namespace NUClear {
@@ -188,32 +189,41 @@ public:
      * Logs a message through the system so the various log handlers can access it.
      * The arguments being logged should be able to be added into a stringstream.
      *
-     * @tparam level     The level to log at (defaults to DEBUG)
+     * @tparam level     The level to log at
      * @tparam Arguments The types of the arguments we are logging
      *
      * @param args The arguments we are logging
      */
     template <enum LogLevel level, typename... Arguments>
     void log(Arguments&&... args) {
-        log(level, std::forward<Arguments>(args)...);
+        logger.log(nullptr, level, std::forward<Arguments>(args)...);
     }
     template <typename... Arguments>
     void log(const LogLevel& level, Arguments&&... args) {
-        std::stringstream ss;
-        log(level, ss, std::forward<Arguments>(args)...);
+        logger.log(nullptr, level, std::forward<Arguments>(args)...);
     }
-    template <typename First, typename... Arguments>
-    void log(const LogLevel& level, std::stringstream& ss, First&& first, Arguments&&... args) {
-        ss << std::forward<First>(first) << " ";
-        log(level, ss, std::forward<Arguments>(args)...);
+
+    /**
+     * Log a message through NUClear's system.
+     *
+     * This version of log takes a pointer to a reactor as an argument.
+     * When logging from a reactor's log function, even if it's not logging within a reactor needs the context to add
+     * the extra information about the reactors name.
+     *
+     * @tparam level     The level to log at (defaults to DEBUG)
+     * @tparam Arguments The types of the arguments we are logging
+     *
+     * @param reactor The reactor that is logging
+     * @param args    The arguments we are logging
+     */
+    template <enum LogLevel level, typename... Arguments>
+    void log(const Reactor* reactor, Arguments&&... args) {
+        logger.log(reactor, level, std::forward<Arguments>(args)...);
     }
-    template <typename Last>
-    void log(const LogLevel& level, std::stringstream& ss, Last&& last) {
-        ss << std::forward<Last>(last);
-        log(level, ss);
+    template <typename... Arguments>
+    void log(const Reactor* reactor, const LogLevel& level, Arguments&&... args) {
+        logger.log(reactor, level, std::forward<Arguments>(args)...);
     }
-    void log(const LogLevel& level, std::stringstream& message);
-    void log(const LogLevel& level, std::string message);
 
     /**
      * Emits data to the system and routes it to the other systems that use it.
@@ -235,8 +245,7 @@ public:
         emit<dsl::word::emit::Local>(std::move(data));
     }
     template <template <typename> class First,
-              template <typename>
-              class... Remainder,
+              template <typename> class... Remainder,
               typename T,
               typename... Arguments>
     void emit(std::unique_ptr<T>& data, Arguments&&... args) {
@@ -244,8 +253,7 @@ public:
     }
 
     template <template <typename> class First,
-              template <typename>
-              class... Remainder,
+              template <typename> class... Remainder,
               typename T,
               typename... Arguments>
     void emit(std::unique_ptr<T>&& data, Arguments&&... args) {
@@ -283,8 +291,7 @@ public:
      * @param data The data we are emitting
      */
     template <template <typename> class First,
-              template <typename>
-              class... Remainder,
+              template <typename> class... Remainder,
               typename T,
               typename... Arguments>
     void emit_shared(std::shared_ptr<T> data, Arguments&&... args) {
@@ -326,6 +333,8 @@ public:
     threading::scheduler::Scheduler scheduler;
     /// Our vector of Reactors, will get destructed when this vector is
     std::vector<std::unique_ptr<NUClear::Reactor>> reactors;
+    /// Our logger that handles logging messages
+    util::Logger logger;
 };
 
 /**

--- a/src/Reactor.hpp
+++ b/src/Reactor.hpp
@@ -177,10 +177,12 @@ public:
     /// The demangled string name of this reactor
     const std::string reactor_name;
 
-protected:
-    /// The level that this reactor logs at
+    /// The display level above which logs from this reactor will be displayed
     LogLevel log_level{LogLevel::INFO};
+    /// The minimum log level that will be always emitted (if log_level is below this those will be emitted too)
+    LogLevel min_log_level{LogLevel::DEBUG};
 
+protected:
     /***************************************************************************************************************
      * The types here are imported from other contexts so that when extending from the Reactor type in normal      *
      * usage there does not need to be any namespace declarations on the used types.                               *
@@ -436,9 +438,7 @@ public:
      */
     template <enum LogLevel level = DEBUG, typename... Arguments>
     void log(Arguments&&... args) const {
-
-        // If the log is above or equal to our log level
-        powerplant.log<level>(std::forward<Arguments>(args)...);
+        powerplant.log<level>(this, std::forward<Arguments>(args)...);
     }
 
     /**
@@ -453,9 +453,7 @@ public:
      */
     template <typename... Arguments>
     void log(const LogLevel& level, Arguments&&... args) const {
-
-        // If the log is above or equal to our log level
-        powerplant.log(level, std::forward<Arguments>(args)...);
+        powerplant.log(this, level, std::forward<Arguments>(args)...);
     }
 };
 

--- a/src/Reactor.hpp
+++ b/src/Reactor.hpp
@@ -438,7 +438,7 @@ public:
      */
     template <enum LogLevel level = DEBUG, typename... Arguments>
     void log(Arguments&&... args) const {
-        powerplant.log<level>(this, std::forward<Arguments>(args)...);
+        log(level, std::forward<Arguments>(args)...);
     }
 
     /**
@@ -453,7 +453,10 @@ public:
      */
     template <typename... Arguments>
     void log(const LogLevel& level, Arguments&&... args) const {
-        powerplant.log(this, level, std::forward<Arguments>(args)...);
+        // Short circuit here before going to the more expensive log function
+        if (level >= min_log_level || level >= log_level) {
+            powerplant.log(this, level, std::forward<Arguments>(args)...);
+        }
     }
 };
 

--- a/src/Reactor.hpp
+++ b/src/Reactor.hpp
@@ -438,7 +438,10 @@ public:
      */
     template <enum LogLevel level = DEBUG, typename... Arguments>
     void log(Arguments&&... args) const {
-        log(level, std::forward<Arguments>(args)...);
+        // Short circuit here before going to the more expensive log function
+        if (level >= min_log_level || level >= log_level) {
+            powerplant.log<level>(this, std::forward<Arguments>(args)...);
+        }
     }
 
     /**

--- a/src/message/LogMessage.hpp
+++ b/src/message/LogMessage.hpp
@@ -67,7 +67,7 @@ namespace message {
         std::string message;
 
         /// The name of the reactor that made this log message if it was from a reactor's log function
-        std::string reactor_name{};
+        std::string reactor_name;
 
         /// The statistics of the currently executing task that made this message
         const std::shared_ptr<const ReactionStatistics> statistics{nullptr};

--- a/src/message/LogMessage.hpp
+++ b/src/message/LogMessage.hpp
@@ -42,15 +42,19 @@ namespace message {
          * @param level         The logging level of the log
          * @param display_level The logging level of the reactor that made this log
          * @param message       The string contents of the message
+         * @param reactor_name  The name of the reactor that made this if it was from a reactor's log function or a
+         *                      reaction belonging to that reactor
          * @param statistics    The statistics of the currently executing task or nullptr if not in a task
          */
         LogMessage(const LogLevel& level,
                    const LogLevel& display_level,
                    std::string message,
+                   std::string reactor_name,
                    std::shared_ptr<const ReactionStatistics> statistics)
             : level(level)
             , display_level(display_level)
             , message(std::move(message))
+            , reactor_name(std::move(reactor_name))
             , statistics(std::move(statistics)) {}
 
         /// The logging level of the log
@@ -61,6 +65,9 @@ namespace message {
 
         /// The string contents of the message
         std::string message;
+
+        /// The name of the reactor that made this log message if it was from a reactor's log function
+        std::string reactor_name{};
 
         /// The statistics of the currently executing task that made this message
         const std::shared_ptr<const ReactionStatistics> statistics{nullptr};

--- a/src/util/Logger.cpp
+++ b/src/util/Logger.cpp
@@ -26,7 +26,7 @@ namespace util {
 
     Logger::LogLevels Logger::get_current_log_levels(const Reactor* calling_reactor) {
         // Get the current reactor either from the passed in reactor or the current task
-        auto* reactor = get_current_reactor(calling_reactor);
+        const auto* reactor = get_current_reactor(calling_reactor);
         return reactor != nullptr ? LogLevels(reactor->log_level, reactor->min_log_level)
                                   : LogLevels(LogLevel::UNKNOWN, LogLevel::UNKNOWN);
     }

--- a/src/util/Logger.cpp
+++ b/src/util/Logger.cpp
@@ -1,0 +1,49 @@
+#include "Logger.hpp"
+
+#include "../Reactor.hpp"
+#include "../dsl/word/emit/Inline.hpp"
+#include "../message/LogMessage.hpp"
+#include "../threading/ReactionTask.hpp"
+
+namespace NUClear {
+namespace util {
+
+    /**
+     * Get the current reactor that is running based on the passed in reactor, or the current task if not in a reactor.
+     *
+     * @param calling_reactor The reactor that is calling this function or nullptr if not called from a reactor
+     *
+     * @return The current reactor or nullptr if not in a reactor
+     */
+    const Reactor* get_current_reactor(const Reactor* calling_reactor) {
+        if (calling_reactor != nullptr) {
+            return calling_reactor;
+        }
+        // Get the current task
+        auto current_task = threading::ReactionTask::get_current_task();
+        return current_task != nullptr && current_task->parent != nullptr ? &current_task->parent->reactor : nullptr;
+    }
+
+    Logger::LogLevels Logger::get_current_log_levels(const Reactor* calling_reactor) {
+        // Get the current reactor either from the passed in reactor or the current task
+        auto* reactor = get_current_reactor(calling_reactor);
+        return reactor != nullptr ? LogLevels(reactor->log_level, reactor->min_log_level)
+                                  : LogLevels(LogLevel::UNKNOWN, LogLevel::UNKNOWN);
+    }
+
+    void Logger::do_log(const Reactor* calling_reactor, const LogLevel& level, const std::string& message) {
+        // Get the current context
+        const auto* reactor      = get_current_reactor(calling_reactor);
+        const auto* current_task = threading::ReactionTask::get_current_task();
+        auto log_levels          = get_current_log_levels(reactor);
+
+        // Inline emit the log message to default handlers to pause the current task until the log message is processed
+        powerplant.emit<dsl::word::emit::Inline>(
+            std::make_unique<message::LogMessage>(level,
+                                                  log_levels.display_log_level,
+                                                  message,
+                                                  reactor != nullptr ? reactor->reactor_name : "",
+                                                  current_task != nullptr ? current_task->statistics : nullptr));
+    }
+}  // namespace util
+}  // namespace NUClear

--- a/src/util/Logger.cpp
+++ b/src/util/Logger.cpp
@@ -20,7 +20,7 @@ namespace util {
             return calling_reactor;
         }
         // Get the current task
-        auto current_task = threading::ReactionTask::get_current_task();
+        const auto current_task = threading::ReactionTask::get_current_task();
         return current_task != nullptr && current_task->parent != nullptr ? &current_task->parent->reactor : nullptr;
     }
 

--- a/src/util/Logger.cpp
+++ b/src/util/Logger.cpp
@@ -20,7 +20,7 @@ namespace util {
             return calling_reactor;
         }
         // Get the current task
-        const auto current_task = threading::ReactionTask::get_current_task();
+        const auto* const current_task = threading::ReactionTask::get_current_task();
         return current_task != nullptr && current_task->parent != nullptr ? &current_task->parent->reactor : nullptr;
     }
 

--- a/src/util/Logger.hpp
+++ b/src/util/Logger.hpp
@@ -1,0 +1,96 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2013 NUClear Contributors
+ *
+ * This file is part of the NUClear codebase.
+ * See https://github.com/Fastcode/NUClear for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef NUCLEAR_UTIL_LOGGER_HPP
+#define NUCLEAR_UTIL_LOGGER_HPP
+
+#include <sstream>
+#include <utility>
+
+#include "../LogLevel.hpp"
+#include "string_join.hpp"
+
+namespace NUClear {
+
+// Forward declarations
+class PowerPlant;
+class Reactor;
+
+namespace util {
+
+    /**
+     * The Logger class is used to handle converting the variardic log calls into an appropriate log message.
+     *
+     * It's also responsible for working out which messages should be emitted and which should be ignored.
+     */
+    class Logger {
+    public:
+        Logger(PowerPlant& powerplant) : powerplant(powerplant) {}
+
+        /**
+         * Log a message to the system.
+         *
+         * This function will check if a log message should be emitted based on the current log levels and then emit the
+         * log message.
+         */
+        template <typename... Arguments>
+        void log(const Reactor* reactor, const LogLevel& level, const Arguments&... args) {
+            // Check if the log level is above the minimum log levels
+            auto log_levels = get_current_log_levels(reactor);
+            if (level >= log_levels.display_log_level || level >= log_levels.min_log_level) {
+                // Collapse the arguments into a string and perform the log action
+                do_log(reactor, level, string_join(" ", std::forward<const Arguments&>(args)...));
+            }
+        }
+
+    private:
+        /**
+         * Describes the log levels for a particular reactor.
+         */
+        struct LogLevels {
+            LogLevels(LogLevel display_log_level, LogLevel min_log_level)
+                : display_log_level(display_log_level), min_log_level(min_log_level) {}
+
+            /// The log level that should be displayed
+            LogLevel display_log_level;
+            /// The minimum log level that should be emitted
+            LogLevel min_log_level;
+        };
+
+        /**
+         * Get the log levels for the current reactor or UNKNOWN if not in a reactor.
+         */
+        static LogLevels get_current_log_levels(const Reactor* reactor);
+
+        /**
+         * Perform the log action and emit the log message.
+         */
+        void do_log(const Reactor* reactor, const LogLevel& level, const std::string& message);
+
+        /// The powerplant that this logger is logging for, used for emitting log messages
+        PowerPlant& powerplant;
+    };
+
+}  // namespace util
+}  // namespace NUClear
+
+#endif  // NUCLEAR_UTIL_LOGGER_HPP

--- a/src/util/string_join.hpp
+++ b/src/util/string_join.hpp
@@ -1,0 +1,67 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 NUClear Contributors
+ *
+ * This file is part of the NUClear codebase.
+ * See https://github.com/Fastcode/NUClear for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef NUCLEAR_UTIL_STRING_JOIN_HPP
+#define NUCLEAR_UTIL_STRING_JOIN_HPP
+
+#include <sstream>
+#include <string>
+
+namespace NUClear {
+namespace util {
+
+    namespace detail {
+        // No argument base case
+        inline void do_string_join(std::stringstream& /*out*/, const std::string& /*delimiter*/) {}
+
+        // Single argument case
+        template <typename Last>
+        void do_string_join(std::stringstream& out, const std::string& /*delimiter*/, Last&& last) {
+            out << std::forward<Last>(last);
+        }
+
+        // Two or more arguments case
+        template <typename First, typename Second, typename... Remainder>
+        void do_string_join(std::stringstream& out,
+                            const std::string& delimiter,
+                            First&& first,
+                            Second&& second,
+                            Remainder&&... remainder) {
+            out << std::forward<First>(first) << delimiter;
+            do_string_join(out, delimiter, std::forward<Second>(second), std::forward<Remainder>(remainder)...);
+        }
+    }  // namespace detail
+
+    /**
+     * Join a list of arguments into a single string with a delimiter between each argument.
+     */
+    template <typename... Arguments>
+    std::string string_join(const std::string& delimiter, Arguments&&... args) {
+        std::stringstream out;
+        detail::do_string_join(out, delimiter, std::forward<Arguments>(args)...);
+        return out.str();
+    }
+
+}  // namespace util
+}  // namespace NUClear
+
+#endif  // NUCLEAR_UTIL_STRING_JOIN_HPP

--- a/tests/tests/util/string_join.cpp
+++ b/tests/tests/util/string_join.cpp
@@ -1,0 +1,121 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 NUClear Contributors
+ *
+ * This file is part of the NUClear codebase.
+ * See https://github.com/Fastcode/NUClear for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "util/string_join.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <string>
+#include <typeinfo>
+
+struct TestSymbol {
+    friend std::ostream& operator<<(std::ostream& os, const TestSymbol&) {
+        return os << typeid(TestSymbol).name();
+    }
+};
+
+
+SCENARIO("Test string_join correctly joins strings", "[util][string_join]") {
+
+    GIVEN("An empty set of arguments") {
+        std::string delimiter = GENERATE("", ",", " ");
+
+        WHEN("string_join is called") {
+            const std::string result = NUClear::util::string_join(delimiter);
+
+            THEN("It should return an empty string") {
+                REQUIRE(result.empty());
+            }
+        }
+    }
+
+    GIVEN("A single string argument") {
+        std::string delimiter = GENERATE("", ",", " ");
+        std::string arg       = GENERATE("test", "string", "join");
+
+        WHEN("string_join is called") {
+            const std::string result = NUClear::util::string_join(delimiter, arg);
+
+            THEN("It should return the argument") {
+                REQUIRE(result == arg);
+            }
+        }
+    }
+
+    GIVEN("Two string arguments") {
+        std::string delimiter = GENERATE("", ",", " ");
+        std::string arg1      = GENERATE("test", "string", "join");
+        std::string arg2      = GENERATE("test", "string", "join");
+
+        WHEN("string_join is called") {
+            const std::string result = NUClear::util::string_join(delimiter, arg1, arg2);
+
+            THEN("It should return the two arguments joined by the delimiter") {
+                REQUIRE(result == arg1 + delimiter + arg2);
+            }
+        }
+    }
+
+    GIVEN("Three string arguments") {
+        std::string delimiter = GENERATE("", ",", " ");
+        std::string arg1      = GENERATE("test", "string", "join");
+        std::string arg2      = GENERATE("test", "string", "join");
+        std::string arg3      = GENERATE("test", "string", "join");
+
+        WHEN("string_join is called") {
+            const std::string result = NUClear::util::string_join(delimiter, arg1, arg2, arg3);
+
+            THEN("It should return the three arguments joined by the delimiter") {
+                REQUIRE(result == arg1 + delimiter + arg2 + delimiter + arg3);
+            }
+        }
+    }
+
+    GIVEN("A mix of string and non-string arguments") {
+        std::string delimiter = GENERATE("", ",", " ");
+        std::string arg1      = GENERATE("test", "string", "join");
+        std::string arg2      = GENERATE("test", "string", "join");
+        int arg3              = GENERATE(1, 2, 3);
+
+        WHEN("string_join is called") {
+            const std::string result = NUClear::util::string_join(delimiter, arg1, arg2, arg3);
+
+            THEN("It should return the arguments joined by the delimiter") {
+                REQUIRE(result == arg1 + delimiter + arg2 + delimiter + std::to_string(arg3));
+            }
+        }
+    }
+
+    GIVEN("A class with an overloaded operator<<") {
+        std::string delimiter = GENERATE("", ",", " ");
+        TestSymbol arg1;
+        TestSymbol arg2;
+
+        WHEN("string_join is called") {
+            const std::string result = NUClear::util::string_join(delimiter, arg1, arg2);
+
+            THEN("It should return the arguments joined by the delimiter") {
+                REQUIRE(result == typeid(TestSymbol).name() + delimiter + typeid(TestSymbol).name());
+            }
+        }
+    }
+}

--- a/tests/tests/util/string_join.cpp
+++ b/tests/tests/util/string_join.cpp
@@ -28,7 +28,7 @@
 #include <typeinfo>
 
 struct TestSymbol {
-    friend std::ostream& operator<<(std::ostream& os, const TestSymbol&) {
+    friend std::ostream& operator<<(std::ostream& os, const TestSymbol& /*symbol*/) {
         return os << typeid(TestSymbol).name();
     }
 };
@@ -37,7 +37,7 @@ struct TestSymbol {
 SCENARIO("Test string_join correctly joins strings", "[util][string_join]") {
 
     GIVEN("An empty set of arguments") {
-        std::string delimiter = GENERATE("", ",", " ");
+        const std::string delimiter = GENERATE("", ",", " ");
 
         WHEN("string_join is called") {
             const std::string result = NUClear::util::string_join(delimiter);
@@ -49,8 +49,8 @@ SCENARIO("Test string_join correctly joins strings", "[util][string_join]") {
     }
 
     GIVEN("A single string argument") {
-        std::string delimiter = GENERATE("", ",", " ");
-        std::string arg       = GENERATE("test", "string", "join");
+        const std::string delimiter = GENERATE("", ",", " ");
+        const std::string arg       = GENERATE("test", "string", "join");
 
         WHEN("string_join is called") {
             const std::string result = NUClear::util::string_join(delimiter, arg);
@@ -62,9 +62,9 @@ SCENARIO("Test string_join correctly joins strings", "[util][string_join]") {
     }
 
     GIVEN("Two string arguments") {
-        std::string delimiter = GENERATE("", ",", " ");
-        std::string arg1      = GENERATE("test", "string", "join");
-        std::string arg2      = GENERATE("test", "string", "join");
+        const std::string delimiter = GENERATE("", ",", " ");
+        const std::string arg1      = GENERATE("test", "string", "join");
+        const std::string arg2      = GENERATE("test", "string", "join");
 
         WHEN("string_join is called") {
             const std::string result = NUClear::util::string_join(delimiter, arg1, arg2);
@@ -76,10 +76,10 @@ SCENARIO("Test string_join correctly joins strings", "[util][string_join]") {
     }
 
     GIVEN("Three string arguments") {
-        std::string delimiter = GENERATE("", ",", " ");
-        std::string arg1      = GENERATE("test", "string", "join");
-        std::string arg2      = GENERATE("test", "string", "join");
-        std::string arg3      = GENERATE("test", "string", "join");
+        const std::string delimiter = GENERATE("", ",", " ");
+        const std::string arg1      = GENERATE("test", "string", "join");
+        const std::string arg2      = GENERATE("test", "string", "join");
+        const std::string arg3      = GENERATE("test", "string", "join");
 
         WHEN("string_join is called") {
             const std::string result = NUClear::util::string_join(delimiter, arg1, arg2, arg3);
@@ -91,10 +91,10 @@ SCENARIO("Test string_join correctly joins strings", "[util][string_join]") {
     }
 
     GIVEN("A mix of string and non-string arguments") {
-        std::string delimiter = GENERATE("", ",", " ");
-        std::string arg1      = GENERATE("test", "string", "join");
-        std::string arg2      = GENERATE("test", "string", "join");
-        int arg3              = GENERATE(1, 2, 3);
+        const std::string delimiter = GENERATE("", ",", " ");
+        const std::string arg1      = GENERATE("test", "string", "join");
+        const std::string arg2      = GENERATE("test", "string", "join");
+        const int arg3              = GENERATE(1, 2, 3);
 
         WHEN("string_join is called") {
             const std::string result = NUClear::util::string_join(delimiter, arg1, arg2, arg3);
@@ -106,9 +106,9 @@ SCENARIO("Test string_join correctly joins strings", "[util][string_join]") {
     }
 
     GIVEN("A class with an overloaded operator<<") {
-        std::string delimiter = GENERATE("", ",", " ");
-        TestSymbol arg1;
-        TestSymbol arg2;
+        const std::string delimiter = GENERATE("", ",", " ");
+        const TestSymbol arg1;
+        const TestSymbol arg2;
 
         WHEN("string_join is called") {
             const std::string result = NUClear::util::string_join(delimiter, arg1, arg2);


### PR DESCRIPTION
This pulls the logging code out into its own class as it was getting more complex.

It also allows limiting sending of logs from a reactor. Sending out every trace message was causing a lot of overhead.

Now there are two variables in each reactor, one to describe the displayed log level `log_level` and one to describe the minimum emitted log level `min_log_level`