### PR TITLE
Cache pool information on reactions to avoid finding it each time

### DIFF
--- a/src/threading/Reaction.hpp
+++ b/src/threading/Reaction.hpp
@@ -46,7 +46,7 @@ namespace threading {
     struct ReactionIdentifiers;
     namespace scheduler {
         class Scheduler;
-    }
+    }  // namespace scheduler
 
     /**
      * This class holds the definition of a Reaction.

--- a/src/threading/Reaction.hpp
+++ b/src/threading/Reaction.hpp
@@ -44,6 +44,9 @@ namespace threading {
     // Forward declare
     class ReactionTask;
     struct ReactionIdentifiers;
+    namespace scheduler {
+        class Scheduler;
+    }
 
     /**
      * This class holds the definition of a Reaction.
@@ -131,6 +134,10 @@ namespace threading {
 
         /// The callback generator function (creates databound callbacks)
         TaskGenerator generator;
+
+        /// Cached data for this reaction added by the scheduler
+        std::shared_ptr<void> scheduler_data;
+        friend class scheduler::Scheduler;  /// Let the scheduler mess with reaction objects
     };
 
 }  // namespace threading


### PR DESCRIPTION
Currently every single task that is added to the scheduler is required to lock a pool mutex to find it's pool. There are too many mutex locks on this path currently and it's obviously slowing down the system as a whole.

While lock free queues will hopefully eventually solve the lower level queue problems, this higher level mutex to select a pool can be avoided by caching it on the reaction as once a reaction is created it will always target the same pool.