### PR TITLE
Allow UDP to bind to the same ip/port

### DIFF
--- a/src/dsl/word/UDP.hpp
+++ b/src/dsl/word/UDP.hpp
@@ -199,32 +199,20 @@ namespace dsl {
                     }
                 }
 
-                // Broadcast and multicast reuse address and port
-                if (options.type == ConnectOptions::Type::BROADCAST
-                    || options.type == ConnectOptions::Type::MULTICAST) {
-
-                    if (::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char*>(&yes), sizeof(yes)) < 0) {
-                        throw std::system_error(network_errno,
-                                                std::system_category(),
-                                                "Unable to reuse address on the socket");
-                    }
+                if (::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char*>(&yes), sizeof(yes)) < 0) {
+                    throw std::system_error(network_errno,
+                                            std::system_category(),
+                                            "Unable to reuse address on the socket");
+                }
 
 // If SO_REUSEPORT is available set it too
 #ifdef SO_REUSEPORT
-                    if (::setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, reinterpret_cast<char*>(&yes), sizeof(yes)) < 0) {
-                        throw std::system_error(network_errno,
-                                                std::system_category(),
-                                                "Unable to reuse port on the socket");
-                    }
-#endif
-
-                    // We enable SO_BROADCAST since sometimes we need to send broadcast packets
-                    if (::setsockopt(fd, SOL_SOCKET, SO_BROADCAST, reinterpret_cast<char*>(&yes), sizeof(yes)) < 0) {
-                        throw std::system_error(network_errno,
-                                                std::system_category(),
-                                                "Unable to set broadcast on the socket");
-                    }
+                if (::setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, reinterpret_cast<char*>(&yes), sizeof(yes)) < 0) {
+                    throw std::system_error(network_errno,
+                                            std::system_category(),
+                                            "Unable to reuse port on the socket");
                 }
+#endif
 
                 // Bind to the address
                 if (::bind(fd, &bind_address.sock, bind_address.size()) != 0) {

--- a/src/dsl/word/emit/UDP.hpp
+++ b/src/dsl/word/emit/UDP.hpp
@@ -103,6 +103,24 @@ namespace dsl {
                         throw std::system_error(network_errno, std::system_category(), "Unable to open the UDP socket");
                     }
 
+                    int yes = 1;
+                    // Set reuse address and port so that emit can use the same port multiple times
+                    if (::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char*>(&yes), sizeof(yes))
+                        < 0) {
+                        throw std::system_error(network_errno,
+                                                std::system_category(),
+                                                "Unable to set the reuse address option on the UDP socket");
+                    }
+#ifdef SO_REUSEPORT
+                    // If SO_REUSEPORT is available set it too
+                    if (::setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, reinterpret_cast<const char*>(&yes), sizeof(yes))
+                        < 0) {
+                        throw std::system_error(network_errno,
+                                                std::system_category(),
+                                                "Unable to set the reuse port option on the UDP socket");
+                    }
+#endif
+
                     // If we are using multicast and we have a specific from_addr we need to tell the system to use the
                     // correct interface
                     if (multicast && !from_addr.empty()) {

--- a/src/dsl/word/emit/UDP.hpp
+++ b/src/dsl/word/emit/UDP.hpp
@@ -163,7 +163,6 @@ namespace dsl {
                     }
 
                     // Assume that if the user is sending a broadcast they want to enable broadcasting
-                    int yes = 1;
                     if (::setsockopt(fd, SOL_SOCKET, SO_BROADCAST, reinterpret_cast<const char*>(&yes), sizeof(yes))
                         < 0) {
                         throw std::system_error(network_errno,


### PR DESCRIPTION
This pull request refactors how socket options are set for UDP sockets, improving consistency and reliability in both the main UDP implementation and the emit path. The changes focus on ensuring proper reuse of addresses and ports, and on clarifying when broadcast options are set.