### PR TITLE
Correct the executable path for osx

### DIFF
--- a/tests/test_util/executable_path.cpp
+++ b/tests/test_util/executable_path.cpp
@@ -51,7 +51,7 @@ std::string get_executable_path() {
     std::array<char, PATH_MAX> buffer{};
     uint32_t size = buffer.size();
     if (::_NSGetExecutablePath(buffer.data(), &size) == 0) {
-        return {buffer.data(), size};
+        return {buffer.data()};
     }
     throw std::system_error(std::make_error_code(std::errc::no_such_file_or_directory),
                             "Could not get executable path");


### PR DESCRIPTION
on osx, the executable path was using the size variable, however this wasn't holding the number of bytes put in the buffer, it instead just is used to output the required size if there was not enough. As a result, the string had nulls in it. Later when it was concatenated with an extension for traces, the nulls meant that the final path was just the binary name which was overwritten.

since PATH_MAX is used as the buffer size, we don't need to look at the space required as it should be PATH_MAX or less by definition.