### PR TITLE
Swap to just using thread_local for thread local storage

### DIFF
--- a/src/dsl/store/ThreadStore.hpp
+++ b/src/dsl/store/ThreadStore.hpp
@@ -23,8 +23,6 @@
 #ifndef NUCLEAR_DSL_STORE_THREADSTORE_HPP
 #define NUCLEAR_DSL_STORE_THREADSTORE_HPP
 
-#include "../../util/platform.hpp"
-
 namespace NUClear {
 namespace dsl {
     namespace store {
@@ -46,12 +44,12 @@ namespace dsl {
          */
         template <typename DataType, int Index = 0>
         struct ThreadStore {
-            static ATTRIBUTE_TLS DataType* value;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+            static thread_local DataType* value;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
         };
 
         template <typename DataType, int index>
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-        ATTRIBUTE_TLS DataType* ThreadStore<DataType, index>::value = nullptr;
+        thread_local DataType* ThreadStore<DataType, index>::value = nullptr;
 
     }  // namespace store
 }  // namespace dsl

--- a/src/dsl/word/TaskScope.hpp
+++ b/src/dsl/word/TaskScope.hpp
@@ -24,7 +24,6 @@
 
 #include "../../id.hpp"
 #include "../../threading/ReactionTask.hpp"
-#include "../../util/platform.hpp"
 
 namespace NUClear {
 namespace dsl {
@@ -93,12 +92,12 @@ namespace dsl {
         private:
             /// The current task id that is running
             // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-            static ATTRIBUTE_TLS NUClear::id_t current_task_id;
+            static thread_local NUClear::id_t current_task_id;
         };
 
         // Initialise the current task id
         template <typename Group>  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-        ATTRIBUTE_TLS NUClear::id_t TaskScope<Group>::current_task_id{0};
+        thread_local NUClear::id_t TaskScope<Group>::current_task_id{0};
 
     }  // namespace word
 }  // namespace dsl

--- a/src/threading/ReactionTask.cpp
+++ b/src/threading/ReactionTask.cpp
@@ -29,7 +29,6 @@
 
 #include "../id.hpp"
 #include "../message/ReactionStatistics.hpp"
-#include "../util/platform.hpp"
 #include "Reaction.hpp"
 
 namespace NUClear {

--- a/src/threading/ReactionTask.cpp
+++ b/src/threading/ReactionTask.cpp
@@ -95,7 +95,7 @@ namespace threading {
 
     // Initialize our current task
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-    ATTRIBUTE_TLS ReactionTask* ReactionTask::current_task = nullptr;
+    thread_local ReactionTask* ReactionTask::current_task = nullptr;
 
 }  // namespace threading
 }  // namespace NUClear

--- a/src/threading/ReactionTask.hpp
+++ b/src/threading/ReactionTask.hpp
@@ -32,7 +32,6 @@
 #include "../util/GroupDescriptor.hpp"
 #include "../util/Inline.hpp"
 #include "../util/ThreadPoolDescriptor.hpp"
-#include "../util/platform.hpp"
 #include "Reaction.hpp"
 
 namespace NUClear {
@@ -53,7 +52,7 @@ namespace threading {
     class ReactionTask {
     private:
         /// The current task that is being executed by this thread (or nullptr if none is)
-        static ATTRIBUTE_TLS ReactionTask* current_task;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+        static thread_local ReactionTask* current_task;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
     public:
         /// Type of the functions that ReactionTasks execute

--- a/src/threading/scheduler/Pool.cpp
+++ b/src/threading/scheduler/Pool.cpp
@@ -36,7 +36,6 @@
 #include "../../message/ReactionStatistics.hpp"
 #include "../../threading/Reaction.hpp"
 #include "../../util/Inline.hpp"
-#include "../../util/platform.hpp"
 #include "../ReactionTask.hpp"
 #include "CountingLock.hpp"
 #include "Scheduler.hpp"
@@ -283,7 +282,7 @@ namespace threading {
 
         // Initialise the current pool to nullptr if it is not already
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-        ATTRIBUTE_TLS Pool* Pool::current_pool = nullptr;
+        thread_local Pool* Pool::current_pool = nullptr;
 
     }  // namespace scheduler
 }  // namespace threading

--- a/src/threading/scheduler/Pool.hpp
+++ b/src/threading/scheduler/Pool.hpp
@@ -246,7 +246,7 @@ namespace threading {
             std::unique_ptr<Lock> pool_idle = nullptr;
 
             /// A thread local pointer to the current pool this thread is running in
-            static ATTRIBUTE_TLS Pool* current_pool;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+            static thread_local Pool* current_pool;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
             friend class Scheduler;
         };


### PR DESCRIPTION
I would much prefer just to use the standard thread_local keyword for thread local storage rather than having custom properties. See which compilers are ok with this and if it's not too onerous change the minimum requirements for NUClear to match