### PR TITLE
Fix the double forwarding bug in function fusion

### DIFF
--- a/src/PowerPlant.hpp
+++ b/src/PowerPlant.hpp
@@ -311,24 +311,6 @@ public:
         FusionFunction::call(*this, data, std::forward<Arguments>(args)...);
     }
 
-    template <template <typename> class First, template <typename> class... Remainder, typename... Arguments>
-    void emit_shared(Arguments&&... args) {
-
-        using Functions      = std::tuple<First<void>, Remainder<void>...>;
-        using ArgumentPack   = decltype(std::forward_as_tuple(*this, std::forward<Arguments>(args)...));
-        using CallerArgs     = std::tuple<>;
-        using FusionFunction = util::FunctionFusion<Functions, ArgumentPack, EmitCaller, CallerArgs, 1>;
-
-        // Provide a check to make sure they are passing us the right stuff
-        static_assert(
-            FusionFunction::value,
-            "There was an error with the arguments for the emit function, Check that your scope and arguments "
-            "match what you are trying to do.");
-
-        // Fuse our emit handlers and call the fused function
-        FusionFunction::call(*this, std::forward<Arguments>(args)...);
-    }
-
     /// Our TaskScheduler that handles distributing task to the pool threads
     threading::scheduler::Scheduler scheduler;
     /// Our vector of Reactors, will get destructed when this vector is

--- a/src/Reactor.hpp
+++ b/src/Reactor.hpp
@@ -376,7 +376,8 @@ public:
         }
 
     public:
-        Binder(Reactor& r, Arguments&&... args) : reactor(r), args(args...) {}
+        template <typename... Args>
+        Binder(Reactor& r, Args&&... args) : reactor(r), args(std::forward<Args>(args)...) {}
 
         template <typename Label, typename Function>
         auto then(Label&& label, Function&& callback) {

--- a/src/Reactor.hpp
+++ b/src/Reactor.hpp
@@ -135,9 +135,9 @@ namespace dsl {
             template <typename WatchdogGroup, typename RuntimeType>
             struct WatchdogServicer;
             template <typename WatchdogGroup, typename RuntimeType>
-            WatchdogServicer<WatchdogGroup, RuntimeType> ServiceWatchdog(RuntimeType&& data);
+            std::unique_ptr<WatchdogServicer<WatchdogGroup, RuntimeType>> ServiceWatchdog(RuntimeType&& data);
             template <typename WatchdogGroup>
-            WatchdogServicer<WatchdogGroup, void> ServiceWatchdog();
+            std::unique_ptr<WatchdogServicer<WatchdogGroup, void>> ServiceWatchdog();
         }  // namespace emit
     }  // namespace word
 }  // namespace dsl
@@ -272,10 +272,7 @@ protected:
 
     /// @copydoc dsl::word::emit::ServiceWatchdog
     template <typename WatchdogGroup, typename... Arguments>
-    auto ServiceWatchdog(Arguments&&... args)
-        // THIS IS VERY IMPORTANT, the return type must be dependent on the function call
-        // otherwise it won't check it's valid in SFINAE
-        -> decltype(dsl::word::emit::ServiceWatchdog<WatchdogGroup>(std::forward<Arguments>(args)...)) {
+    auto ServiceWatchdog(Arguments&&... args) {
         return dsl::word::emit::ServiceWatchdog<WatchdogGroup>(std::forward<Arguments>(args)...);
     }
 
@@ -368,7 +365,7 @@ public:
                 util::CallbackGenerator<DSL, Function>(std::forward<Function>(callback)));
 
             // Get our tuple from binding our reaction
-            auto tuple = DSL::bind(reaction, std::get<Index>(args)...);
+            auto tuple = DSL::bind(reaction, std::move(std::get<Index>(args))...);
 
             auto handle = threading::ReactionHandle(reaction);
             reactor.reaction_handles.push_back(handle);

--- a/src/dsl/word/emit/Watchdog.hpp
+++ b/src/dsl/word/emit/Watchdog.hpp
@@ -125,8 +125,8 @@ namespace dsl {
              * @return A WatchdogServicer object which will update the service time of the specified watchdog
              */
             template <typename WatchdogGroup, typename RuntimeType>
-            WatchdogServicer<WatchdogGroup, RuntimeType> ServiceWatchdog(RuntimeType&& data) {
-                return WatchdogServicer<WatchdogGroup, RuntimeType>(std::forward<RuntimeType>(data));
+            std::unique_ptr<WatchdogServicer<WatchdogGroup, RuntimeType>> ServiceWatchdog(RuntimeType&& data) {
+                return std::make_unique<WatchdogServicer<WatchdogGroup, RuntimeType>>(std::forward<RuntimeType>(data));
             }
 
             /**
@@ -137,8 +137,8 @@ namespace dsl {
              * @return WatchdogServicer<WatchdogGroup, void>
              */
             template <typename WatchdogGroup>
-            WatchdogServicer<WatchdogGroup, void> ServiceWatchdog() {
-                return WatchdogServicer<WatchdogGroup, void>();
+            std::unique_ptr<WatchdogServicer<WatchdogGroup, void>> ServiceWatchdog() {
+                return std::make_unique<WatchdogServicer<WatchdogGroup, void>>();
             }
 
             /**
@@ -158,9 +158,9 @@ namespace dsl {
 
                 template <typename WatchdogGroup, typename RuntimeType>
                 static void emit(const PowerPlant& /*powerplant*/,
-                                 WatchdogServicer<WatchdogGroup, RuntimeType>& servicer) {
+                                 const std::shared_ptr<WatchdogServicer<WatchdogGroup, RuntimeType>>& servicer) {
                     // Update our service time
-                    servicer.service();
+                    servicer->service();
                 }
             };
 

--- a/src/util/FunctionFusion.hpp
+++ b/src/util/FunctionFusion.hpp
@@ -48,7 +48,7 @@ namespace util {
      * @return The object returned by the called subfunction
      */
     template <typename Function, int... Shared, int... Selected, typename... Arguments>
-    auto apply_function_fusion_call(std::tuple<Arguments...>&& args,
+    auto apply_function_fusion_call(const std::tuple<Arguments...>& args,
                                     const Sequence<Shared...>& /*shared*/,
                                     const Sequence<Selected...>& /*selected*/)
         -> decltype(Function::call(

--- a/src/util/FunctionFusion.hpp
+++ b/src/util/FunctionFusion.hpp
@@ -177,11 +177,7 @@ namespace util {
                                        NextStep::call(std::forward<Args>(args)...))) {
 
             // Call each on a separate line to preserve order of execution
-            // TODO(thouliston) this is a legitimate bug, fix it in a future PR and add a test to ensure it doesn't
-            // regress
-            // NOLINTNEXTLINE(bugprone-use-after-move)
-            auto current = tuplify(call_one<CurrentFunction>(CurrentRange(), std::forward<Args>(args)...));
-            // NOLINTNEXTLINE(bugprone-use-after-move)
+            auto current   = tuplify(call_one<CurrentFunction>(CurrentRange(), std::forward<Args>(args)...));
             auto remainder = NextStep::call(std::forward<Args>(args)...);
 
             return std::tuple_cat(std::move(current), std::move(remainder));

--- a/src/util/FunctionFusion.hpp
+++ b/src/util/FunctionFusion.hpp
@@ -146,14 +146,14 @@ namespace util {
          *
          * @return the result of calling this specific function
          */
-        template <typename Function, int Start, int End>
+        template <typename Function, int Start, int End, typename... Args>
         // It is forwarded as a tuple
-        static auto call_one(const Sequence<Start, End>& /*e*/, Arguments&&... args)
+        static auto call_one(const Sequence<Start, End>& /*e*/, Args&&... args)
             -> decltype(apply_function_fusion_call<Function, Shared, Start, End>(
-                std::forward_as_tuple(std::forward<Arguments>(args)...))) {
+                std::forward_as_tuple(std::forward<Args>(args)...))) {
 
             return apply_function_fusion_call<Function, Shared, Start, End>(
-                std::forward_as_tuple(std::forward<Arguments>(args)...));
+                std::forward_as_tuple(std::forward<Args>(args)...));
         }
 
         /**

--- a/src/util/FunctionFusion.hpp
+++ b/src/util/FunctionFusion.hpp
@@ -48,11 +48,13 @@ namespace util {
      * @return The object returned by the called subfunction
      */
     template <typename Function, int... Shared, int... Selected, typename... Arguments>
-    auto apply_function_fusion_call(const std::tuple<Arguments...>& args,
+    auto apply_function_fusion_call(std::tuple<Arguments...>&& args,
                                     const Sequence<Shared...>& /*shared*/,
                                     const Sequence<Selected...>& /*selected*/)
         -> decltype(Function::call(std::get<Shared>(args)..., std::get<Selected>(args)...)) {
-        return Function::call(std::get<Shared>(args)..., std::get<Selected>(args)...);
+        return Function::call(
+            static_cast<std::tuple_element_t<Shared, std::tuple<Arguments...>>>(std::get<Shared>(args))...,
+            static_cast<std::tuple_element_t<Selected, std::tuple<Arguments...>>>(std::get<Selected>(args))...);
     }
 
     /**

--- a/src/util/FunctionFusion.hpp
+++ b/src/util/FunctionFusion.hpp
@@ -20,8 +20,8 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef NUCLEAR_UTIL_FUNCTIONFUSION_HPP
-#define NUCLEAR_UTIL_FUNCTIONFUSION_HPP
+#ifndef NUCLEAR_UTIL_FUNCTION_FUSION_HPP
+#define NUCLEAR_UTIL_FUNCTION_FUSION_HPP
 
 #include "Sequence.hpp"
 #include "tuplify.hpp"
@@ -140,11 +140,12 @@ namespace util {
          */
         template <typename Function, int Start, int End>
         // It is forwarded as a tuple
-        // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
         static auto call_one(const Sequence<Start, End>& /*e*/, Arguments&&... args)
-            -> decltype(apply_function_fusion_call<Function, Shared, Start, End>(std::forward_as_tuple(args...))) {
+            -> decltype(apply_function_fusion_call<Function, Shared, Start, End>(
+                std::forward_as_tuple(std::forward<Arguments>(args)...))) {
 
-            return apply_function_fusion_call<Function, Shared, Start, End>(std::forward_as_tuple(args...));
+            return apply_function_fusion_call<Function, Shared, Start, End>(
+                std::forward_as_tuple(std::forward<Arguments>(args)...));
         }
 
         /**
@@ -361,4 +362,4 @@ namespace util {
 }  // namespace util
 }  // namespace NUClear
 
-#endif  // NUCLEAR_UTIL_FUNCTIONFUSION_HPP
+#endif  // NUCLEAR_UTIL_FUNCTION_FUSION_HPP

--- a/src/util/Sequence.hpp
+++ b/src/util/Sequence.hpp
@@ -23,6 +23,8 @@
 #ifndef NUCLEAR_UTIL_SEQUENCE_HPP
 #define NUCLEAR_UTIL_SEQUENCE_HPP
 
+#include <type_traits>
+
 namespace NUClear {
 namespace util {
 

--- a/tests/tests/util/FunctionFusion.cpp
+++ b/tests/tests/util/FunctionFusion.cpp
@@ -91,8 +91,6 @@ template <typename T>
 struct AppendCaller {
     template <typename... Args>
     static auto call(Args&&... args) -> decltype(T::append(std::forward<Args>(args)...)) {
-
-        std::cout << "Received: " << NUClear::util::demangle(typeid(std::tuple<Args...>).name()) << std::endl;
         return T::append(std::forward<Args>(args)...);
     }
 };

--- a/tests/tests/util/FunctionFusion.cpp
+++ b/tests/tests/util/FunctionFusion.cpp
@@ -49,8 +49,10 @@ struct Appender {
         const std::vector<char> x1 = std::move(x);
         const std::vector<char> y1 = std::move(y);
 
-        std::vector<char> out = {'r', 'r'};
-        out.insert(out.end(), x1.begin(), x1.end());
+        std::vector<char> out;
+        out.push_back('r');
+        out.push_back('r');
+        out.insert(out.end(), x1.begin(), x1.end());  // HERE
         out.insert(out.end(), y1.begin(), y1.end());
 
         return out;
@@ -61,7 +63,9 @@ struct Appender {
         const std::vector<char> x1 = std::move(x);
         const auto& y1             = y;
 
-        std::vector<char> out = {'l', 'r'};
+        std::vector<char> out;
+        out.push_back('r');
+        out.push_back('l');
         out.insert(out.end(), x1.begin(), x1.end());
         out.insert(out.end(), y1.begin(), y1.end());
 
@@ -73,8 +77,10 @@ struct Appender {
         const auto& x1             = x;
         const std::vector<char> y1 = std::move(y);
 
-        std::vector<char> out = {'l', 'r'};
-        out.insert(out.end(), x1.begin(), x1.end());
+        std::vector<char> out;
+        out.push_back('l');
+        out.push_back('r');
+        out.insert(out.end(), x1.begin(), x1.end());  // HERE
         out.insert(out.end(), y1.begin(), y1.end());
 
         return out;
@@ -85,7 +91,9 @@ struct Appender {
         const auto& x1 = x;
         const auto& y1 = y;
 
-        std::vector<char> out = {'l', 'l'};
+        std::vector<char> out;
+        out.push_back('l');
+        out.push_back('l');
         out.insert(out.end(), x.begin(), x.end());
         out.insert(out.end(), y.begin(), y.end());
 

--- a/tests/tests/util/FunctionFusion.cpp
+++ b/tests/tests/util/FunctionFusion.cpp
@@ -20,12 +20,18 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include "util/FunctionFusion.hpp"
+
 #include <catch2/catch_test_macros.hpp>
-#include <memory>
+#include <tuple>
 #include <utility>
 #include <vector>
 
-#include "nuclear"
+
+// There are several linting rules from clang-tidy that will trigger in this code.
+// However as the point of these tests is to show what the behaviour is in these situations they are suppressed for this
+// file
+// NOLINTBEGIN(bugprone-use-after-move)
 
 namespace {  // Make everything here internal linkage
 
@@ -40,8 +46,8 @@ struct Appender {
 
     /// rvalue/rvalue
     static std::vector<char> append(std::vector<char>&& x, std::vector<char>&& y) {
-        std::vector<char> x1 = std::move(x);
-        std::vector<char> y1 = std::move(y);
+        const std::vector<char> x1 = std::move(x);
+        const std::vector<char> y1 = std::move(y);
 
         std::vector<char> out = {'r', 'r'};
         out.insert(out.end(), x1.begin(), x1.end());
@@ -52,8 +58,8 @@ struct Appender {
 
     /// rvalue/lvalue
     static std::vector<char> append(std::vector<char>&& x, const std::vector<char>& y) {
-        std::vector<char> x1 = std::move(x);
-        const auto& y1       = y;
+        const std::vector<char> x1 = std::move(x);
+        const auto& y1             = y;
 
         std::vector<char> out = {'l', 'r'};
         out.insert(out.end(), x1.begin(), x1.end());
@@ -64,8 +70,8 @@ struct Appender {
 
     /// lvalue/rvalue
     static std::vector<char> append(const std::vector<char>& x, std::vector<char>&& y) {
-        const auto& x1       = x;
-        std::vector<char> y1 = std::move(y);
+        const auto& x1             = x;
+        const std::vector<char> y1 = std::move(y);
 
         std::vector<char> out = {'l', 'r'};
         out.insert(out.end(), x1.begin(), x1.end());
@@ -154,3 +160,5 @@ SCENARIO("Shared arguments to FunctionFusion are not moved", "[util][FunctionFus
         }
     }
 }
+
+// NOLINTEND(bugprone-use-after-move)

--- a/tests/tests/util/FunctionFusion.cpp
+++ b/tests/tests/util/FunctionFusion.cpp
@@ -1,0 +1,158 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 NUClear Contributors
+ *
+ * This file is part of the NUClear codebase.
+ * See https://github.com/Fastcode/NUClear for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "nuclear"
+
+namespace {  // Make everything here internal linkage
+
+/**
+ * This struct is used to test what is passed from FunctionFusion to the call function.
+ *
+ * It has four different versions of append to see which one is called
+ * The ones that take rvalue references will move the arguments into new temporaries to ensure the original arguments
+ * will be empty after the function runs.
+ */
+struct Appender {
+
+    /// rvalue/rvalue
+    static std::vector<char> append(std::vector<char>&& x, std::vector<char>&& y) {
+        std::vector<char> x1 = std::move(x);
+        std::vector<char> y1 = std::move(y);
+
+        std::vector<char> out = {'r', 'r'};
+        out.insert(out.end(), x1.begin(), x1.end());
+        out.insert(out.end(), y1.begin(), y1.end());
+
+        return out;
+    }
+
+    /// rvalue/lvalue
+    static std::vector<char> append(std::vector<char>&& x, const std::vector<char>& y) {
+        std::vector<char> x1 = std::move(x);
+        const auto& y1       = y;
+
+        std::vector<char> out = {'l', 'r'};
+        out.insert(out.end(), x1.begin(), x1.end());
+        out.insert(out.end(), y1.begin(), y1.end());
+
+        return out;
+    }
+
+    /// lvalue/rvalue
+    static std::vector<char> append(const std::vector<char>& x, std::vector<char>&& y) {
+        const auto& x1       = x;
+        std::vector<char> y1 = std::move(y);
+
+        std::vector<char> out = {'l', 'r'};
+        out.insert(out.end(), x1.begin(), x1.end());
+        out.insert(out.end(), y1.begin(), y1.end());
+
+        return out;
+    }
+
+    /// lvalue/lvalue
+    static std::vector<char> append(const std::vector<char>& x, const std::vector<char>& y) {
+        const auto& x1 = x;
+        const auto& y1 = y;
+
+        std::vector<char> out = {'l', 'l'};
+        out.insert(out.end(), x.begin(), x.end());
+        out.insert(out.end(), y.begin(), y.end());
+
+        return out;
+    }
+};
+
+template <typename T>
+struct AppendCaller {
+    template <typename... Args>
+    static auto call(Args&&... args) -> decltype(T::append(std::forward<Args>(args)...)) {
+
+        std::cout << "Received: " << NUClear::util::demangle(typeid(std::tuple<Args...>).name()) << std::endl;
+        return T::append(std::forward<Args>(args)...);
+    }
+};
+
+template <int Shared, typename... Args>
+auto do_fusion(Args&&... args) {
+    return NUClear::util::FunctionFusion<std::tuple<Appender, Appender>,
+                                         decltype(std::forward_as_tuple(std::forward<Args>(args)...)),
+                                         AppendCaller,
+                                         std::tuple<>,
+                                         Shared>::call(std::forward<Args>(args)...);
+}
+
+}  // namespace
+
+SCENARIO("Shared arguments to FunctionFusion are not moved", "[util][FunctionFusion][shared][move]") {
+
+    WHEN("calling append with 1 shared and 1 selected arguments") {
+        std::vector<char> shared({'s'});
+        std::vector<char> arg1({'1'});
+        std::vector<char> arg2({'2'});
+
+        auto result = do_fusion<1>(std::move(shared), std::move(arg1), std::move(arg2));
+
+        const auto& r1 = std::get<0>(result);
+        const auto& r2 = std::get<1>(result);
+
+        THEN("the results are correct") {
+            CHECK(r1 == std::vector<char>({'l', 'r', 's', '1'}));
+            CHECK(r2 == std::vector<char>({'l', 'r', 's', '2'}));
+        }
+        THEN("the shared argument is not moved") {
+            CHECK(shared == std::vector<char>({'s'}));
+        }
+        THEN("the selected arguments are moved") {
+            CHECK(arg1.empty());
+            CHECK(arg2.empty());
+        }
+    }
+
+    WHEN("calling append with 0 shared and 2 selected arguments") {
+        std::vector<char> arg1({'1'});
+        std::vector<char> arg2({'2'});
+        std::vector<char> arg3({'3'});
+        std::vector<char> arg4({'4'});
+
+        auto result = do_fusion<0>(std::move(arg1), std::move(arg2), std::move(arg3), std::move(arg4));
+
+        const auto& r1 = std::get<0>(result);
+        const auto& r2 = std::get<1>(result);
+
+        THEN("the results are correct") {
+            CHECK(r1 == std::vector<char>({'r', 'r', '1', '2'}));
+            CHECK(r2 == std::vector<char>({'r', 'r', '3', '4'}));
+        }
+        THEN("the selected arguments are moved") {
+            CHECK(arg1.empty());
+            CHECK(arg2.empty());
+            CHECK(arg3.empty());
+            CHECK(arg4.empty());
+        }
+    }
+}

--- a/tests/tests/util/moving.cpp
+++ b/tests/tests/util/moving.cpp
@@ -42,6 +42,16 @@ void perfect_forwarding(T&& v) {
     std::vector<int> v2 = std::forward<T>(v);
 }
 
+template <typename T>
+void perfect_forwarding_to_assign(T&& v) {
+    assign(std::forward<T>(v));
+}
+
+template <typename T>
+void perfect_forwarding_to_assign_with_move(T&& v) {
+    assign_with_move(std::forward<T>(v));
+}
+
 }  // namespace
 
 SCENARIO("Testing how rvalues are handled") {
@@ -80,6 +90,22 @@ SCENARIO("Testing how rvalues are handled") {
             perfect_forwarding(v1);
             THEN("the vector still has the data") {
                 REQUIRE(v1 == std::vector<int>{0, 1});
+            }
+        }
+
+        WHEN("moving it to a function that assigns with perfect forwarding") {
+            perfect_forwarding_to_assign(std::move(v1));
+            THEN("the vector is not empty") {
+                REQUIRE(v1 == std::vector<int>{0, 1});
+            }
+        }
+
+        WHEN(
+            "moving it to a function as an rvalue and assigns it to a new vector with std::move with perfect "
+            "forwarding") {
+            perfect_forwarding_to_assign_with_move(std::move(v1));
+            THEN("the vector is empty") {
+                REQUIRE(v1 == std::vector<int>{});
             }
         }
     }

--- a/tests/tests/util/moving.cpp
+++ b/tests/tests/util/moving.cpp
@@ -21,7 +21,13 @@
  */
 
 #include <catch2/catch_test_macros.hpp>
+#include <utility>
 #include <vector>
+
+// There are several linting rules from clang-tidy that will trigger in this code.
+// However as the point of these tests is to show what the behaviour is in these situations they are suppressed for this
+// file
+// NOLINTBEGIN(bugprone-use-after-move,cppcoreguidelines-rvalue-reference-param-not-moved,performance-unnecessary-copy-initialization)
 
 namespace {  // Internal linkage
 
@@ -30,16 +36,16 @@ void do_nothing(std::vector<int>&& v) {
 }
 
 void assign(std::vector<int>&& v) {
-    std::vector<int> v2 = v;
+    const std::vector<int> v2 = v;
 }
 
 void assign_with_move(std::vector<int>&& v) {
-    std::vector<int> v2 = std::move(v);
+    const std::vector<int> v2 = std::move(v);
 }
 
 template <typename T>
 void perfect_forwarding(T&& v) {
-    std::vector<int> v2 = std::forward<T>(v);
+    const std::vector<int> v2 = std::forward<T>(v);
 }
 
 template <typename T>
@@ -92,14 +98,14 @@ SCENARIO("Test to ensure that l and r values operate according to the standard")
         WHEN("moving it to a function that assigns with perfect forwarding") {
             perfect_forwarding(std::move(v1));
             THEN("the vector is empty") {
-                REQUIRE(v1 == std::vector<int>{});
+                REQUIRE(v1.empty());
             }
         }
 
         WHEN("moving it to a function as an rvalue and assigns it to a new vector with std::move") {
             assign_with_move(std::move(v1));
             THEN("the vector is empty") {
-                REQUIRE(v1 == std::vector<int>{});
+                REQUIRE(v1.empty());
             }
         }
 
@@ -118,12 +124,14 @@ SCENARIO("Test to ensure that l and r values operate according to the standard")
         }
 
         WHEN(
-            "moving it to a function as an rvalue and assigns it to a new vector with std::move with perfect "
+            "moving it to a function as an rvalue and assigning to a new vector with std::move with perfect "
             "forwarding") {
             perfect_forwarding_to_assign_with_move(std::move(v1));
             THEN("the vector is empty") {
-                REQUIRE(v1 == std::vector<int>{});
+                REQUIRE(v1.empty());
             }
         }
     }
 }
+
+// NOLINTEND(bugprone-use-after-move,cppcoreguidelines-rvalue-reference-param-not-moved,performance-unnecessary-copy-initialization)

--- a/tests/tests/util/moving.cpp
+++ b/tests/tests/util/moving.cpp
@@ -1,0 +1,86 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 NUClear Contributors
+ *
+ * This file is part of the NUClear codebase.
+ * See https://github.com/Fastcode/NUClear for further info.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <vector>
+
+namespace {  // Internal linkage
+
+void do_nothing(std::vector<int>&& v) {
+    // Do nothing with v
+}
+
+void assign(std::vector<int>&& v) {
+    std::vector<int> v2 = v;
+}
+
+void assign_with_move(std::vector<int>&& v) {
+    std::vector<int> v2 = std::move(v);
+}
+
+template <typename T>
+void perfect_forwarding(T&& v) {
+    std::vector<int> v2 = std::forward<T>(v);
+}
+
+}  // namespace
+
+SCENARIO("Testing how rvalues are handled") {
+    GIVEN("a vector with some data") {
+        std::vector<int> v1 = {0, 1};
+
+        WHEN("moving it to a function that does nothing") {
+            do_nothing(std::move(v1));
+            THEN("the vector still has the data") {
+                CHECK(v1 == std::vector<int>{0, 1});
+            }
+        }
+
+        WHEN("moving it to a function as an rvalue and assigns it to a new vector") {
+            assign(std::move(v1));
+            THEN("the vector still has the data") {
+                REQUIRE(v1 == std::vector<int>{0, 1});
+            }
+        }
+
+        WHEN("moving it to a function that assigns with perfect forwarding") {
+            perfect_forwarding(std::move(v1));
+            THEN("the vector is empty") {
+                REQUIRE(v1 == std::vector<int>{});
+            }
+        }
+
+        WHEN("moving it to a function as an rvalue and assigns it to a new vector with std::move") {
+            assign_with_move(std::move(v1));
+            THEN("the vector is empty") {
+                REQUIRE(v1 == std::vector<int>{});
+            }
+        }
+
+        WHEN("not moving it to a function with perfect forwarding") {
+            perfect_forwarding(v1);
+            THEN("the vector still has the data") {
+                REQUIRE(v1 == std::vector<int>{0, 1});
+            }
+        }
+    }
+}

--- a/tests/tests/util/moving.cpp
+++ b/tests/tests/util/moving.cpp
@@ -54,7 +54,24 @@ void perfect_forwarding_to_assign_with_move(T&& v) {
 
 }  // namespace
 
-SCENARIO("Testing how rvalues are handled") {
+/**
+ * This test is mostly here to encode an understanding of l/r values in code.
+ *
+ * When a function receives a value as an "rvalue reference" it is still an lvalue as it has a name even though it's an
+ * lvalue reference to an rvalue. To make it back into an rvalue reference you need to do a static cast to an rvalue.
+ * Typically this is done with std::move or std::forward.
+ *
+ * These casts don't actually do anything to the underlying data, they just change the type of the reference.
+ * So if you do one of these casts, but then don't actually do anything with the reference, the data will still be in
+ * the same state as it was before the cast.
+ *
+ * As a result, if you std::move a variable into a function but that function doesn't do anything with the variable, the
+ * result will be no change to the variable.
+ *
+ * Therefore if you are std::forwarding variables and you know that the variables will not be used in multiple places
+ * (e.g. function fusion) then these casts won't cause problems.
+ */
+SCENARIO("Test to ensure that l and r values operate according to the standard") {
     GIVEN("a vector with some data") {
         std::vector<int> v1 = {0, 1};
 


### PR DESCRIPTION
Function fusion technically runs std::forward on the same arguments multiple times, in theory this could mean that the second time a function gets those arguments they could have been moved away.

This one was interesting as I realised that I wasn't even forwarding the arguments all the way down. At the last level they were left as lvalue. After fixing this issue the actual bug could be fixed so that shared arguments will always be passed through as lvalues, while unique variables will only ever be sent to a single function and thus, forwarding them multiple times is fine as only one function will ever "see" the final value.