### PR TITLE
Make the min_log_level feature opt in

### DIFF
--- a/src/Reactor.hpp
+++ b/src/Reactor.hpp
@@ -184,7 +184,7 @@ public:
     /// The display level above which logs from this reactor will be displayed
     LogLevel log_level{LogLevel::INFO};
     /// The minimum log level that will be always emitted (if log_level is below this those will be emitted too)
-    LogLevel min_log_level{LogLevel::DEBUG};
+    LogLevel min_log_level{LogLevel::FATAL};
 
 protected:
     /***************************************************************************************************************


### PR DESCRIPTION
Even with the min_log_level being gated not to include trace by default, it still slows down some code unexpectedly. Make it so that the feature has to be explicitly used rather than always being set to debug or above.