### PR TITLE
Wake up chrono controller when RTF is zero

### DIFF
--- a/src/extension/ChronoController.cpp
+++ b/src/extension/ChronoController.cpp
@@ -166,10 +166,7 @@ namespace extension {
 
                         if (clock::rtf() == 0.0) {
                             // If we are paused then just wait until we are unpaused
-                            wait.wait(lock, [this, &start] {
-                                return !running.load(std::memory_order_acquire) || clock::rtf() != 0.0
-                                       || NUClear::clock::now() != start;
-                            });
+                            wait.wait(lock);
                         }
                         else if (time_until_task > cv_accuracy) {  // A long time in the future
                             // Wait on the cv


### PR DESCRIPTION
Currently if the RTF is zero, chronocontroller will remain waiting until the RTF or the time changes. This is a problem if we ever want a chrono controller task to run at the same time as `now()` and time is frozen. This PR fixes this by allowing chronocontroller to wake up when RTF is zero.  