### PR TITLE
Upgrade clang-tidy to version 19

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -71,3 +71,5 @@ CheckOptions:
     value: google
   - key: readability-braces-around-statements.ShortStatementLines
     value: "1"
+  - key: misc-include-cleaner.IgnoreHeaders
+    value: "asm-generic/.*;bits/.*"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -34,6 +34,7 @@ Checks: >
   -readability-function-size,
   -readability-identifier-length,
   -readability-magic-numbers,
+  -readability-math-missing-parentheses,
   -readability-uppercase-literal-suffix,
   modernize-*,
   -modernize-use-trailing-return-type,

--- a/.github/workflows/gcc.yaml
+++ b/.github/workflows/gcc.yaml
@@ -36,7 +36,7 @@ jobs:
             version: "7"
 
     name: Linux GCC-${{ matrix.toolchain.version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     continue-on-error: true
 
     # Use the container for this specific version of gcc

--- a/.github/workflows/gcc.yaml
+++ b/.github/workflows/gcc.yaml
@@ -96,7 +96,7 @@ jobs:
         run: ctest --output-on-failure -E "dsl/UDP"
 
       - name: Upload Traces
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: traces-gcc-${{ matrix.toolchain.version }}

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -20,19 +20,19 @@ concurrency:
 jobs:
   linux-clang-tidy:
     name: Linux Clang-Tidy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Install clang-tidy-15
+      - name: Install clang-tidy
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" | sudo tee /etc/apt/sources.list.d/llvm-15
-          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" | sudo tee -a /etc/apt/sources.list.d/llvm-15
+          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" | sudo tee /etc/apt/sources.list.d/llvm-19
+          echo "deb-src http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" | sudo tee -a /etc/apt/sources.list.d/llvm-19
           sudo apt-get update
-          sudo apt-get install -y clang-tidy-15
+          sudo apt-get install -y clang-tidy-19
 
       # Download and install cmake
       - name: Install CMake
@@ -62,7 +62,7 @@ jobs:
 
           mkdir -p ${{ github.workspace }}/.ctcache
 
-          echo CTCACHE_CLANG_TIDY='/usr/bin/clang-tidy-15' >> "$GITHUB_ENV"
+          echo CTCACHE_CLANG_TIDY='/usr/bin/clang-tidy-19' >> "$GITHUB_ENV"
           echo CTCACHE_LOCAL=1 >> "$GITHUB_ENV"
           echo CTCACHE_SAVE_OUTPUT=1 >> "$GITHUB_ENV"
           echo CTCACHE_DIR='${{github.workspace}}/.ctcache' >> "$GITHUB_ENV"

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -29,10 +29,10 @@ jobs:
       - name: Install clang-tidy
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" | sudo tee /etc/apt/sources.list.d/llvm-19
-          echo "deb-src http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" | sudo tee -a /etc/apt/sources.list.d/llvm-19
+          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" | sudo tee /etc/apt/sources.list.d/llvm-19.list
+          echo "deb-src http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" | sudo tee -a /etc/apt/sources.list.d/llvm-19.list
           sudo apt-get update
-          sudo apt-get install -y clang-tidy-20
+          sudo apt-get install -y clang-tidy-19
 
       # Download and install cmake
       - name: Install CMake
@@ -62,7 +62,7 @@ jobs:
 
           mkdir -p ${{ github.workspace }}/.ctcache
 
-          echo CTCACHE_CLANG_TIDY='/usr/bin/clang-tidy-20' >> "$GITHUB_ENV"
+          echo CTCACHE_CLANG_TIDY='/usr/bin/clang-tidy-19' >> "$GITHUB_ENV"
           echo CTCACHE_LOCAL=1 >> "$GITHUB_ENV"
           echo CTCACHE_SAVE_OUTPUT=1 >> "$GITHUB_ENV"
           echo CTCACHE_DIR='${{github.workspace}}/.ctcache' >> "$GITHUB_ENV"

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -32,7 +32,7 @@ jobs:
           echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" | sudo tee /etc/apt/sources.list.d/llvm-19
           echo "deb-src http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" | sudo tee -a /etc/apt/sources.list.d/llvm-19
           sudo apt-get update
-          sudo apt-get install -y clang-tidy-19
+          sudo apt-get install -y clang-tidy-20
 
       # Download and install cmake
       - name: Install CMake
@@ -62,7 +62,7 @@ jobs:
 
           mkdir -p ${{ github.workspace }}/.ctcache
 
-          echo CTCACHE_CLANG_TIDY='/usr/bin/clang-tidy-19' >> "$GITHUB_ENV"
+          echo CTCACHE_CLANG_TIDY='/usr/bin/clang-tidy-20' >> "$GITHUB_ENV"
           echo CTCACHE_LOCAL=1 >> "$GITHUB_ENV"
           echo CTCACHE_SAVE_OUTPUT=1 >> "$GITHUB_ENV"
           echo CTCACHE_DIR='${{github.workspace}}/.ctcache' >> "$GITHUB_ENV"

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -64,7 +64,7 @@ jobs:
         run: ctest --output-on-failure
 
       - name: Upload Traces
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: traces-macos

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -67,11 +67,11 @@ jobs:
         run: ctest --output-on-failure
 
       - name: Collect coverage into one XML report
-        if: always()
+        if: ${{ !cancelled() }}
         run: gcovr --gcov-ignore-parse-errors=negative_hits.warn_once_per_file --exclude-unreachable-branches --exclude-noncode-lines --sonarqube > coverage.xml
 
       - name: Upload coverage report
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage-sonar
@@ -80,7 +80,7 @@ jobs:
           overwrite: true
 
       - name: Run sonar-scanner
-        if: always()
+        if: ${{ !cancelled() }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -90,7 +90,7 @@ jobs:
             --define sonar.coverageReportPaths=coverage.xml
 
       - name: Upload Traces
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: traces-sonar

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -85,7 +85,7 @@ jobs:
         run: ctest --output-on-failure
 
       - name: Upload Traces
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: traces-windows-${{ matrix.toolchain.name }}

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ tags
 docs/doxygen
 docs/doxygen_sqlite3.db
 *.sublime-workspace
+.DS_Store

--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -1,10 +1,10 @@
 # Default not to run the clang-tidy checks, default to whatever our CI_BUILD is
 option(ENABLE_CLANG_TIDY "Enable building with clang-tidy checks.")
 if(ENABLE_CLANG_TIDY)
-  # Search for clang-tidy-15 first as this is the version installed in CI
-  find_program(CLANG_TIDY_EXECUTABLE NAMES clang-tidy-15 clang-tidy)
+  # Search for the same version of clang-tidy as is used in CI first
+  find_program(CLANG_TIDY_EXECUTABLE NAMES clang-tidy-19 clang-tidy)
   if(NOT CLANG_TIDY_EXECUTABLE)
-    message(FATAL_ERROR "clang-tidy-15 not found.")
+    message(FATAL_ERROR "clang-tidy not found.")
   endif()
 
   # Report clang-tidy executable details

--- a/src/Configuration.hpp
+++ b/src/Configuration.hpp
@@ -23,7 +23,6 @@
 #ifndef NUCLEAR_CONFIGURATION_HPP
 #define NUCLEAR_CONFIGURATION_HPP
 
-#include <cstddef>
 #include <thread>
 
 namespace NUClear {

--- a/src/Environment.hpp
+++ b/src/Environment.hpp
@@ -24,8 +24,8 @@
 #define NUCLEAR_ENVIRONMENT_HPP
 
 #include <string>
+#include <utility>
 
-#include "LogLevel.hpp"
 
 namespace NUClear {
 

--- a/src/LogLevel.hpp
+++ b/src/LogLevel.hpp
@@ -24,7 +24,7 @@
 #define NUCLEAR_LOGLEVEL_HPP
 
 #include <cstdint>
-#include <ostream>
+#include <iosfwd>
 #include <string>
 
 // Why do we need to include platform.hpp here?

--- a/src/LogLevel.hpp
+++ b/src/LogLevel.hpp
@@ -23,7 +23,9 @@
 #ifndef NUCLEAR_LOGLEVEL_HPP
 #define NUCLEAR_LOGLEVEL_HPP
 
+#include <cstdint>
 #include <ostream>
+#include <string>
 
 // Why do we need to include platform.hpp here?
 // Because windows defines a bunch of things for legacy reasons, one of which is a #define for ERROR as blank

--- a/src/PowerPlant.cpp
+++ b/src/PowerPlant.cpp
@@ -22,19 +22,18 @@
 
 #include "PowerPlant.hpp"
 
-#include <exception>
-#include <tuple>
+#include <memory>
+#include <utility>
 
+#include "Configuration.hpp"
 #include "Reactor.hpp"
 #include "dsl/store/DataStore.hpp"
 #include "dsl/word/Shutdown.hpp"
 #include "dsl/word/Startup.hpp"
 #include "dsl/word/emit/Inline.hpp"
-#include "extension/ChronoController.hpp"
-#include "extension/IOController.hpp"
-#include "extension/NetworkController.hpp"
+#include "id.hpp"
 #include "message/CommandLineArguments.hpp"
-#include "message/LogMessage.hpp"
+#include "threading/Reaction.hpp"
 #include "threading/ReactionTask.hpp"
 
 namespace NUClear {

--- a/src/PowerPlant.hpp
+++ b/src/PowerPlant.hpp
@@ -23,18 +23,18 @@
 #ifndef NUCLEAR_POWER_PLANT_HPP
 #define NUCLEAR_POWER_PLANT_HPP
 
-#include <atomic>
-#include <functional>
 #include <memory>
-#include <sstream>
+#include <tuple>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
 // Utilities
-#include "Configuration.hpp"
+#include "Configuration.hpp"  // IWYU pragma: export
 #include "Environment.hpp"
 #include "LogLevel.hpp"
 #include "id.hpp"
+#include "threading/Reaction.hpp"
 #include "threading/ReactionTask.hpp"
 #include "threading/scheduler/Scheduler.hpp"
 #include "util/FunctionFusion.hpp"

--- a/src/Reactor.cpp
+++ b/src/Reactor.cpp
@@ -22,6 +22,8 @@
 
 #include "Reactor.hpp"
 
+#include "LogLevel.hpp"
+
 namespace NUClear {
 
 constexpr LogLevel Reactor::TRACE;

--- a/src/Reactor.hpp
+++ b/src/Reactor.hpp
@@ -24,18 +24,22 @@
 #define NUCLEAR_REACTOR_HPP
 
 #include <chrono>
-#include <functional>
+#include <cstddef>
+#include <memory>
 #include <regex>
 #include <string>
-#include <typeindex>
+#include <tuple>
+#include <utility>
 #include <vector>
 
-#include "Environment.hpp"
-#include "LogLevel.hpp"
+#include "Environment.hpp"  // IWYU pragma: export
+#include "LogLevel.hpp"     // IWYU pragma: export
+#include "clock.hpp"        // IWYU pragma: export
 #include "dsl/Parse.hpp"
-#include "threading/Reaction.hpp"
-#include "threading/ReactionHandle.hpp"
-#include "threading/ReactionIdentifiers.hpp"
+#include "id.hpp"                             // IWYU pragma: export
+#include "threading/Reaction.hpp"             // IWYU pragma: export
+#include "threading/ReactionHandle.hpp"       // IWYU pragma: export
+#include "threading/ReactionIdentifiers.hpp"  // IWYU pragma: export
 #include "util/CallbackGenerator.hpp"
 #include "util/Sequence.hpp"
 #include "util/demangle.hpp"

--- a/src/dsl/fusion/BindFusion.hpp
+++ b/src/dsl/fusion/BindFusion.hpp
@@ -79,13 +79,13 @@ namespace dsl {
                                                    reaction,
                                                    std::forward<Arguments>(args)...))>::value,
                                                NoReturn,
-                                               Return>::template call(reaction, std::forward<Arguments>(args)...)) {
+                                               Return>::call(reaction, std::forward<Arguments>(args)...)) {
 
                 return std::conditional_t<
                     std::is_void<decltype(Function::template bind<DSL>(reaction,
                                                                        std::forward<Arguments>(args)...))>::value,
                     NoReturn,
-                    Return>::template call(reaction, std::forward<Arguments>(args)...);
+                    Return>::call(reaction, std::forward<Arguments>(args)...);
             }
         };
 

--- a/src/dsl/operation/CacheGet.hpp
+++ b/src/dsl/operation/CacheGet.hpp
@@ -27,6 +27,9 @@
 #include "../store/ThreadStore.hpp"
 
 namespace NUClear {
+namespace threading {
+    class ReactionTask;  // Forward declare ReactionTask
+}  // namespace threading
 namespace dsl {
     namespace operation {
 
@@ -41,6 +44,7 @@ namespace dsl {
          */
         template <typename DataType>
         struct CacheGet {
+            CacheGet() = delete;  // Ensure that DSL words are not instantiated
 
             template <typename DSL, typename T = DataType>
             static std::shared_ptr<const T> get(const threading::ReactionTask& /*task*/) {

--- a/src/dsl/operation/ChronoTask.hpp
+++ b/src/dsl/operation/ChronoTask.hpp
@@ -23,6 +23,8 @@
 #ifndef NUCLEAR_DSL_OPERATION_CHRONO_TASK_HPP
 #define NUCLEAR_DSL_OPERATION_CHRONO_TASK_HPP
 
+#include <functional>
+
 #include "../../clock.hpp"
 #include "../../id.hpp"
 

--- a/src/dsl/operation/TypeBind.hpp
+++ b/src/dsl/operation/TypeBind.hpp
@@ -23,6 +23,8 @@
 #ifndef NUCLEAR_DSL_OPERATION_TYPE_BIND_HPP
 #define NUCLEAR_DSL_OPERATION_TYPE_BIND_HPP
 
+#include <algorithm>
+
 #include "../store/TypeCallbackStore.hpp"
 
 namespace NUClear {
@@ -56,6 +58,7 @@ namespace dsl {
          */
         template <typename DataType>
         struct TypeBind {
+            TypeBind() = delete;  // Ensure that DSL words are not instantiated
 
             template <typename DSL>
             static void bind(const std::shared_ptr<threading::Reaction>& reaction) {

--- a/src/dsl/word/Idle.hpp
+++ b/src/dsl/word/Idle.hpp
@@ -71,7 +71,12 @@ namespace dsl {
             static void bind(const std::shared_ptr<threading::Reaction>& reaction) {
 
                 // Make a fake task to use for finding an appropriate descriptor
-                threading::ReactionTask task(reaction, false, DSL::priority, DSL::run_inline, DSL::pool, DSL::group);
+                const threading::ReactionTask task(reaction,
+                                                   false,
+                                                   DSL::priority,
+                                                   DSL::run_inline,
+                                                   DSL::pool,
+                                                   DSL::group);
                 bind_idle(reaction, PoolType::template pool<DSL>(task));
             }
         };

--- a/src/dsl/word/Shutdown.hpp
+++ b/src/dsl/word/Shutdown.hpp
@@ -52,11 +52,19 @@ namespace dsl {
          * @par Implements
          *  Bind
          */
-        struct Shutdown
-            : operation::TypeBind<Shutdown>
-            , Priority::IDLE {};
+        struct Shutdown {};
 
     }  // namespace word
+
+    namespace operation {
+
+        template <>
+        struct DSLProxy<word::Shutdown>
+            : operation::TypeBind<word::Shutdown>
+            , word::Priority::IDLE {};
+
+    }  // namespace operation
+
 }  // namespace dsl
 }  // namespace NUClear
 

--- a/src/dsl/word/Startup.hpp
+++ b/src/dsl/word/Startup.hpp
@@ -39,9 +39,17 @@ namespace dsl {
          * @par Implements
          *  Bind
          */
-        struct Startup : operation::TypeBind<Startup> {};
+        struct Startup {};
 
     }  // namespace word
+
+    namespace operation {
+
+        template <>
+        struct DSLProxy<word::Startup> : operation::TypeBind<word::Startup> {};
+
+    }  // namespace operation
+
 }  // namespace dsl
 }  // namespace NUClear
 

--- a/src/dsl/word/TaskScope.hpp
+++ b/src/dsl/word/TaskScope.hpp
@@ -21,7 +21,6 @@
  */
 #ifndef NUCLEAR_DSL_WORD_TASK_SCOPE_HPP
 #define NUCLEAR_DSL_WORD_TASK_SCOPE_HPP
-#include <iostream>
 
 #include "../../id.hpp"
 #include "../../threading/ReactionTask.hpp"

--- a/src/dsl/word/TaskScope.hpp
+++ b/src/dsl/word/TaskScope.hpp
@@ -76,7 +76,7 @@ namespace dsl {
             template <typename DSL>
             static Lock scope(const threading::ReactionTask& task) {
                 // Store the old task id
-                NUClear::id_t old_id = current_task_id;
+                const NUClear::id_t old_id = current_task_id;
                 // Set the current task id to the word
                 current_task_id = task.id;
                 // Return a lock that will restore the old task id

--- a/src/dsl/word/UDP.hpp
+++ b/src/dsl/word/UDP.hpp
@@ -367,7 +367,7 @@ namespace dsl {
                 mh.msg_iovlen     = 1;
 
                 // Receive our message
-                ssize_t received = recvmsg(event.fd, &mh, MSG_DONTWAIT);
+                const ssize_t received = recvmsg(event.fd, &mh, MSG_DONTWAIT);
                 if (received < 0) {
                     return {};
                 }

--- a/src/dsl/word/emit/Delay.hpp
+++ b/src/dsl/word/emit/Delay.hpp
@@ -47,7 +47,7 @@ namespace dsl {
             struct Delay {
 
                 static void emit(PowerPlant& powerplant,
-                                 std::shared_ptr<DataType> data,
+                                 const std::shared_ptr<DataType>& data,
                                  NUClear::clock::duration delay) {
 
                     // Our chrono task is just to do a normal emit in the amount of time
@@ -67,7 +67,7 @@ namespace dsl {
                 }
 
                 static void emit(PowerPlant& powerplant,
-                                 std::shared_ptr<DataType> data,
+                                 const std::shared_ptr<DataType>& data,
                                  NUClear::clock::time_point at_time) {
 
                     // Our chrono task is just to do a normal emit in the amount of time

--- a/src/dsl/word/emit/Initialise.hpp
+++ b/src/dsl/word/emit/Initialise.hpp
@@ -53,7 +53,7 @@ namespace dsl {
             template <typename DataType>
             struct Initialise {
 
-                static void emit(PowerPlant& powerplant, std::shared_ptr<DataType> data) {
+                static void emit(PowerPlant& powerplant, const std::shared_ptr<DataType>& data) {
 
                     // Make a floating reaction task to submit which will emit this data
                     auto emitter = std::make_unique<threading::ReactionTask>(

--- a/src/dsl/word/emit/Network.hpp
+++ b/src/dsl/word/emit/Network.hpp
@@ -95,7 +95,7 @@ namespace dsl {
                 }
 
                 static void emit(PowerPlant& powerplant, const std::shared_ptr<DataType>& data, bool reliable) {
-                    emit(powerplant, std::move(data), "", reliable);
+                    emit(powerplant, data, "", reliable);
                 }
             };
 

--- a/src/dsl/word/emit/Network.hpp
+++ b/src/dsl/word/emit/Network.hpp
@@ -24,6 +24,7 @@
 #define NUCLEAR_DSL_WORD_EMIT_NETWORK_HPP
 
 #include <array>
+#include <utility>
 
 #include "../../../util/serialise/Serialise.hpp"
 
@@ -79,7 +80,7 @@ namespace dsl {
             struct Network {
 
                 static void emit(PowerPlant& powerplant,
-                                 std::shared_ptr<DataType> data,
+                                 const std::shared_ptr<DataType>& data,
                                  std::string target = "",
                                  bool reliable      = false) {
 
@@ -93,8 +94,8 @@ namespace dsl {
                     powerplant.emit<Inline>(e);
                 }
 
-                static void emit(PowerPlant& powerplant, std::shared_ptr<DataType> data, bool reliable) {
-                    emit(powerplant, data, "", reliable);
+                static void emit(PowerPlant& powerplant, const std::shared_ptr<DataType>& data, bool reliable) {
+                    emit(powerplant, std::move(data), "", reliable);
                 }
             };
 

--- a/src/dsl/word/emit/UDP.hpp
+++ b/src/dsl/word/emit/UDP.hpp
@@ -60,7 +60,7 @@ namespace dsl {
             struct UDP {
 
                 static void emit(const PowerPlant& /*powerplant*/,
-                                 std::shared_ptr<DataType> data,
+                                 const std::shared_ptr<DataType>& data,
                                  const std::string& to_addr,
                                  in_port_t to_port,
                                  const std::string& from_addr = "",

--- a/src/extension/ChronoController.cpp
+++ b/src/extension/ChronoController.cpp
@@ -22,8 +22,16 @@
 
 #include "ChronoController.hpp"
 
+#include <algorithm>
 #include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <utility>
 
+#include "../Reactor.hpp"
+#include "../dsl/operation/Unbind.hpp"
+#include "../message/TimeTravel.hpp"
 #include "../util/precise_sleep.hpp"
 
 namespace NUClear {

--- a/src/extension/NetworkController.cpp
+++ b/src/extension/NetworkController.cpp
@@ -22,7 +22,22 @@
 
 #include "NetworkController.hpp"
 
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+#include "../Reactor.hpp"
+#include "../dsl/operation/Unbind.hpp"
+#include "../dsl/store/ThreadStore.hpp"
+#include "../dsl/word/Network.hpp"
+#include "../dsl/word/emit/Network.hpp"
+#include "../message/NetworkConfiguration.hpp"
 #include "../message/NetworkEvent.hpp"
+#include "../util/get_hostname.hpp"
 
 namespace NUClear {
 namespace extension {

--- a/src/extension/trace/protobuf.cpp
+++ b/src/extension/trace/protobuf.cpp
@@ -22,8 +22,10 @@
 
 #include "protobuf.hpp"
 
+#include <cstddef>
 #include <cstdint>
 #include <iterator>
+#include <string>
 #include <type_traits>
 #include <vector>
 
@@ -32,71 +34,84 @@ namespace extension {
     namespace trace {
         namespace protobuf {
 
-            namespace encode {
-                template <typename T, typename OutputIterator, std::enable_if_t<std::is_integral<T>::value, int> = 0>
-                OutputIterator redundant_varint(const T& value, const size_t& n_bytes, OutputIterator out) {
-                    // Encode the value as a varint
-                    uint32_t v = value;
-                    for (unsigned i = 0; i < n_bytes - 1; i++) {
-                        *out++ = (v & 0x7F) | 0x80;
-                        v >>= 7;
+            namespace {  // Everything here has internal linkage
+
+                namespace encode {
+                    template <typename T,
+                              typename OutputIterator,
+                              std::enable_if_t<std::is_integral<T>::value, int> = 0>
+                    OutputIterator redundant_varint(const T& value, const size_t& n_bytes, OutputIterator out) {
+                        // Encode the value as a varint
+                        uint32_t v = value;
+                        for (unsigned i = 0; i < n_bytes - 1; i++) {
+                            *out++ = (v & 0x7F) | 0x80;
+                            v >>= 7;
+                        }
+                        *out++ = v & 0x7F;
+                        return out;
                     }
-                    *out++ = v & 0x7F;
-                    return out;
-                }
 
-                template <typename T, typename OutputIterator, std::enable_if_t<std::is_integral<T>::value, int> = 0>
-                OutputIterator varint(const T& value, OutputIterator out) {
-                    // Cast the value down to its unsigned type and encode it as a varint
-                    std::make_unsigned_t<T> v(value);
-                    while (v >= 0x80) {
-                        *out++ = (v & 0x7F) | 0x80;
-                        v >>= 7;
+                    template <typename T,
+                              typename OutputIterator,
+                              std::enable_if_t<std::is_integral<T>::value, int> = 0>
+                    OutputIterator varint(const T& value, OutputIterator out) {
+                        // Cast the value down to its unsigned type and encode it as a varint
+                        std::make_unsigned_t<T> v(value);
+                        while (v >= 0x80) {
+                            *out++ = (v & 0x7F) | 0x80;
+                            v >>= 7;
+                        }
+                        *out++ = v & 0x7F;
+                        return out;
                     }
-                    *out++ = v & 0x7F;
-                    return out;
-                }
 
-                template <typename T, typename OutputIterator, std::enable_if_t<std::is_integral<T>::value, int> = 0>
-                OutputIterator fixed(const T& value, OutputIterator out) {
-                    // Cast the value down to its unsigned type and encode it as fixed
-                    const std::make_unsigned_t<T> v(value);
-                    for (size_t i = 0; i < sizeof(T); ++i) {
-                        *out++ = (v >> (i * 8)) & 0xFF;
+                    template <typename T,
+                              typename OutputIterator,
+                              std::enable_if_t<std::is_integral<T>::value, int> = 0>
+                    OutputIterator fixed(const T& value, OutputIterator out) {
+                        // Cast the value down to its unsigned type and encode it as fixed
+                        const std::make_unsigned_t<T> v(value);
+                        for (size_t i = 0; i < sizeof(T); ++i) {
+                            *out++ = (v >> (i * 8)) & 0xFF;
+                        }
+                        return out;
                     }
-                    return out;
-                }
 
-                template <typename Iterator, typename OutputIterator>
-                OutputIterator length_delimited(Iterator begin, Iterator end, OutputIterator out) {
-                    // Encode the value as a varint length and then the string
-                    out = varint(uint32_t(std::distance(begin, end)), out);
-                    out = std::copy(begin, end, out);
-                    return out;
-                }
+                    template <typename Iterator, typename OutputIterator>
+                    OutputIterator length_delimited(Iterator begin, Iterator end, OutputIterator out) {
+                        // Encode the value as a varint length and then the string
+                        out = varint(uint32_t(std::distance(begin, end)), out);
+                        out = std::copy(begin, end, out);
+                        return out;
+                    }
 
-            }  // namespace encode
+                }  // namespace encode
 
-            namespace field {
-                template <typename T, typename OutputIterator>
-                OutputIterator varint(const uint32_t& id, const T& value, OutputIterator out) {
-                    out = encode::varint(uint32_t(id << 3 | 0), out);
-                    return encode::varint(value, out);
-                }
+                namespace field {
+                    template <typename T, typename OutputIterator>
+                    OutputIterator varint(const uint32_t& id, const T& value, OutputIterator out) {
+                        out = encode::varint(uint32_t(id << 3 | 0), out);
+                        return encode::varint(value, out);
+                    }
 
-                template <typename T, typename OutputIterator>
-                OutputIterator fixed(const uint32_t& id, const T& value, OutputIterator out) {
-                    out = encode::varint(uint32_t(id << 3 | 1), out);
-                    return encode::fixed(value, out);
-                }
+                    template <typename T, typename OutputIterator>
+                    OutputIterator fixed(const uint32_t& id, const T& value, OutputIterator out) {
+                        out = encode::varint(uint32_t(id << 3 | 1), out);
+                        return encode::fixed(value, out);
+                    }
 
-                template <typename Iterator, typename OutputIterator>
-                OutputIterator length_delimited(const uint32_t& id, Iterator begin, Iterator end, OutputIterator out) {
-                    out = encode::varint(uint32_t(id << 3 | 2), out);
-                    return encode::length_delimited(begin, end, out);
-                }
+                    template <typename Iterator, typename OutputIterator>
+                    OutputIterator length_delimited(const uint32_t& id,
+                                                    Iterator begin,
+                                                    Iterator end,
+                                                    OutputIterator out) {
+                        out = encode::varint(uint32_t(id << 3 | 2), out);
+                        return encode::length_delimited(begin, end, out);
+                    }
 
-            }  // namespace field
+                }  // namespace field
+
+            }  // namespace
 
             void uint64(const uint32_t& id, const uint64_t& value, std::vector<char>& data) {
                 field::varint(id, value, std::back_inserter(data));

--- a/src/id.hpp
+++ b/src/id.hpp
@@ -23,7 +23,7 @@
 #ifndef NUCLEAR_UTIL_ID_HPP
 #define NUCLEAR_UTIL_ID_HPP
 
-#include <cstdint>
+#include <cstddef>
 
 namespace NUClear {
 

--- a/src/message/LogMessage.hpp
+++ b/src/message/LogMessage.hpp
@@ -58,10 +58,10 @@ namespace message {
             , statistics(std::move(statistics)) {}
 
         /// The logging level of the log
-        LogLevel level{};
+        LogLevel level;
 
         /// The logging level of the reactor that made the log (the level to display at)
-        LogLevel display_level{};
+        LogLevel display_level;
 
         /// The string contents of the message
         std::string message;

--- a/src/message/ReactionStatistics.cpp
+++ b/src/message/ReactionStatistics.cpp
@@ -22,7 +22,16 @@
 
 #include "ReactionStatistics.hpp"
 
+#include <chrono>
+#include <memory>
+#include <set>
+#include <thread>
+#include <utility>
+
+#include "../clock.hpp"
+#include "../id.hpp"
 #include "../threading/scheduler/Pool.hpp"
+#include "../util/usage_clock.hpp"
 
 namespace NUClear {
 namespace message {

--- a/src/nuclear.in
+++ b/src/nuclear.in
@@ -50,6 +50,10 @@
 #include "${nuclear_include_base_directory}extension/NetworkController.hpp"
 #include "${nuclear_include_base_directory}extension/TraceController.hpp"
 
+// Publicly available utilities
+#include "${nuclear_include_base_directory}util/demangle.hpp"
+#include "${nuclear_include_base_directory}dsl/operation/ChronoTask.hpp"
+
 // IWYU pragma: end_exports
 
 #endif  // NUCLEAR

--- a/src/nuclear.in
+++ b/src/nuclear.in
@@ -51,8 +51,8 @@
 #include "${nuclear_include_base_directory}extension/TraceController.hpp"
 
 // Publicly available utilities
-#include "${nuclear_include_base_directory}util/demangle.hpp"
 #include "${nuclear_include_base_directory}dsl/operation/ChronoTask.hpp"
+#include "${nuclear_include_base_directory}util/demangle.hpp"
 
 // IWYU pragma: end_exports
 

--- a/src/nuclear.in
+++ b/src/nuclear.in
@@ -23,9 +23,17 @@
 #ifndef NUCLEAR
 #define NUCLEAR
 
+// IWYU pragma: begin_exports
+
 // Main classes
 #include "${nuclear_include_base_directory}PowerPlant.hpp"
 #include "${nuclear_include_base_directory}Reactor.hpp"
+#include "${nuclear_include_base_directory}threading/Reaction.hpp"
+#include "${nuclear_include_base_directory}threading/ReactionTask.hpp"
+
+// Base types
+#include "${nuclear_include_base_directory}clock.hpp"
+#include "${nuclear_include_base_directory}id.hpp"
 
 // Message types
 #include "${nuclear_include_base_directory}message/CommandLineArguments.hpp"
@@ -41,5 +49,7 @@
 #include "${nuclear_include_base_directory}extension/IOController.hpp"
 #include "${nuclear_include_base_directory}extension/NetworkController.hpp"
 #include "${nuclear_include_base_directory}extension/TraceController.hpp"
+
+// IWYU pragma: end_exports
 
 #endif  // NUCLEAR

--- a/src/threading/Reaction.cpp
+++ b/src/threading/Reaction.cpp
@@ -22,6 +22,7 @@
 
 #include "Reaction.hpp"
 
+#include <atomic>
 #include <memory>
 #include <utility>
 

--- a/src/threading/ReactionTask.cpp
+++ b/src/threading/ReactionTask.cpp
@@ -24,6 +24,7 @@
 
 #include <atomic>
 #include <functional>
+#include <memory>
 #include <utility>
 
 #include "../id.hpp"

--- a/src/threading/scheduler/Group.cpp
+++ b/src/threading/scheduler/Group.cpp
@@ -25,9 +25,12 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <utility>
 #include <vector>
 
 #include "../../id.hpp"
+#include "../../util/GroupDescriptor.hpp"
+#include "Lock.hpp"
 
 namespace NUClear {
 namespace threading {

--- a/src/threading/scheduler/Pool.cpp
+++ b/src/threading/scheduler/Pool.cpp
@@ -22,13 +22,22 @@
 #include "Pool.hpp"
 
 #include <algorithm>
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <thread>
+#include <utility>
+#include <vector>
 
 #include "../../dsl/word/MainThread.hpp"
 #include "../../dsl/word/Pool.hpp"
+#include "../../id.hpp"
 #include "../../message/ReactionStatistics.hpp"
+#include "../../threading/Reaction.hpp"
 #include "../../util/Inline.hpp"
+#include "../../util/platform.hpp"
 #include "../ReactionTask.hpp"
-#include "CombinedLock.hpp"
 #include "CountingLock.hpp"
 #include "Scheduler.hpp"
 

--- a/src/threading/scheduler/Pool.cpp
+++ b/src/threading/scheduler/Pool.cpp
@@ -188,9 +188,9 @@ namespace threading {
                 }
             }
             catch (const ShutdownThreadException&) {
-                // This throw is here for when the pool is stopped
+                Pool::current_pool = nullptr;
+                return;
             }
-            Pool::current_pool = nullptr;
         }
 
         Pool::Task Pool::get_task() {

--- a/src/threading/scheduler/Scheduler.cpp
+++ b/src/threading/scheduler/Scheduler.cpp
@@ -22,11 +22,22 @@
 #include "Scheduler.hpp"
 
 #include <algorithm>
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <set>
 #include <stdexcept>
+#include <utility>
+#include <vector>
 
 #include "../../dsl/word/MainThread.hpp"
-#include "../../dsl/word/Pool.hpp"
+#include "../../id.hpp"
+#include "../../threading/Reaction.hpp"
+#include "../../threading/ReactionTask.hpp"
 #include "CombinedLock.hpp"
+#include "Group.hpp"
+#include "Lock.hpp"
+#include "Pool.hpp"
 
 namespace NUClear {
 namespace threading {

--- a/src/util/FileDescriptor.cpp
+++ b/src/util/FileDescriptor.cpp
@@ -22,6 +22,7 @@
 
 #include "FileDescriptor.hpp"
 
+#include <cerrno>
 #include <functional>
 #include <utility>
 

--- a/src/util/FunctionFusion.hpp
+++ b/src/util/FunctionFusion.hpp
@@ -200,8 +200,8 @@ namespace util {
         using no  = std::false_type;
 
         template <typename F>
-        static auto test(int) -> decltype(apply_function_fusion_call<F, Shared, Start, End>(std::declval<Arguments>()),
-                                          yes());
+        static auto test(int)
+            -> decltype(apply_function_fusion_call<F, Shared, Start, End>(std::declval<Arguments>()), yes());
         template <typename>
         static no test(...);
 
@@ -211,8 +211,7 @@ namespace util {
 
     template <typename Functions,
               typename Arguments,
-              template <typename, typename...>
-              class FunctionWrapper,
+              template <typename, typename...> class FunctionWrapper,
               typename WrapperArgs,
               int Shared                  = 0,
               int Start                   = Shared,
@@ -248,8 +247,7 @@ namespace util {
     template <typename CurrentFunction,
               typename... Functions,
               typename... Arguments,
-              template <typename, typename...>
-              class FunctionWrapper,
+              template <typename, typename...> class FunctionWrapper,
               typename... WrapperArgs,
               int Shared,
               int Start,
@@ -332,8 +330,7 @@ namespace util {
      * Otherwise it will be a false_type to indicate its failure.
      */
     template <typename... Arguments,
-              template <typename, typename...>
-              class FunctionWrapper,
+              template <typename, typename...> class FunctionWrapper,
               typename... WrapperArgs,
               int Shared,
               int Start,

--- a/src/util/FunctionFusion.hpp
+++ b/src/util/FunctionFusion.hpp
@@ -177,7 +177,11 @@ namespace util {
                                        NextStep::call(std::forward<Args>(args)...))) {
 
             // Call each on a separate line to preserve order of execution
-            auto current   = tuplify(call_one<CurrentFunction>(CurrentRange(), std::forward<Args>(args)...));
+            // TODO(thouliston) this is a legitimate bug, fix it in a future PR and add a test to ensure it doesn't
+            // regress
+            // NOLINTNEXTLINE(bugprone-use-after-move)
+            auto current = tuplify(call_one<CurrentFunction>(CurrentRange(), std::forward<Args>(args)...));
+            // NOLINTNEXTLINE(bugprone-use-after-move)
             auto remainder = NextStep::call(std::forward<Args>(args)...);
 
             return std::tuple_cat(std::move(current), std::move(remainder));

--- a/src/util/Logger.cpp
+++ b/src/util/Logger.cpp
@@ -1,4 +1,29 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 NUClear Contributors
+ *
+ * This file is part of the NUClear codebase.
+ * See https://github.com/Fastcode/NUClear for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 #include "Logger.hpp"
+
+#include <memory>
+#include <string>
 
 #include "../Reactor.hpp"
 #include "../dsl/word/emit/Inline.hpp"
@@ -8,21 +33,27 @@
 namespace NUClear {
 namespace util {
 
-    /**
-     * Get the current reactor that is running based on the passed in reactor, or the current task if not in a reactor.
-     *
-     * @param calling_reactor The reactor that is calling this function or nullptr if not called from a reactor
-     *
-     * @return The current reactor or nullptr if not in a reactor
-     */
-    const Reactor* get_current_reactor(const Reactor* calling_reactor) {
-        if (calling_reactor != nullptr) {
-            return calling_reactor;
+    namespace {  // Anonymous namespace for internal linkage
+
+        /**
+         * Get the current reactor that is running based on the passed in reactor, or the current task if not in a
+         * reactor.
+         *
+         * @param calling_reactor The reactor that is calling this function or nullptr if not called from a reactor
+         *
+         * @return The current reactor or nullptr if not in a reactor
+         */
+        const Reactor* get_current_reactor(const Reactor* calling_reactor) {
+            if (calling_reactor != nullptr) {
+                return calling_reactor;
+            }
+            // Get the current task
+            const auto* const current_task = threading::ReactionTask::get_current_task();
+            return current_task != nullptr && current_task->parent != nullptr ? &current_task->parent->reactor
+                                                                              : nullptr;
         }
-        // Get the current task
-        const auto* const current_task = threading::ReactionTask::get_current_task();
-        return current_task != nullptr && current_task->parent != nullptr ? &current_task->parent->reactor : nullptr;
-    }
+
+    }  // namespace
 
     Logger::LogLevels Logger::get_current_log_levels(const Reactor* calling_reactor) {
         // Get the current reactor either from the passed in reactor or the current task

--- a/src/util/Logger.hpp
+++ b/src/util/Logger.hpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 NUClear Contributors
+ * Copyright (c) 2024 NUClear Contributors
  *
  * This file is part of the NUClear codebase.
  * See https://github.com/Fastcode/NUClear for further info.

--- a/src/util/TypeMap.hpp
+++ b/src/util/TypeMap.hpp
@@ -80,7 +80,7 @@ namespace util {
          *
          * @param d A pointer to the data to be stored (the map takes ownership)
          */
-        static void set(std::shared_ptr<Value> d) {
+        static void set(const std::shared_ptr<Value>& d) {
             const std::lock_guard<std::mutex> lock(data_mutex);
             data = d;
         }

--- a/src/util/platform.hpp
+++ b/src/util/platform.hpp
@@ -195,6 +195,8 @@ struct WSAHolder {
 
     #include <cerrno>
 
+struct iovec;  // IWYU pragma: export
+
     // Move errno so it can be used in windows
     #define network_errno  errno
     #define INVALID_SOCKET (-1)

--- a/src/util/platform.hpp
+++ b/src/util/platform.hpp
@@ -182,16 +182,16 @@ struct WSAHolder {
 
     // Include real networking stuff
     #include <arpa/inet.h>
-    #include <fcntl.h>
-    #include <ifaddrs.h>
-    #include <net/if.h>
-    #include <netdb.h>
-    #include <netinet/in.h>
-    #include <poll.h>
-    #include <sys/ioctl.h>
-    #include <sys/socket.h>
-    #include <sys/types.h>
-    #include <unistd.h>
+    #include <fcntl.h>       // IWYU pragma: export
+    #include <ifaddrs.h>     // IWYU pragma: export
+    #include <net/if.h>      // IWYU pragma: export
+    #include <netdb.h>       // IWYU pragma: export
+    #include <netinet/in.h>  // IWYU pragma: export
+    #include <poll.h>        // IWYU pragma: export
+    #include <sys/ioctl.h>   // IWYU pragma: export
+    #include <sys/socket.h>  // IWYU pragma: export
+    #include <sys/types.h>   // IWYU pragma: export
+    #include <unistd.h>      // IWYU pragma: export
 
     #include <cerrno>
 

--- a/src/util/platform.hpp
+++ b/src/util/platform.hpp
@@ -181,17 +181,20 @@ struct WSAHolder {
 #else
 
     // Include real networking stuff
+    // export with IWYU as this is the header that should be used for these functions
+    // IWYU pragma: begin_exports
     #include <arpa/inet.h>
-    #include <fcntl.h>       // IWYU pragma: export
-    #include <ifaddrs.h>     // IWYU pragma: export
-    #include <net/if.h>      // IWYU pragma: export
-    #include <netdb.h>       // IWYU pragma: export
-    #include <netinet/in.h>  // IWYU pragma: export
-    #include <poll.h>        // IWYU pragma: export
-    #include <sys/ioctl.h>   // IWYU pragma: export
-    #include <sys/socket.h>  // IWYU pragma: export
-    #include <sys/types.h>   // IWYU pragma: export
-    #include <unistd.h>      // IWYU pragma: export
+    #include <fcntl.h>
+    #include <ifaddrs.h>
+    #include <net/if.h>
+    #include <netdb.h>
+    #include <netinet/in.h>
+    #include <poll.h>
+    #include <sys/ioctl.h>
+    #include <sys/socket.h>
+    #include <sys/types.h>
+    #include <unistd.h>
+    // IWYU pragma: end_exports
 
     #include <cerrno>
 

--- a/src/util/platform.hpp
+++ b/src/util/platform.hpp
@@ -198,8 +198,6 @@ struct WSAHolder {
 
     #include <cerrno>
 
-struct iovec;  // IWYU pragma: export
-
     // Move errno so it can be used in windows
     #define network_errno  errno
     #define INVALID_SOCKET (-1)

--- a/src/util/precise_sleep.cpp
+++ b/src/util/precise_sleep.cpp
@@ -22,6 +22,8 @@
 
 #include "precise_sleep.hpp"
 
+#include <time.h>  // NOLINT(modernize-deprecated-headers) Technically nanosleep lives in time.h not ctime
+
 #include <chrono>
 #include <ctime>
 

--- a/src/util/precise_sleep.cpp
+++ b/src/util/precise_sleep.cpp
@@ -22,9 +22,11 @@
 
 #include "precise_sleep.hpp"
 
+#include <chrono>
+#include <ctime>
+
 #if defined(_WIN32)
 
-    #include <chrono>
     #include <cstdint>
     #include <stdexcept>
 
@@ -61,8 +63,6 @@ namespace util {
 #else
 
     #include <cerrno>
-    #include <cstdint>
-    #include <ctime>
 
 namespace NUClear {
 namespace util {

--- a/src/util/serialise/Serialise.hpp
+++ b/src/util/serialise/Serialise.hpp
@@ -115,7 +115,7 @@ namespace util {
             static uint64_t hash() {
 
                 // Serialise based on the demangled class name
-                std::string type_name = demangle(typeid(T).name());
+                const std::string type_name = demangle(typeid(T).name());
                 return xxhash64(type_name.c_str(), type_name.size(), 0x4e55436c);
             }
         };

--- a/src/util/usage_clock.cpp
+++ b/src/util/usage_clock.cpp
@@ -27,6 +27,7 @@ namespace util {
 }  // namespace NUClear
 
 #else
+
     #include <ctime>
 
 namespace NUClear {
@@ -34,7 +35,9 @@ namespace util {
 
     cpu_clock::time_point cpu_clock::now() noexcept {
         ::timespec ts{};
-        ::clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts);
+        if (::clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts) != 0) {
+            return time_point{};  // Error, return a default time point
+        }
         return time_point(std::chrono::seconds(ts.tv_sec) + std::chrono::nanoseconds(ts.tv_nsec));
     }
 

--- a/src/util/usage_clock.cpp
+++ b/src/util/usage_clock.cpp
@@ -1,6 +1,9 @@
 #include "usage_clock.hpp"
 
+#include <time.h>  // NOLINT(modernize-deprecated-headers) Technically clock_gettime lives in time.h not ctime
+
 #include <chrono>
+#include <ctime>
 
 // Windows
 #if defined(_WIN32)
@@ -27,8 +30,6 @@ namespace util {
 }  // namespace NUClear
 
 #else
-
-    #include <ctime>
 
 namespace NUClear {
 namespace util {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,12 +42,10 @@ set_target_properties(${catch2_target} PROPERTIES CMAKE_CXX_FLAGS "")
 # Create a test_util library that is used by all tests
 file(GLOB_RECURSE test_util_src "test_util/*.cpp")
 add_library(test_util OBJECT ${test_util_src})
-target_link_libraries(test_util INTERFACE "$<LINK_LIBRARY:WHOLE_ARCHIVE,NUClear::nuclear>")
+target_link_libraries(test_util PUBLIC NUClear::nuclear)
 target_link_libraries(test_util PUBLIC Catch2::Catch2)
+target_include_directories(test_util PUBLIC ${PROJECT_BINARY_DIR}/include ${PROJECT_SOURCE_DIR}/src)
 target_include_directories(test_util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(
-  test_util SYSTEM PUBLIC ${CATCH_INCLUDE_DIRS} ${PROJECT_BINARY_DIR}/include "${PROJECT_SOURCE_DIR}/src"
-)
 
 # Create a test binary for each test file
 file(GLOB_RECURSE test_sources "tests/*.cpp")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,7 +42,9 @@ set_target_properties(${catch2_target} PROPERTIES CMAKE_CXX_FLAGS "")
 # Create a test_util library that is used by all tests
 file(GLOB_RECURSE test_util_src "test_util/*.cpp")
 add_library(test_util OBJECT ${test_util_src})
-target_link_libraries(test_util PUBLIC NUClear::nuclear)
+# This is linking WHOLE_ARCHIVE as otherwise the linker will remove the WSAHolder from the final binary
+# As a result the WSA initialisation code won't run and the network tests will fail
+target_link_libraries(test_util INTERFACE "$<LINK_LIBRARY:WHOLE_ARCHIVE,NUClear::nuclear>")
 target_link_libraries(test_util PUBLIC Catch2::Catch2)
 target_include_directories(test_util PUBLIC ${PROJECT_BINARY_DIR}/include ${PROJECT_SOURCE_DIR}/src)
 target_include_directories(test_util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/networktest.cpp
+++ b/tests/networktest.cpp
@@ -27,10 +27,11 @@
 #include <iostream>
 #include <limits>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <thread>
 #include <utility>
+
+#include "nuclear"
 
 struct PerformEmits {};
 

--- a/tests/networktest.cpp
+++ b/tests/networktest.cpp
@@ -20,11 +20,17 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include <array>
+#include <chrono>
 #include <csignal>
+#include <cstdint>
 #include <cstdlib>
 #include <iostream>
+#include <limits>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <thread>
+#include <utility>
 
 struct PerformEmits {};
 

--- a/tests/test_util/TestBase.hpp
+++ b/tests/test_util/TestBase.hpp
@@ -24,11 +24,11 @@
 #define TEST_UTIL_TEST_BASE_HPP
 
 #include <catch2/catch_test_macros.hpp>
+#include <nuclear>
 #include <string>
 #include <utility>
 
-#include "nuclear"
-#include "test_util/diff_string.hpp"
+#include "test_util/diff_string.hpp"  // IWYU pragma: export
 
 namespace test_util {
 
@@ -54,6 +54,7 @@ public:
         std::string message;
     };
 
+private:
     explicit TestBase(std::unique_ptr<NUClear::Environment> environment,
                       const bool& shutdown_on_idle             = true,
                       const std::chrono::milliseconds& timeout = std::chrono::milliseconds(1000))
@@ -93,10 +94,15 @@ public:
         });
     }
 
-private:
+    /// Mutex to wait on for the test timeout
     std::mutex timeout_mutex;
+    /// Condition variable to wait on for the test timeout
     std::condition_variable timeout_cv;
+    /// If the shutdown was clean
     bool clean_shutdown = false;
+
+    // CRTP subclass is a friend of the base class so it can access the constructor
+    friend BaseClass;
 };
 
 }  // namespace test_util

--- a/tests/test_util/TestBase.hpp
+++ b/tests/test_util/TestBase.hpp
@@ -24,10 +24,10 @@
 #define TEST_UTIL_TEST_BASE_HPP
 
 #include <catch2/catch_test_macros.hpp>
-#include <nuclear>
 #include <string>
 #include <utility>
 
+#include "nuclear"
 #include "test_util/diff_string.hpp"  // IWYU pragma: export
 
 namespace test_util {

--- a/tests/test_util/common.hpp
+++ b/tests/test_util/common.hpp
@@ -23,9 +23,8 @@
 #ifndef TEST_UTIL_COMMON_HPP
 #define TEST_UTIL_COMMON_HPP
 
-#include <nuclear>
-
 #include "executable_path.hpp"
+#include "nuclear"
 
 namespace test_util {
 

--- a/tests/test_util/diff_string.cpp
+++ b/tests/test_util/diff_string.cpp
@@ -24,7 +24,9 @@
 
 #include <algorithm>
 #include <cstring>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "lcs.hpp"
 

--- a/tests/test_util/executable_path.cpp
+++ b/tests/test_util/executable_path.cpp
@@ -59,6 +59,8 @@ std::string get_executable_path() {
 }  // namespace test_util
 
 #elif defined(__linux__)
+    #include <linux/limits.h>
+    #include <sys/types.h>
     #include <unistd.h>
 
 namespace test_util {

--- a/tests/test_util/executable_path.cpp
+++ b/tests/test_util/executable_path.cpp
@@ -24,7 +24,7 @@
 
 #include <array>
 #include <climits>
-#include <stdexcept>
+#include <cstddef>
 #include <string>
 #include <system_error>
 

--- a/tests/test_util/has_ipv6.cpp
+++ b/tests/test_util/has_ipv6.cpp
@@ -23,7 +23,8 @@
 #include "has_ipv6.hpp"
 
 #include <algorithm>
-#include <nuclear>
+
+#include "nuclear"
 
 namespace test_util {
 

--- a/tests/test_util/has_ipv6.cpp
+++ b/tests/test_util/has_ipv6.cpp
@@ -24,7 +24,8 @@
 
 #include <algorithm>
 
-#include "nuclear"
+#include "util/network/get_interfaces.hpp"
+#include "util/platform.hpp"
 
 namespace test_util {
 

--- a/tests/test_util/has_ipv6.cpp
+++ b/tests/test_util/has_ipv6.cpp
@@ -22,6 +22,7 @@
 
 #include "has_ipv6.hpp"
 
+#include <algorithm>
 #include <nuclear>
 
 namespace test_util {

--- a/tests/test_util/lcs.hpp
+++ b/tests/test_util/lcs.hpp
@@ -74,7 +74,7 @@ std::pair<std::vector<bool>, std::vector<bool>> lcs(const std::vector<T>& a, con
                 a[x] == b[y] ? (x == 0 ? (y + 1) * insert_weight : last_weights[x - 1]) : 0x7FFFFFFF;
 
             // Find the smallest weight
-            const int min_weight = std::min(std::min(weight_from_left, weight_from_top), weight_from_diagonal);
+            const int min_weight = std::min({weight_from_left, weight_from_top, weight_from_diagonal});
             curr_weights[x]      = min_weight;
 
             const int direction = (min_weight == weight_from_diagonal ? 0x01 : 0x0)  //

--- a/tests/tests/api/LogLevel.cpp
+++ b/tests/tests/api/LogLevel.cpp
@@ -1,11 +1,31 @@
-#define CATCH_CONFIG_MAIN
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 NUClear Contributors
+ *
+ * This file is part of the NUClear codebase.
+ * See https://github.com/Fastcode/NUClear for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 #include "LogLevel.hpp"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
-#include <catch2/generators/catch_generators_all.hpp>
-#include <ostream>
 #include <sstream>
+#include <string>
 #include <tuple>
 
 SCENARIO("LogLevel smart enum values can be constructed and converted appropriately") {

--- a/tests/tests/api/ReactionHandle.cpp
+++ b/tests/tests/api/ReactionHandle.cpp
@@ -20,12 +20,18 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 
+namespace {  // Make everything in this file have internal linkage
 
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
@@ -66,6 +72,7 @@ public:
     std::vector<std::string> events;
 };
 
+}  // namespace
 
 TEST_CASE("Testing reaction handle functionality", "[api][reactionhandle]") {
     NUClear::Configuration config;

--- a/tests/tests/api/ReactionHandle.cpp
+++ b/tests/tests/api/ReactionHandle.cpp
@@ -23,11 +23,11 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/api/ReactionStatistics.cpp
+++ b/tests/tests/api/ReactionStatistics.cpp
@@ -20,8 +20,13 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <exception>
+#include <memory>
 #include <nuclear>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/api/ReactionStatistics.cpp
+++ b/tests/tests/api/ReactionStatistics.cpp
@@ -24,10 +24,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <exception>
 #include <memory>
-#include <nuclear>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/api/ReactionStatisticsTiming.cpp
+++ b/tests/tests/api/ReactionStatisticsTiming.cpp
@@ -20,43 +20,42 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <algorithm>
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <map>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <util/usage_clock.hpp>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"
 #include "util/precise_sleep.hpp"
 
-using TimeUnit = test_util::TimeUnit;
-
-/// Events that occur during the test and the time they occur
-/// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-std::vector<std::pair<std::string, NUClear::clock::time_point>> code_events;
-/// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-std::vector<std::pair<std::string, NUClear::clock::time_point>> stat_events;
-
-struct Usage {
-    std::map<std::string, std::chrono::steady_clock::duration> real;
-    std::map<std::string, NUClear::util::cpu_clock::duration> cpu;
-};
-
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-Usage usage;
-
-struct DoTest {};
-struct HeavyTask {};
-struct LightTask {};
-
-const std::string heavy_name   = "Heavy";    // NOLINT(cert-err58-cpp)
-const std::string light_name   = "Light";    // NOLINT(cert-err58-cpp)
-const std::string initial_name = "Initial";  // NOLINT(cert-err58-cpp)
-constexpr int scale            = 5;          // Number of time units to sleep/wait for
-
 using NUClear::message::ReactionEvent;
+using test_util::TimeUnit;
 
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
+    struct Usage {
+        std::map<std::string, std::chrono::steady_clock::duration> real;
+        std::map<std::string, NUClear::util::cpu_clock::duration> cpu;
+    };
+
+    struct DoTest {};
+    struct HeavyTask {};
+    struct LightTask {};
+
+    const std::string heavy_name   = "Heavy";    // NOLINT(cert-err58-cpp)
+    const std::string light_name   = "Light";    // NOLINT(cert-err58-cpp)
+    const std::string initial_name = "Initial";  // NOLINT(cert-err58-cpp)
+    static constexpr int scale     = 5;          // Number of time units to sleep/wait for
+
     TestReactor(std::unique_ptr<NUClear::Environment> environment)
         : TestBase(std::move(environment), true, std::chrono::seconds(2)) {
 
@@ -66,7 +65,7 @@ public:
             emit(std::make_unique<HeavyTask>());
             code_events.emplace_back("Finished " + initial_name + ":" + heavy_name, NUClear::clock::now());
         });
-        on<Trigger<HeavyTask>>().then(heavy_name, [] {
+        on<Trigger<HeavyTask>>().then(heavy_name, [this] {
             code_events.emplace_back("Started " + heavy_name, NUClear::clock::now());
             auto start = NUClear::clock::now();
             while (NUClear::clock::now() - start < TimeUnit(scale)) {
@@ -80,13 +79,13 @@ public:
             emit(std::make_unique<LightTask>());
             code_events.emplace_back("Finished " + initial_name + ":" + light_name, NUClear::clock::now());
         });
-        on<Trigger<LightTask>>().then(light_name, [] {
+        on<Trigger<LightTask>>().then(light_name, [this] {
             code_events.emplace_back("Started " + light_name, NUClear::clock::now());
             NUClear::util::precise_sleep(TimeUnit(scale));
             code_events.emplace_back("Finished " + light_name, NUClear::clock::now());
         });
 
-        on<Trigger<ReactionEvent>>().then([](const ReactionEvent& event) {
+        on<Trigger<ReactionEvent>>().then([this](const ReactionEvent& event) {
             const auto& stats = *event.statistics;
             // Check the name ends with light_name or heavy_name
             if (stats.identifiers->name.substr(stats.identifiers->name.size() - light_name.size()) == light_name
@@ -116,7 +115,16 @@ public:
             emit(std::make_unique<Step<1>>());
         });
     }
+
+    /// Code events that occur during the test and the time they occur
+    std::vector<std::pair<std::string, NUClear::clock::time_point>> code_events;
+    /// Statistic events that occur during the test and the time they occur
+    std::vector<std::pair<std::string, NUClear::clock::time_point>> stat_events;
+    /// Usage statistics for the heavy and light tasks
+    Usage usage;
 };
+// Needed because until c++17 this value will cause a linker error if it is not defined in a cpp file
+constexpr int TestReactor::scale;
 
 
 TEST_CASE("Testing reaction statistics timing", "[api][reactionstatistics][timing]") {
@@ -125,8 +133,16 @@ TEST_CASE("Testing reaction statistics timing", "[api][reactionstatistics][timin
     config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
-    plant.install<TestReactor>();
+    auto& reactor = plant.install<TestReactor>();
     plant.start();
+
+    // Extract variables
+    const auto& code_events = reactor.code_events;
+    auto& stat_events       = reactor.stat_events;
+    const auto& usage       = reactor.usage;
+    constexpr int scale     = TestReactor::scale;
+    const auto& heavy_name  = reactor.heavy_name;
+    const auto& light_name  = reactor.light_name;
 
     // Sort the stats events by timestamp as they are not always going to be in order due to how stats are processed
     std::stable_sort(stat_events.begin(), stat_events.end(), [](const auto& lhs, const auto& rhs) {
@@ -134,7 +150,7 @@ TEST_CASE("Testing reaction statistics timing", "[api][reactionstatistics][timin
     });
 
 
-    auto make_delta = [](const std::vector<std::pair<std::string, NUClear::clock::time_point>>& events) {
+    auto make_delta = [&](const std::vector<std::pair<std::string, NUClear::clock::time_point>>& events) {
         std::vector<std::string> delta_events;
         auto first = events.front().second;
         for (const auto& event : events) {
@@ -175,8 +191,8 @@ TEST_CASE("Testing reaction statistics timing", "[api][reactionstatistics][timin
     }
 
     // Most of heavy real time should be cpu time
-    REQUIRE(usage.cpu[heavy_name] > usage.real[heavy_name] / 2);
+    REQUIRE(usage.cpu.at(heavy_name) > usage.real.at(heavy_name) / 2);
 
     // Most of light real time should be sleeping
-    REQUIRE(usage.cpu[light_name] < usage.real[light_name] / 2);
+    REQUIRE(usage.cpu.at(light_name) < usage.real.at(light_name) / 2);
 }

--- a/tests/tests/api/ReactionStatisticsTiming.cpp
+++ b/tests/tests/api/ReactionStatisticsTiming.cpp
@@ -26,12 +26,12 @@
 #include <chrono>
 #include <map>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <util/usage_clock.hpp>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/api/ReactorArgs.cpp
+++ b/tests/tests/api/ReactorArgs.cpp
@@ -21,7 +21,11 @@
  */
 
 #include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
 
 class TestReactorNoArgs : public NUClear::Reactor {
 public:

--- a/tests/tests/api/ReactorArgs.cpp
+++ b/tests/tests/api/ReactorArgs.cpp
@@ -23,9 +23,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cstdint>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
+
+#include "nuclear"
 
 class TestReactorNoArgs : public NUClear::Reactor {
 public:

--- a/tests/tests/api/TimeTravel.cpp
+++ b/tests/tests/api/TimeTravel.cpp
@@ -1,6 +1,15 @@
+#include <algorithm>
+#include <array>
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <chrono>
+#include <clock.hpp>
+#include <cmath>
+#include <cstdint>
+#include <memory>
 #include <nuclear>
+#include <utility>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"

--- a/tests/tests/api/TimeTravel.cpp
+++ b/tests/tests/api/TimeTravel.cpp
@@ -26,7 +26,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 #include <chrono>
-#include <clock.hpp>
 #include <cmath>
 #include <cstdint>
 #include <memory>

--- a/tests/tests/api/TimeTravel.cpp
+++ b/tests/tests/api/TimeTravel.cpp
@@ -8,9 +8,9 @@
 #include <cmath>
 #include <cstdint>
 #include <memory>
-#include <nuclear>
 #include <utility>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/api/TimeTravel.cpp
+++ b/tests/tests/api/TimeTravel.cpp
@@ -1,3 +1,25 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 NUClear Contributors
+ *
+ * This file is part of the NUClear codebase.
+ * See https://github.com/Fastcode/NUClear for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 #include <algorithm>
 #include <array>
 #include <catch2/catch_message.hpp>

--- a/tests/tests/api/TimeTravelFrozen.cpp
+++ b/tests/tests/api/TimeTravelFrozen.cpp
@@ -5,10 +5,10 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
-#include <nuclear>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 #include "util/precise_sleep.hpp"

--- a/tests/tests/api/TimeTravelFrozen.cpp
+++ b/tests/tests/api/TimeTravelFrozen.cpp
@@ -1,3 +1,25 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 NUClear Contributors
+ *
+ * This file is part of the NUClear codebase.
+ * See https://github.com/Fastcode/NUClear for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>

--- a/tests/tests/api/TimeTravelFrozen.cpp
+++ b/tests/tests/api/TimeTravelFrozen.cpp
@@ -1,7 +1,13 @@
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
-#include <future>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <mutex>
 #include <nuclear>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/Always.cpp
+++ b/tests/tests/dsl/Always.cpp
@@ -20,8 +20,13 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
@@ -62,6 +67,7 @@ TEST_CASE("The Always DSL keyword runs continuously when it can", "[api][always]
     NUClear::Configuration config;
     config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
+    test_util::add_tracing(plant);
     auto& reactor = plant.install<TestReactor>();
     plant.start();
 

--- a/tests/tests/dsl/Always.cpp
+++ b/tests/tests/dsl/Always.cpp
@@ -23,11 +23,11 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/ArgumentFission.cpp
+++ b/tests/tests/dsl/ArgumentFission.cpp
@@ -24,12 +24,12 @@
 #include <catch2/catch_test_macros.hpp>
 #include <chrono>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <tuple>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/ArgumentFission.cpp
+++ b/tests/tests/dsl/ArgumentFission.cpp
@@ -20,12 +20,20 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <tuple>
 #include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
+
+namespace {  // Make everything in this file have internal linkage
 
 /// Events that occur during the test
 std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -84,6 +92,7 @@ public:
     }
 };
 
+}  // namespace
 
 TEST_CASE("Testing distributing arguments to multiple bind functions (NUClear Fission)", "[api][dsl][fission]") {
 

--- a/tests/tests/dsl/BlockNoData.cpp
+++ b/tests/tests/dsl/BlockNoData.cpp
@@ -23,11 +23,11 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/BlockNoData.cpp
+++ b/tests/tests/dsl/BlockNoData.cpp
@@ -20,8 +20,13 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/Buffer.cpp
+++ b/tests/tests/dsl/Buffer.cpp
@@ -23,11 +23,11 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/Buffer.cpp
+++ b/tests/tests/dsl/Buffer.cpp
@@ -20,8 +20,13 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/CommandLineArguments.cpp
+++ b/tests/tests/dsl/CommandLineArguments.cpp
@@ -20,9 +20,14 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/CommandLineArguments.cpp
+++ b/tests/tests/dsl/CommandLineArguments.cpp
@@ -23,12 +23,12 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/CustomGet.cpp
+++ b/tests/tests/dsl/CustomGet.cpp
@@ -23,11 +23,11 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/CustomGet.cpp
+++ b/tests/tests/dsl/CustomGet.cpp
@@ -20,13 +20,23 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 
-struct CustomGet : NUClear::dsl::operation::TypeBind<CustomGet> {
+struct CustomGet {
+
+    template <typename DSL>
+    static void bind(const std::shared_ptr<NUClear::threading::Reaction>& reaction) {
+        NUClear::dsl::operation::TypeBind<CustomGet>::template bind<DSL>(reaction);
+    }
 
     template <typename DSL>
     static std::shared_ptr<std::string> get(const NUClear::threading::ReactionTask& /*task*/) {

--- a/tests/tests/dsl/CustomGet.cpp
+++ b/tests/tests/dsl/CustomGet.cpp
@@ -27,6 +27,7 @@
 #include <utility>
 #include <vector>
 
+#include "dsl/operation/TypeBind.hpp"
 #include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/DSLOrdering.cpp
+++ b/tests/tests/dsl/DSLOrdering.cpp
@@ -23,11 +23,11 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/DSLOrdering.cpp
+++ b/tests/tests/dsl/DSLOrdering.cpp
@@ -20,8 +20,13 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/DSLProxy.cpp
+++ b/tests/tests/dsl/DSLProxy.cpp
@@ -20,6 +20,8 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include "dsl/operation/DSLProxy.hpp"
+
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
@@ -28,6 +30,7 @@
 #include <vector>
 
 #include "dsl/operation/CacheGet.hpp"
+#include "dsl/operation/TypeBind.hpp"
 #include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/DSLProxy.cpp
+++ b/tests/tests/dsl/DSLProxy.cpp
@@ -23,11 +23,12 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "dsl/operation/CacheGet.hpp"
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/DSLProxy.cpp
+++ b/tests/tests/dsl/DSLProxy.cpp
@@ -20,8 +20,13 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/Every.cpp
+++ b/tests/tests/dsl/Every.cpp
@@ -28,11 +28,11 @@
 #include <cstdlib>
 #include <iterator>
 #include <memory>
-#include <nuclear>
 #include <numeric>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/Every.cpp
+++ b/tests/tests/dsl/Every.cpp
@@ -20,9 +20,18 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdlib>
+#include <iterator>
+#include <memory>
 #include <nuclear>
 #include <numeric>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
@@ -49,6 +58,8 @@ public:
     std::vector<NUClear::clock::time_point> dynamic_times;
 };
 
+namespace {
+
 void test_results(const std::vector<NUClear::clock::time_point>& times) {
 
     // Build up our difference vector
@@ -73,6 +84,7 @@ void test_results(const std::vector<NUClear::clock::time_point>& times) {
     REQUIRE(std::abs(mean + stddev * 2) < 0.008);
 }
 
+}  // namespace
 
 TEST_CASE("Testing the Every<> DSL word", "[api][every][per]") {
 

--- a/tests/tests/dsl/FlagMessage.cpp
+++ b/tests/tests/dsl/FlagMessage.cpp
@@ -23,11 +23,11 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/FlagMessage.cpp
+++ b/tests/tests/dsl/FlagMessage.cpp
@@ -20,8 +20,13 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/FusionInOrder.cpp
+++ b/tests/tests/dsl/FusionInOrder.cpp
@@ -21,7 +21,12 @@
  */
 
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <utility>
+#include <vector>
+
+namespace {  // Make everything here internal linkage
 
 std::vector<int> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables,-warnings-as-errors)
 
@@ -36,11 +41,11 @@ struct Extension {
 class TestReactor : public NUClear::Reactor {
 public:
     TestReactor(std::unique_ptr<NUClear::Environment> environment) : Reactor(std::move(environment)) {
-
         on<Extension<0>, Extension<1>, Extension<2>, Extension<3>, Extension<4>>().then([] {});
     }
 };
 
+}  // namespace
 
 TEST_CASE("Testing that the bind functions of extensions are executed in order", "[api][extension][bind]") {
 

--- a/tests/tests/dsl/FusionInOrder.cpp
+++ b/tests/tests/dsl/FusionInOrder.cpp
@@ -22,9 +22,10 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <utility>
 #include <vector>
+
+#include "nuclear"
 
 namespace {  // Make everything here internal linkage
 

--- a/tests/tests/dsl/GroupPool.cpp
+++ b/tests/tests/dsl/GroupPool.cpp
@@ -24,12 +24,13 @@
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
 #include <mutex>
-#include <nuclear>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
+#include "util/Sequence.hpp"
 
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:

--- a/tests/tests/dsl/GroupPool.cpp
+++ b/tests/tests/dsl/GroupPool.cpp
@@ -20,8 +20,13 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <mutex>
 #include <nuclear>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/IO.cpp
+++ b/tests/tests/dsl/IO.cpp
@@ -21,7 +21,12 @@
  */
 
 #include <array>
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/IO.cpp
+++ b/tests/tests/dsl/IO.cpp
@@ -36,7 +36,7 @@
 
     #include <unistd.h>
 
-    #include <nuclear>
+    #include "nuclear"
 
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:

--- a/tests/tests/dsl/IO.cpp
+++ b/tests/tests/dsl/IO.cpp
@@ -143,6 +143,8 @@ TEST_CASE("Testing the IO extension", "[api][io]") {
 
 #else
 
+    #include <catch2/catch_message.hpp>
+    #include <catch2/catch_test_macros.hpp>
 
 TEST_CASE("Testing the IO extension", "[api][io]") {
     SUCCEED("This test is not supported on Windows");

--- a/tests/tests/dsl/IO.cpp
+++ b/tests/tests/dsl/IO.cpp
@@ -20,23 +20,24 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include <array>
-#include <catch2/catch_message.hpp>
-#include <catch2/catch_test_macros.hpp>
-#include <memory>
-#include <string>
-#include <utility>
-#include <vector>
-
-#include "test_util/TestBase.hpp"
-#include "test_util/common.hpp"
-
 // Windows can't do this test as it doesn't have file descriptors
 #ifndef _WIN32
 
+    #include <fcntl.h>
+    #include <sys/types.h>
     #include <unistd.h>
 
+    #include <array>
+    #include <catch2/catch_message.hpp>
+    #include <catch2/catch_test_macros.hpp>
+    #include <memory>
+    #include <string>
+    #include <utility>
+    #include <vector>
+
     #include "nuclear"
+    #include "test_util/TestBase.hpp"
+    #include "test_util/common.hpp"
 
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:

--- a/tests/tests/dsl/Idle.cpp
+++ b/tests/tests/dsl/Idle.cpp
@@ -25,12 +25,12 @@
 #include <chrono>
 #include <memory>
 #include <mutex>
-#include <nuclear>
 #include <string>
 #include <thread>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/Idle.cpp
+++ b/tests/tests/dsl/Idle.cpp
@@ -20,8 +20,16 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <memory>
+#include <mutex>
 #include <nuclear>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"

--- a/tests/tests/dsl/IdleCrossPool.cpp
+++ b/tests/tests/dsl/IdleCrossPool.cpp
@@ -23,12 +23,12 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <thread>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/IdleCrossPool.cpp
+++ b/tests/tests/dsl/IdleCrossPool.cpp
@@ -20,8 +20,14 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"

--- a/tests/tests/dsl/IdleGlobal.cpp
+++ b/tests/tests/dsl/IdleGlobal.cpp
@@ -20,8 +20,11 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <atomic>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <utility>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"

--- a/tests/tests/dsl/IdleGlobal.cpp
+++ b/tests/tests/dsl/IdleGlobal.cpp
@@ -23,9 +23,9 @@
 #include <atomic>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <utility>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/IdleSingle.cpp
+++ b/tests/tests/dsl/IdleSingle.cpp
@@ -20,11 +20,19 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <array>
+#include <atomic>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_tostring.hpp>
+#include <chrono>
+#include <map>
+#include <memory>
 #include <nuclear>
+#include <sstream>
+#include <string>
+#include <utility>
 
 #include "test_util/TestBase.hpp"
-#include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"
 #include "util/precise_sleep.hpp"
 

--- a/tests/tests/dsl/IdleSingle.cpp
+++ b/tests/tests/dsl/IdleSingle.cpp
@@ -27,11 +27,11 @@
 #include <chrono>
 #include <map>
 #include <memory>
-#include <nuclear>
 #include <sstream>
 #include <string>
 #include <utility>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 #include "util/precise_sleep.hpp"

--- a/tests/tests/dsl/IdleSingleGlobal.cpp
+++ b/tests/tests/dsl/IdleSingleGlobal.cpp
@@ -20,11 +20,19 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <array>
+#include <atomic>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_tostring.hpp>
+#include <chrono>
+#include <map>
+#include <memory>
 #include <nuclear>
+#include <sstream>
+#include <string>
+#include <utility>
 
 #include "test_util/TestBase.hpp"
-#include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"
 
 namespace Catch {

--- a/tests/tests/dsl/IdleSingleGlobal.cpp
+++ b/tests/tests/dsl/IdleSingleGlobal.cpp
@@ -27,11 +27,11 @@
 #include <chrono>
 #include <map>
 #include <memory>
-#include <nuclear>
 #include <sstream>
 #include <string>
 #include <utility>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/IdleSync.cpp
+++ b/tests/tests/dsl/IdleSync.cpp
@@ -20,8 +20,13 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <mutex>
 #include <nuclear>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"

--- a/tests/tests/dsl/IdleSync.cpp
+++ b/tests/tests/dsl/IdleSync.cpp
@@ -24,10 +24,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
 #include <mutex>
-#include <nuclear>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/Inline.cpp
+++ b/tests/tests/dsl/Inline.cpp
@@ -34,6 +34,7 @@
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"
+#include "threading/scheduler/Pool.hpp"
 #include "util/precise_sleep.hpp"
 
 class TestReactor : public test_util::TestBase<TestReactor> {

--- a/tests/tests/dsl/Inline.cpp
+++ b/tests/tests/dsl/Inline.cpp
@@ -20,8 +20,16 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <map>
+#include <memory>
+#include <mutex>
 #include <nuclear>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"

--- a/tests/tests/dsl/Inline.cpp
+++ b/tests/tests/dsl/Inline.cpp
@@ -25,12 +25,12 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <nuclear>
 #include <string>
 #include <thread>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/Last.cpp
+++ b/tests/tests/dsl/Last.cpp
@@ -24,12 +24,12 @@
 #include <catch2/catch_test_macros.hpp>
 #include <list>
 #include <memory>
-#include <nuclear>
 #include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/Last.cpp
+++ b/tests/tests/dsl/Last.cpp
@@ -20,8 +20,15 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <list>
+#include <memory>
 #include <nuclear>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/MainThread.cpp
+++ b/tests/tests/dsl/MainThread.cpp
@@ -20,8 +20,14 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/MainThread.cpp
+++ b/tests/tests/dsl/MainThread.cpp
@@ -23,12 +23,12 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <thread>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/MissingArguments.cpp
+++ b/tests/tests/dsl/MissingArguments.cpp
@@ -23,11 +23,11 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/MissingArguments.cpp
+++ b/tests/tests/dsl/MissingArguments.cpp
@@ -20,8 +20,13 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/Once.cpp
+++ b/tests/tests/dsl/Once.cpp
@@ -23,11 +23,11 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/Once.cpp
+++ b/tests/tests/dsl/Once.cpp
@@ -20,8 +20,13 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/Optional.cpp
+++ b/tests/tests/dsl/Optional.cpp
@@ -23,11 +23,11 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/Optional.cpp
+++ b/tests/tests/dsl/Optional.cpp
@@ -20,8 +20,13 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/Priority.cpp
+++ b/tests/tests/dsl/Priority.cpp
@@ -25,12 +25,12 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <random>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/Priority.cpp
+++ b/tests/tests/dsl/Priority.cpp
@@ -20,9 +20,16 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <algorithm>
+#include <array>
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
 #include <random>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/Raw.cpp
+++ b/tests/tests/dsl/Raw.cpp
@@ -21,7 +21,10 @@
  */
 
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/Raw.cpp
+++ b/tests/tests/dsl/Raw.cpp
@@ -22,10 +22,10 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/RawFunction.cpp
+++ b/tests/tests/dsl/RawFunction.cpp
@@ -20,11 +20,18 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
+
+namespace {  // Anonymous namespace to ensure internal linkage
 
 /// Events that occur during the test
 std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -78,6 +85,8 @@ void raw_function_test_right_arg(const Data& data) {
 void raw_function_test_both_args(const Message& msg, const Data& data) {
     events.push_back("Raw function both args: " + msg.data + " " + data.data);
 }
+
+}  // namespace
 
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:

--- a/tests/tests/dsl/RawFunction.cpp
+++ b/tests/tests/dsl/RawFunction.cpp
@@ -23,11 +23,11 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/Shutdown.cpp
+++ b/tests/tests/dsl/Shutdown.cpp
@@ -23,11 +23,11 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/Shutdown.cpp
+++ b/tests/tests/dsl/Shutdown.cpp
@@ -20,8 +20,13 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/Startup.cpp
+++ b/tests/tests/dsl/Startup.cpp
@@ -23,11 +23,11 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/Startup.cpp
+++ b/tests/tests/dsl/Startup.cpp
@@ -20,8 +20,13 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/Sync.cpp
+++ b/tests/tests/dsl/Sync.cpp
@@ -23,11 +23,11 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/Sync.cpp
+++ b/tests/tests/dsl/Sync.cpp
@@ -20,8 +20,13 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"

--- a/tests/tests/dsl/SyncMulti.cpp
+++ b/tests/tests/dsl/SyncMulti.cpp
@@ -20,8 +20,14 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"

--- a/tests/tests/dsl/SyncMulti.cpp
+++ b/tests/tests/dsl/SyncMulti.cpp
@@ -24,11 +24,11 @@
 #include <catch2/catch_test_macros.hpp>
 #include <chrono>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/SyncOrder.cpp
+++ b/tests/tests/dsl/SyncOrder.cpp
@@ -21,9 +21,9 @@
  */
 
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
-#include <numeric>
-#include <string>
+#include <utility>
 #include <vector>
 
 #include "test_util/TestBase.hpp"

--- a/tests/tests/dsl/SyncOrder.cpp
+++ b/tests/tests/dsl/SyncOrder.cpp
@@ -22,10 +22,10 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/TCP.cpp
+++ b/tests/tests/dsl/TCP.cpp
@@ -27,11 +27,11 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 #include "test_util/has_ipv6.hpp"

--- a/tests/tests/dsl/TCP.cpp
+++ b/tests/tests/dsl/TCP.cpp
@@ -35,6 +35,10 @@
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 #include "test_util/has_ipv6.hpp"
+#include "util/FileDescriptor.hpp"
+#include "util/network/resolve.hpp"
+#include "util/network/sock_t.hpp"
+#include "util/platform.hpp"
 
 enum TestPorts : in_port_t {
     KNOWN_V4_PORT = 40010,

--- a/tests/tests/dsl/TCP.cpp
+++ b/tests/tests/dsl/TCP.cpp
@@ -20,15 +20,21 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <array>
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 #include "test_util/has_ipv6.hpp"
-
-/// Events that occur during the test
-std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 enum TestPorts : in_port_t {
     KNOWN_V4_PORT = 40010,
@@ -41,23 +47,19 @@ enum TestType : uint8_t {
     V6_KNOWN,
     V6_EPHEMERAL,
 };
-std::vector<TestType> active_tests;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
-in_port_t v4_port = 0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-in_port_t v6_port = 0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
-struct TestConnection {
-    TestConnection(std::string name, std::string address, in_port_t port)
-        : name(std::move(name)), address(std::move(address)), port(port) {}
-    std::string name;
-    std::string address;
-    in_port_t port;
-};
-
-struct Finished {};
 
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:
+    struct TestConnection {
+        TestConnection(std::string name, std::string address, in_port_t port)
+            : name(std::move(name)), address(std::move(address)), port(port) {}
+        std::string name;
+        std::string address;
+        in_port_t port;
+    };
+
+    struct Finished {};
+
     void handle_data(const std::string& name, const IO::Event& event) {
         // We have data to read
         if ((event.events & IO::READ) != 0) {
@@ -77,8 +79,8 @@ public:
         }
     }
 
-    TestReactor(std::unique_ptr<NUClear::Environment> environment)
-        : TestBase(std::move(environment), false, std::chrono::seconds(2)) {
+    TestReactor(std::unique_ptr<NUClear::Environment> environment, const std::vector<TestType>& active_tests_)
+        : TestBase(std::move(environment), false, std::chrono::seconds(2)), active_tests(active_tests_) {
 
         for (const auto& t : active_tests) {
             switch (t) {
@@ -122,7 +124,7 @@ public:
         }
 
         // Send a test message to the known port
-        on<Trigger<TestConnection>, Sync<TestReactor>>().then([](const TestConnection& target) {
+        on<Trigger<TestConnection>, Sync<TestReactor>>().then([this](const TestConnection& target) {
             // Resolve the target address
             const NUClear::util::network::sock_t address = NUClear::util::network::resolve(target.address, target.port);
 
@@ -193,7 +195,18 @@ public:
         });
     }
 
+    /// Events that occur during the test
+    std::vector<std::string> events;
+
 private:
+    /// The active tests to run
+    std::vector<TestType> active_tests;
+
+    /// The bound ephemeral port for IPv4
+    in_port_t v4_port = 0;
+    /// The bound ephemeral port for IPv6
+    in_port_t v6_port = 0;
+
     size_t test_no = 0;
     NUClear::util::FileDescriptor known_port_fd;
     NUClear::util::FileDescriptor ephemeral_port_fd;
@@ -203,6 +216,7 @@ private:
 TEST_CASE("Testing listening for TCP connections and receiving data messages", "[api][network][tcp]") {
 
     // First work out what tests will be active
+    std::vector<TestType> active_tests;
     active_tests.push_back(V4_KNOWN);
     active_tests.push_back(V4_EPHEMERAL);
     if (test_util::has_ipv6()) {
@@ -215,7 +229,7 @@ TEST_CASE("Testing listening for TCP connections and receiving data messages", "
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     plant.install<NUClear::extension::IOController>();
-    plant.install<TestReactor>();
+    auto& reactor = plant.install<TestReactor>(active_tests);
     plant.start();
 
     // Get the results for the tests we expect
@@ -251,8 +265,8 @@ TEST_CASE("Testing listening for TCP connections and receiving data messages", "
     expected.push_back("Finishing Test");
 
     // Make an info print the diff in an easy to read way if we fail
-    INFO(test_util::diff_string(expected, events));
+    INFO(test_util::diff_string(expected, reactor.events));
 
     // Check the events fired in order and only those events
-    REQUIRE(events == expected);
+    REQUIRE(reactor.events == expected);
 }

--- a/tests/tests/dsl/TaskScope.cpp
+++ b/tests/tests/dsl/TaskScope.cpp
@@ -26,12 +26,12 @@
 #include <catch2/catch_tostring.hpp>
 #include <map>
 #include <memory>
-#include <nuclear>
 #include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/TaskScope.cpp
+++ b/tests/tests/dsl/TaskScope.cpp
@@ -20,9 +20,17 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <array>
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_tostring.hpp>
+#include <map>
+#include <memory>
 #include <nuclear>
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
@@ -122,7 +130,7 @@ TEST_CASE("Test that Trigger statements get the correct data", "[api][trigger]")
     NUClear::Configuration config;
     config.default_pool_concurrency = 1;
     NUClear::PowerPlant plant(config);
-    // test_util::add_tracing(plant);
+    test_util::add_tracing(plant);
     const auto& reactor = plant.install<TestReactor>();
     plant.start();
 

--- a/tests/tests/dsl/Transient.cpp
+++ b/tests/tests/dsl/Transient.cpp
@@ -28,6 +28,9 @@
 #include <utility>
 #include <vector>
 
+#include "dsl/operation/CacheGet.hpp"
+#include "dsl/operation/TypeBind.hpp"
+#include "dsl/trait/is_transient.hpp"
 #include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/Transient.cpp
+++ b/tests/tests/dsl/Transient.cpp
@@ -23,12 +23,12 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/Transient.cpp
+++ b/tests/tests/dsl/Transient.cpp
@@ -20,8 +20,14 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/Trigger.cpp
+++ b/tests/tests/dsl/Trigger.cpp
@@ -23,11 +23,11 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/Trigger.cpp
+++ b/tests/tests/dsl/Trigger.cpp
@@ -20,8 +20,13 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/UDP.cpp
+++ b/tests/tests/dsl/UDP.cpp
@@ -28,11 +28,11 @@
 #include <cstdint>
 #include <exception>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 #include "test_util/has_ipv6.hpp"

--- a/tests/tests/dsl/UDP.cpp
+++ b/tests/tests/dsl/UDP.cpp
@@ -36,6 +36,8 @@
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 #include "test_util/has_ipv6.hpp"
+#include "util/network/get_interfaces.hpp"
+#include "util/platform.hpp"
 
 namespace {  // Anonymous namespace to ensure internal linkage
 

--- a/tests/tests/dsl/UDP.cpp
+++ b/tests/tests/dsl/UDP.cpp
@@ -20,15 +20,24 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <algorithm>
+#include <array>
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 #include "test_util/has_ipv6.hpp"
 
-/// Events that occur during the test
-std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+namespace {  // Anonymous namespace to ensure internal linkage
 
 enum TestPorts : in_port_t {
     UNICAST_V4   = 40000,
@@ -51,13 +60,6 @@ const std::string IPV6_BIND = "::1";  // NOLINT(cert-err58-cpp)
 const std::string IPV6_BIND = "::";  // NOLINT(cert-err58-cpp)
 #endif
 
-// Ephemeral ports that we will use
-in_port_t uni_v4_port   = 0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-in_port_t uni_v6_port   = 0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-in_port_t broad_v4_port = 0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-in_port_t multi_v4_port = 0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-in_port_t multi_v6_port = 0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
 enum TestType : uint8_t {
     UNICAST_V4_KNOWN,
     UNICAST_V4_EPHEMERAL,
@@ -70,9 +72,8 @@ enum TestType : uint8_t {
     MULTICAST_V6_KNOWN,
     MULTICAST_V6_EPHEMERAL,
 };
-std::vector<TestType> active_tests;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-inline std::string get_broadcast_addr() {
+std::string get_broadcast_addr() {
     static std::string addr;
 
     if (!addr.empty()) {
@@ -96,73 +97,77 @@ inline std::string get_broadcast_addr() {
     return addr;
 }
 
-struct SendTarget {
-    std::string data;
-    struct Target {
-        std::string address;
-        in_port_t port = 0;
-    };
-    Target to{};
-    Target from{};
-};
-std::vector<SendTarget> send_targets(const std::string& type, in_port_t port) {
-    std::vector<SendTarget> results;
-
-    // Loop through the active tests and add the send targets
-    // Make sure that the type we are actually after is sent last
-    for (const auto& t : active_tests) {
-        switch (t) {
-            case UNICAST_V4_KNOWN:
-            case UNICAST_V4_EPHEMERAL: {
-                results.push_back(SendTarget{type + ":Uv4", {"127.0.0.1", port}, {}});
-            } break;
-            case UNICAST_V6_KNOWN:
-            case UNICAST_V6_EPHEMERAL: {
-                results.push_back(SendTarget{type + ":Uv6", {"::1", port}, {}});
-            } break;
-            case BROADCAST_V4_KNOWN:
-            case BROADCAST_V4_EPHEMERAL: {
-                results.push_back(SendTarget{type + ":Bv4", {get_broadcast_addr(), port}, {}});
-            } break;
-            case MULTICAST_V4_KNOWN:
-            case MULTICAST_V4_EPHEMERAL: {
-                results.push_back(SendTarget{type + ":Mv4", {IPV4_MULTICAST_ADDRESS, port}, {}});
-            } break;
-            case MULTICAST_V6_KNOWN:
-            case MULTICAST_V6_EPHEMERAL: {
-                results.push_back(SendTarget{type + ":Mv6", {IPV6_MULTICAST_ADDRESS, port}, {IPV6_BIND, 0}});
-            } break;
-        }
-    }
-
-    // remove duplicates
-    results.erase(std::unique(results.begin(),
-                              results.end(),
-                              [](const SendTarget& a, const SendTarget& b) {
-                                  return a.to.address == b.to.address && a.to.port == b.to.port && a.data == b.data
-                                         && a.from.address == b.from.address && a.from.port == b.from.port;
-                              }),
-                  results.end());
-
-    // Stable sort so that the type we are after is last
-    std::stable_sort(results.begin(), results.end(), [](const SendTarget& /*a*/, const SendTarget& b) {
-        // We want to sort such that the one we are after is last and everything else is unmodified
-        // That means that every comparision except one should be false
-        // This is because equality is implied if a < b == false and b < a == false
-        // The only time we should return true is when b is our target (which would make a less than it)
-        return b.data.substr(0, 3) == b.data.substr(5, 8);
-    });
-
-    return results;
-}
-
-struct Finished {
-    Finished(std::string name) : name(std::move(name)) {}
-    std::string name;
-};
+}  // namespace
 
 class TestReactor : public test_util::TestBase<TestReactor> {
-private:
+public:
+    struct Finished {
+        Finished(std::string name) : name(std::move(name)) {}
+        std::string name;
+    };
+
+
+    struct SendTarget {
+        std::string data;
+        struct Target {
+            std::string address;
+            in_port_t port = 0;
+        };
+        Target to{};
+        Target from{};
+    };
+
+    std::vector<SendTarget> send_targets(const std::string& type, in_port_t port) const {
+        std::vector<SendTarget> results;
+
+        // Loop through the active tests and add the send targets
+        // Make sure that the type we are actually after is sent last
+        for (const auto& t : active_tests) {
+            switch (t) {
+                case UNICAST_V4_KNOWN:
+                case UNICAST_V4_EPHEMERAL: {
+                    results.push_back(SendTarget{type + ":Uv4", {"127.0.0.1", port}, {}});
+                } break;
+                case UNICAST_V6_KNOWN:
+                case UNICAST_V6_EPHEMERAL: {
+                    results.push_back(SendTarget{type + ":Uv6", {"::1", port}, {}});
+                } break;
+                case BROADCAST_V4_KNOWN:
+                case BROADCAST_V4_EPHEMERAL: {
+                    results.push_back(SendTarget{type + ":Bv4", {get_broadcast_addr(), port}, {}});
+                } break;
+                case MULTICAST_V4_KNOWN:
+                case MULTICAST_V4_EPHEMERAL: {
+                    results.push_back(SendTarget{type + ":Mv4", {IPV4_MULTICAST_ADDRESS, port}, {}});
+                } break;
+                case MULTICAST_V6_KNOWN:
+                case MULTICAST_V6_EPHEMERAL: {
+                    results.push_back(SendTarget{type + ":Mv6", {IPV6_MULTICAST_ADDRESS, port}, {IPV6_BIND, 0}});
+                } break;
+            }
+        }
+
+        // remove duplicates
+        results.erase(std::unique(results.begin(),
+                                  results.end(),
+                                  [](const SendTarget& a, const SendTarget& b) {
+                                      return a.to.address == b.to.address && a.to.port == b.to.port && a.data == b.data
+                                             && a.from.address == b.from.address && a.from.port == b.from.port;
+                                  }),
+                      results.end());
+
+        // Stable sort so that the type we are after is last
+        std::stable_sort(results.begin(), results.end(), [](const SendTarget& /*a*/, const SendTarget& b) {
+            // We want to sort such that the one we are after is last and everything else is unmodified
+            // That means that every comparision except one should be false
+            // This is because equality is implied if a < b == false and b < a == false
+            // The only time we should return true is when b is our target (which would make a less than it)
+            return b.data.substr(0, 3) == b.data.substr(5, 8);
+        });
+
+        return results;
+    }
+
     void handle_data(const std::string& name, const UDP::Packet& packet) {
         const std::string data(packet.payload.begin(), packet.payload.end());
 
@@ -176,8 +181,8 @@ private:
         }
     }
 
-public:
-    TestReactor(std::unique_ptr<NUClear::Environment> environment) : TestBase(std::move(environment), false) {
+    TestReactor(std::unique_ptr<NUClear::Environment> environment, const std::vector<TestType>& active_tests_)
+        : TestBase(std::move(environment), false), active_tests(active_tests_) {
 
         for (const auto& t : active_tests) {
             switch (t) {
@@ -343,7 +348,17 @@ public:
         });
     }
 
+    /// Events that occur during the test
+    std::vector<std::string> events;
+
+    in_port_t uni_v4_port   = 0;  // Ephemeral port for IPv4 unicast
+    in_port_t uni_v6_port   = 0;  // Ephemeral port for IPv6 unicast
+    in_port_t broad_v4_port = 0;  // Ephemeral port for IPv4 broadcast
+    in_port_t multi_v4_port = 0;  // Ephemeral port for IPv4 multicast
+    in_port_t multi_v6_port = 0;  // Ephemeral port for IPv6 multicast
+
 private:
+    std::vector<TestType> active_tests;  // The active tests to run
     size_t test_no = 0;
 };
 
@@ -351,6 +366,7 @@ private:
 TEST_CASE("Testing sending and receiving of UDP messages", "[api][network][udp]") {
 
     // Build up the list of active tests based on what we have available
+    std::vector<TestType> active_tests;
     active_tests.push_back(UNICAST_V4_KNOWN);
     active_tests.push_back(UNICAST_V4_EPHEMERAL);
     if (test_util::has_ipv6()) {
@@ -371,7 +387,7 @@ TEST_CASE("Testing sending and receiving of UDP messages", "[api][network][udp]"
     NUClear::PowerPlant plant(config);
     test_util::add_tracing(plant);
     plant.install<NUClear::extension::IOController>();
-    plant.install<TestReactor>();
+    const auto& reactor = plant.install<TestReactor>(active_tests);
     plant.start();
 
     std::vector<std::string> expected;
@@ -379,7 +395,7 @@ TEST_CASE("Testing sending and receiving of UDP messages", "[api][network][udp]"
         switch (t) {
             case UNICAST_V4_KNOWN: {
                 expected.push_back("- Known Unicast V4 Test -");
-                for (const auto& line : send_targets("Uv4K", UNICAST_V4)) {
+                for (const auto& line : reactor.send_targets("Uv4K", UNICAST_V4)) {
                     expected.push_back(" -> " + line.to.address + ":" + std::to_string(line.to.port));
                 }
                 expected.push_back("Uv4K <- Uv4K:Uv4 (127.0.0.1:" + std::to_string(UNICAST_V4) + ")");
@@ -387,15 +403,15 @@ TEST_CASE("Testing sending and receiving of UDP messages", "[api][network][udp]"
 
             case UNICAST_V4_EPHEMERAL: {
                 expected.push_back("- Ephemeral Unicast V4 Test -");
-                for (const auto& line : send_targets("Uv4E", uni_v4_port)) {
+                for (const auto& line : reactor.send_targets("Uv4E", reactor.uni_v4_port)) {
                     expected.push_back(" -> " + line.to.address + ":" + std::to_string(line.to.port));
                 }
-                expected.push_back("Uv4E <- Uv4E:Uv4 (127.0.0.1:" + std::to_string(uni_v4_port) + ")");
+                expected.push_back("Uv4E <- Uv4E:Uv4 (127.0.0.1:" + std::to_string(reactor.uni_v4_port) + ")");
             } break;
 
             case UNICAST_V6_KNOWN: {
                 expected.push_back("- Known Unicast V6 Test -");
-                for (const auto& line : send_targets("Uv6K", UNICAST_V6)) {
+                for (const auto& line : reactor.send_targets("Uv6K", UNICAST_V6)) {
                     expected.push_back(" -> " + line.to.address + ":" + std::to_string(line.to.port));
                 }
                 expected.push_back("Uv6K <- Uv6K:Uv6 (::1:" + std::to_string(UNICAST_V6) + ")");
@@ -403,15 +419,15 @@ TEST_CASE("Testing sending and receiving of UDP messages", "[api][network][udp]"
 
             case UNICAST_V6_EPHEMERAL: {
                 expected.push_back("- Ephemeral Unicast V6 Test -");
-                for (const auto& line : send_targets("Uv6E", uni_v6_port)) {
+                for (const auto& line : reactor.send_targets("Uv6E", reactor.uni_v6_port)) {
                     expected.push_back(" -> " + line.to.address + ":" + std::to_string(line.to.port));
                 }
-                expected.push_back("Uv6E <- Uv6E:Uv6 (::1:" + std::to_string(uni_v6_port) + ")");
+                expected.push_back("Uv6E <- Uv6E:Uv6 (::1:" + std::to_string(reactor.uni_v6_port) + ")");
             } break;
 
             case BROADCAST_V4_KNOWN: {
                 expected.push_back("- Known Broadcast V4 Test -");
-                for (const auto& line : send_targets("Bv4K", BROADCAST_V4)) {
+                for (const auto& line : reactor.send_targets("Bv4K", BROADCAST_V4)) {
                     expected.push_back(" -> " + line.to.address + ":" + std::to_string(line.to.port));
                 }
                 expected.push_back("Bv4K <- Bv4K:Bv4 (" + get_broadcast_addr() + ":" + std::to_string(BROADCAST_V4)
@@ -420,16 +436,16 @@ TEST_CASE("Testing sending and receiving of UDP messages", "[api][network][udp]"
 
             case BROADCAST_V4_EPHEMERAL: {
                 expected.push_back("- Ephemeral Broadcast V4 Test -");
-                for (const auto& line : send_targets("Bv4E", broad_v4_port)) {
+                for (const auto& line : reactor.send_targets("Bv4E", reactor.broad_v4_port)) {
                     expected.push_back(" -> " + line.to.address + ":" + std::to_string(line.to.port));
                 }
-                expected.push_back("Bv4E <- Bv4E:Bv4 (" + get_broadcast_addr() + ":" + std::to_string(broad_v4_port)
-                                   + ")");
+                expected.push_back("Bv4E <- Bv4E:Bv4 (" + get_broadcast_addr() + ":"
+                                   + std::to_string(reactor.broad_v4_port) + ")");
             } break;
 
             case MULTICAST_V4_KNOWN: {
                 expected.push_back("- Known Multicast V4 Test -");
-                for (const auto& line : send_targets("Mv4K", MULTICAST_V4)) {
+                for (const auto& line : reactor.send_targets("Mv4K", MULTICAST_V4)) {
                     expected.push_back(" -> " + line.to.address + ":" + std::to_string(line.to.port));
                 }
                 expected.push_back("Mv4K <- Mv4K:Mv4 (" + IPV4_MULTICAST_ADDRESS + ":" + std::to_string(MULTICAST_V4)
@@ -438,16 +454,16 @@ TEST_CASE("Testing sending and receiving of UDP messages", "[api][network][udp]"
 
             case MULTICAST_V4_EPHEMERAL: {
                 expected.push_back("- Ephemeral Multicast V4 Test -");
-                for (const auto& line : send_targets("Mv4E", multi_v4_port)) {
+                for (const auto& line : reactor.send_targets("Mv4E", reactor.multi_v4_port)) {
                     expected.push_back(" -> " + line.to.address + ":" + std::to_string(line.to.port));
                 }
-                expected.push_back("Mv4E <- Mv4E:Mv4 (" + IPV4_MULTICAST_ADDRESS + ":" + std::to_string(multi_v4_port)
-                                   + ")");
+                expected.push_back("Mv4E <- Mv4E:Mv4 (" + IPV4_MULTICAST_ADDRESS + ":"
+                                   + std::to_string(reactor.multi_v4_port) + ")");
             } break;
 
             case MULTICAST_V6_KNOWN: {
                 expected.push_back("- Known Multicast V6 Test -");
-                for (const auto& line : send_targets("Mv6K", MULTICAST_V6)) {
+                for (const auto& line : reactor.send_targets("Mv6K", MULTICAST_V6)) {
                     expected.push_back(" -> " + line.to.address + ":" + std::to_string(line.to.port));
                 }
                 expected.push_back("Mv6K <- Mv6K:Mv6 (" + IPV6_MULTICAST_ADDRESS + ":" + std::to_string(MULTICAST_V6)
@@ -456,18 +472,18 @@ TEST_CASE("Testing sending and receiving of UDP messages", "[api][network][udp]"
 
             case MULTICAST_V6_EPHEMERAL: {
                 expected.push_back("- Ephemeral Multicast V6 Test -");
-                for (const auto& line : send_targets("Mv6E", multi_v6_port)) {
+                for (const auto& line : reactor.send_targets("Mv6E", reactor.multi_v6_port)) {
                     expected.push_back(" -> " + line.to.address + ":" + std::to_string(line.to.port));
                 }
-                expected.push_back("Mv6E <- Mv6E:Mv6 (" + IPV6_MULTICAST_ADDRESS + ":" + std::to_string(multi_v6_port)
-                                   + ")");
+                expected.push_back("Mv6E <- Mv6E:Mv6 (" + IPV6_MULTICAST_ADDRESS + ":"
+                                   + std::to_string(reactor.multi_v6_port) + ")");
             } break;
         }
     }
 
     // Make an info print the diff in an easy to read way if we fail
-    INFO(test_util::diff_string(expected, events));
+    INFO(test_util::diff_string(expected, reactor.events));
 
     // Check the events fired in order and only those events
-    REQUIRE(events == expected);
+    REQUIRE(reactor.events == expected);
 }

--- a/tests/tests/dsl/Watchdog.cpp
+++ b/tests/tests/dsl/Watchdog.cpp
@@ -23,11 +23,11 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/Watchdog.cpp
+++ b/tests/tests/dsl/Watchdog.cpp
@@ -20,10 +20,13 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
-#include <numeric>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"

--- a/tests/tests/dsl/With.cpp
+++ b/tests/tests/dsl/With.cpp
@@ -23,11 +23,11 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/With.cpp
+++ b/tests/tests/dsl/With.cpp
@@ -20,8 +20,13 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/emit/Delay.cpp
+++ b/tests/tests/dsl/emit/Delay.cpp
@@ -20,8 +20,14 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"

--- a/tests/tests/dsl/emit/Delay.cpp
+++ b/tests/tests/dsl/emit/Delay.cpp
@@ -24,11 +24,11 @@
 #include <catch2/catch_test_macros.hpp>
 #include <chrono>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/TimeUnit.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/dsl/emit/EmitFusion.cpp
+++ b/tests/tests/dsl/emit/EmitFusion.cpp
@@ -23,11 +23,11 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 
 namespace {  // Anonymous namespace for internal linkage

--- a/tests/tests/dsl/emit/EmitFusion.cpp
+++ b/tests/tests/dsl/emit/EmitFusion.cpp
@@ -20,12 +20,17 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
-#include "test_util/common.hpp"
+
+namespace {  // Anonymous namespace for internal linkage
 
 /// Events that occur during the test
 std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables,-warnings-as-errors)
@@ -33,30 +38,32 @@ std::vector<std::string> events;  // NOLINT(cppcoreguidelines-avoid-non-const-gl
 template <typename T>
 struct E1 {
     static void emit(const NUClear::PowerPlant& /*powerplant*/,
-                     std::shared_ptr<T> p,
+                     const std::shared_ptr<T>& p,
                      const int& a,
                      const std::string& b) {
         events.push_back("E1a " + *p + " " + std::to_string(a) + " " + b);
     }
 
-    static void emit(const NUClear::PowerPlant& /*powerplant*/, std::shared_ptr<T> p, const std::string& c) {
+    static void emit(const NUClear::PowerPlant& /*powerplant*/, const std::shared_ptr<T>& p, const std::string& c) {
         events.push_back("E1b " + *p + " " + c);
     }
 };
 
 template <typename T>
 struct E2 {
-    static void emit(const NUClear::PowerPlant& /*powerplant*/, std::shared_ptr<T> p, const bool& d) {
+    static void emit(const NUClear::PowerPlant& /*powerplant*/, const std::shared_ptr<T>& p, const bool& d) {
         events.push_back("E2a " + *p + " " + (d ? "true" : "false"));
     }
 
     static void emit(const NUClear::PowerPlant& /*powerplant*/,
-                     std::shared_ptr<T> p,
+                     const std::shared_ptr<T>& p,
                      const int& e,
                      const std::string& f) {
         events.push_back("E2b " + *p + " " + std::to_string(e) + " " + f);
     }
 };
+
+}  // namespace
 
 class TestReactor : public test_util::TestBase<TestReactor> {
 public:

--- a/tests/tests/dsl/emit/Initialise.cpp
+++ b/tests/tests/dsl/emit/Initialise.cpp
@@ -23,11 +23,11 @@
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"
 

--- a/tests/tests/dsl/emit/Initialise.cpp
+++ b/tests/tests/dsl/emit/Initialise.cpp
@@ -20,8 +20,13 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/TestBase.hpp"
 #include "test_util/common.hpp"

--- a/tests/tests/log/Log.cpp
+++ b/tests/tests/log/Log.cpp
@@ -23,11 +23,11 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cstddef>
 #include <memory>
-#include <nuclear>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "nuclear"
 #include "test_util/common.hpp"
 
 namespace {  // Anonymous namespace for internal linkage

--- a/tests/tests/log/Log.cpp
+++ b/tests/tests/log/Log.cpp
@@ -21,11 +21,16 @@
  */
 
 #include <catch2/catch_test_macros.hpp>
-#include <iostream>
+#include <cstddef>
+#include <memory>
 #include <nuclear>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "test_util/common.hpp"
-#include "test_util/executable_path.hpp"
+
+namespace {  // Anonymous namespace for internal linkage
 
 // This is a free floating function that we can use to test the log function when not in a reactor
 template <NUClear::LogLevel::Value level, typename... Args>
@@ -41,6 +46,8 @@ struct LogTestOutput {
 
 /// All the log messages received
 std::vector<LogTestOutput> messages;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+}  // namespace
 
 // All the log levels
 // NOLINTNEXTLINE(cert-err58-cpp,cppcoreguidelines-avoid-non-const-global-variables)

--- a/tests/tests/threading/CountingLock.cpp
+++ b/tests/tests/threading/CountingLock.cpp
@@ -41,8 +41,8 @@ namespace threading {
                 std::atomic<int> active{2 * base + offset};
 
                 WHEN("Two locks are attempted") {
-                    std::unique_ptr<Lock> a1 = std::make_unique<CountingLock>(active, -base, offset);
-                    std::unique_ptr<Lock> a2 = std::make_unique<CountingLock>(active, -base, offset);
+                    auto a1 = std::make_unique<CountingLock>(active, -base, offset);
+                    auto a2 = std::make_unique<CountingLock>(active, -base, offset);
 
                     THEN("The last lock should obtain the lock") {
                         CHECK(a1->lock() == false);
@@ -51,7 +51,7 @@ namespace threading {
 
                     AND_WHEN("The locked lock is released and a third lock is attempted") {
                         a2.reset();
-                        std::unique_ptr<Lock> a3 = std::make_unique<CountingLock>(active, -base, offset);
+                        auto a3 = std::make_unique<CountingLock>(active, -base, offset);
 
                         THEN("Only the third lock should obtain the lock") {
                             CHECK(a1->lock() == false);
@@ -61,7 +61,7 @@ namespace threading {
 
                     AND_WHEN("The unlocked lock is released and a third lock is attempted") {
                         a1.reset();
-                        std::unique_ptr<Lock> a3 = std::make_unique<CountingLock>(active, -base, offset);
+                        auto a3 = std::make_unique<CountingLock>(active, -base, offset);
 
                         THEN("The third lock should obtain the lock as well") {
                             CHECK(a2->lock() == true);

--- a/tests/tests/threading/CountingLock.cpp
+++ b/tests/tests/threading/CountingLock.cpp
@@ -21,6 +21,7 @@
  */
 #include "threading/scheduler/CountingLock.hpp"
 
+#include <atomic>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 #include <memory>

--- a/tests/tests/threading/Group.cpp
+++ b/tests/tests/threading/Group.cpp
@@ -22,8 +22,10 @@
 #include "threading/scheduler/Group.hpp"
 
 #include <array>
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <memory>
 
 namespace NUClear {
 namespace threading {

--- a/tests/tests/threading/Group.cpp
+++ b/tests/tests/threading/Group.cpp
@@ -27,6 +27,10 @@
 #include <catch2/generators/catch_generators.hpp>
 #include <memory>
 
+#include "id.hpp"
+#include "threading/scheduler/Lock.hpp"
+#include "util/GroupDescriptor.hpp"
+
 namespace NUClear {
 namespace threading {
     namespace scheduler {

--- a/tests/tests/util/demangle.cpp
+++ b/tests/tests/util/demangle.cpp
@@ -20,12 +20,19 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include "util/demangle.hpp"
+
 #include <catch2/catch_test_macros.hpp>
-#include <nuclear>
 #include <string>
 #include <typeinfo>
 
 struct TestSymbol {};
+
+namespace symbol {
+namespace in_a_namespace {
+    struct NamespacedSymbol {};
+}  // namespace in_a_namespace
+}  // namespace symbol
 
 template <typename T>
 struct TestTemplate {};
@@ -97,8 +104,8 @@ SCENARIO("Test the demangle function correctly demangles symbols", "[util][deman
     }
 
     GIVEN("A symbol in a namespace") {
-        const char* symbol         = typeid(NUClear::message::CommandLineArguments).name();
-        const std::string expected = "NUClear::message::CommandLineArguments";
+        const char* symbol         = typeid(symbol::in_a_namespace::NamespacedSymbol).name();
+        const std::string expected = "symbol::in_a_namespace::NamespacedSymbol";
 
         WHEN("Demangle is called") {
             const std::string result = NUClear::util::demangle(symbol);

--- a/tests/tests/util/network/resolve.cpp
+++ b/tests/tests/util/network/resolve.cpp
@@ -23,6 +23,7 @@
 #include "util/network/resolve.hpp"
 
 #include <catch2/catch_test_macros.hpp>
+#include <cstdint>
 #include <string>
 
 

--- a/tests/tests/util/network/resolve.cpp
+++ b/tests/tests/util/network/resolve.cpp
@@ -26,6 +26,8 @@
 #include <cstdint>
 #include <string>
 
+#include "util/platform.hpp"
+
 
 TEST_CASE("resolve function returns expected socket address", "[util][network][resolve]") {
 

--- a/tests/tests/util/serialise/serialise.cpp
+++ b/tests/tests/util/serialise/serialise.cpp
@@ -28,7 +28,6 @@
 #include <cstdint>
 #include <iterator>
 #include <list>
-#include <ostream>
 #include <stdexcept>
 #include <string>
 #include <type_traits>

--- a/tests/tests/util/serialise/xxhash.cpp
+++ b/tests/tests/util/serialise/xxhash.cpp
@@ -22,6 +22,7 @@
 
 #include "util/serialise/xxhash.hpp"
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 #include <cstdint>

--- a/tests/tests/util/string_join.cpp
+++ b/tests/tests/util/string_join.cpp
@@ -24,7 +24,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
-#include <ostream>
+#include <iosfwd>
 #include <string>
 #include <typeinfo>
 

--- a/tests/tests/util/string_join.cpp
+++ b/tests/tests/util/string_join.cpp
@@ -24,6 +24,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <ostream>
 #include <string>
 #include <typeinfo>
 


### PR DESCRIPTION
Upgrading clang-tidy to version 19 as well as using ubuntu 24.04 for the GHA runners