### PR TITLE
Fix Sonarcloud Coverage by not including Catch2

### DIFF
--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   sonarcloud:
     name: SonarCloud
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
     steps:
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Install gcovr
-        run: pip install gcovr==7.2
+        run: pip install gcovr==8.2
 
       - name: Install sonar-scanner and build-wrapper
         uses: SonarSource/sonarcloud-github-c-cpp@v3
@@ -49,12 +49,12 @@ jobs:
           cmake -E make_directory build
           cmake -S . -B build \
             -GNinja \
-            -DCMAKE_CXX_FLAGS="--coverage" \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DBUILD_TESTS=ON \
             -DCMAKE_BUILD_TYPE=Debug \
             -DCI_BUILD=ON \
+            -DENABLE_COVERAGE=ON \
             -DENABLE_CLANG_TIDY=OFF
 
       - name: Build the code in debug mode
@@ -69,6 +69,15 @@ jobs:
       - name: Collect coverage into one XML report
         if: always()
         run: gcovr --gcov-ignore-parse-errors=negative_hits.warn_once_per_file --exclude-unreachable-branches --exclude-noncode-lines --sonarqube > coverage.xml
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-sonar
+          path: coverage.xml
+          retention-days: 1 # This sets the artifact TTL to 1 day (minimum is 1 day)
+          overwrite: true
 
       - name: Run sonar-scanner
         if: always()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   set(MASTER_PROJECT ON)
 endif()
 
-# If this option is set we are building using continous integration
+# If this option is set we are building using continuous integration
 option(CI_BUILD "Enable build options for building in the CI server" OFF)
 
 # Include files to set up the compiler options

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,13 @@ target_link_libraries(nuclear ${CMAKE_THREAD_LIBS_INIT})
 set_target_properties(nuclear PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_compile_features(nuclear PUBLIC cxx_std_14)
 
+# When enabling coverage, just set it on the nuclear target so it doesn't end up on catch2
+option(ENABLE_COVERAGE "Enable coverage support" OFF)
+if(ENABLE_COVERAGE)
+  target_compile_options(nuclear PUBLIC "-fprofile-arcs" "-ftest-coverage" "-fprofile-abs-path")
+  target_link_options(nuclear PUBLIC "-fprofile-arcs" "-ftest-coverage" "-fprofile-abs-path")
+endif()
+
 # Enable warnings, and all warnings are errors
 if(MSVC)
   target_compile_options(nuclear PRIVATE /W4 /WX)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,11 +32,12 @@ FetchContent_MakeAvailable(Catch2)
 
 # Silence clang-tidy warnings from catch2
 get_target_property(catch2_target Catch2::Catch2 ALIASED_TARGET)
-set_target_properties(${catch2_target} PROPERTIES CXX_CLANG_TIDY "")
-set_target_properties(${catch2_target} PROPERTIES CXX_CLANG_TIDY "")
 get_target_property(catch2_with_main_target Catch2::Catch2WithMain ALIASED_TARGET)
-set_target_properties(${catch2_with_main_target} PROPERTIES CXX_CLANG_TIDY "")
-set_target_properties(${catch2_with_main_target} PROPERTIES CXX_CLANG_TIDY "")
+set(catch2_targets ${catch2_target} ${catch2_with_main_target})
+
+set_target_properties(${catch2_targets} PROPERTIES CXX_CLANG_TIDY "")
+set_target_properties(${catch2_targets} PROPERTIES CXX_CLANG_TIDY "")
+set_target_properties(${catch2_target} PROPERTIES CMAKE_CXX_FLAGS "")
 
 # Create a test_util library that is used by all tests
 file(GLOB_RECURSE test_util_src "test_util/*.cpp")


### PR DESCRIPTION
The coverage was calculated for the catch2 library since it's coming in as a FetchContent module. This changes how the coverage flags are applied so that only the NUClear library and the tests have coverage arcs on them.