### PR TITLE
Add a longer timeout for deleting timed out packets

### DIFF
--- a/src/extension/network/NUClearNetwork.cpp
+++ b/src/extension/network/NUClearNetwork.cpp
@@ -869,7 +869,7 @@ namespace extension {
                                 // Check for and delete any timed out packets
                                 for (auto it = assemblers.begin(); it != assemblers.end();) {
                                     const auto now              = std::chrono::steady_clock::now();
-                                    const auto timeout          = remote->round_trip_time * 10.0;
+                                    const auto timeout          = std::chrono::seconds(2);
                                     const auto& last_chunk_time = it->second.first;
 
                                     it = now > last_chunk_time + timeout ? assemblers.erase(it) : std::next(it);


### PR DESCRIPTION
Currently NUClearNet is not estimating the round trip time but the time between packets.

This is resulting in it dropping packets far too agressively when the latency is low.

A future fix will estimate round trip time properly, but for now just wait 2 seconds before dropping data from the cache